### PR TITLE
feat: Implement GraphQL store for Google Calendar tokens

### DIFF
--- a/atomic-docker/project/functions/atom-agent/_libs/constants.ts
+++ b/atomic-docker/project/functions/atom-agent/_libs/constants.ts
@@ -94,3 +94,8 @@ export const ATOM_OPENAI_API_KEY = process.env.ATOM_OPENAI_API_KEY || '';
 // OpenAI Model Name for NLU
 // Specifies the model to be used for NLU tasks, preferably one that supports JSON mode.
 export const ATOM_NLU_MODEL_NAME = process.env.ATOM_NLU_MODEL_NAME || 'gpt-3.5-turbo-1106';
+
+// Hasura GraphQL Endpoint Configuration
+// These must be set in the environment for GraphQL communication.
+export const HASURA_GRAPHQL_URL = process.env.HASURA_GRAPHQL_URL || '';
+export const HASURA_ADMIN_SECRET = process.env.HASURA_ADMIN_SECRET || '';


### PR DESCRIPTION
I've replaced the mocked GraphQL client with a real implementation using axios for communication with Hasura. I also adapted `calendarSkills.ts` to use this client for fetching and saving Google Calendar OAuth tokens.

Key changes:
- **`graphqlClient.ts`:** I implemented `executeGraphQLQuery` and `executeGraphQLMutation` to send requests to Hasura, including role-based headers (`X-Hasura-Role`, `X-Hasura-User-Id`) and admin secret. This includes a custom `GraphQLError` for structured error reporting from the client.
- **`calendarSkills.ts`:**
    - `getStoredUserTokens` and `saveUserTokens` now use the real GraphQL client to interact with an assumed `user_tokens` table in Hasura.
    - I defined GraphQL queries and mutations for token operations.
    - I enhanced error handling to catch `GraphQLError` and return standardized `CalendarSkillResponse` objects.
    - I refactored Google Calendar client setup into `getGoogleCalendarClient` for better centralization of auth logic and token refresh handling.
- **`constants.ts`:** I added `HASURA_GRAPHQL_URL` and `HASURA_ADMIN_SECRET`.
- **Testing Strategy:** I outlined comprehensive test cases for the new token management logic, covering success scenarios, various error conditions, and interactions with mocked dependencies.

This change provides a robust mechanism for persisting Google Calendar tokens in a Hasura database, moving away from placeholder implementations.