### PR TITLE
feat: Enhance NLU for ambient task and calendar management

### DIFF
--- a/atomic-docker/project/functions/atom-agent/skills/nluService.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/nluService.ts
@@ -43,9 +43,12 @@ Available Intents and their Entities:
 
 (Existing intents 1-27 are assumed to be listed here)
 1.  Intent: "GetCalendarEvents"
-    - Entities: {"date_range": "e.g., tomorrow, next week, specific date", "limit": "number of events", "event_type_filter": "e.g., Google Meet events"}
+    - Entities: {"date_range": "e.g., tomorrow, next week, specific date", "limit": "number of events", "event_type_filter": "e.g., Google Meet events", "time_query": "e.g., 2:30 PM, evening", "query_type": "e.g., check_availability, list_events"}
+    - Example: User asks "What's on my calendar for tomorrow?" -> {"intent": "GetCalendarEvents", "entities": {"date_range": "tomorrow"}}
+    - Example: User asks "Am I free on Friday at 2:30 PM?" -> {"intent": "GetCalendarEvents", "entities": {"date_range": "Friday", "time_query": "2:30 PM", "query_type": "check_availability"}}
 2.  Intent: "CreateCalendarEvent"
-    - Entities: {"summary": "event title", "start_time": "ISO string or natural language", "end_time": "ISO string or natural language", "description": "event details", "location": "event location", "attendees": "array of email addresses"}
+    - Entities: {"summary": "event title", "start_time": "ISO string or natural language", "end_time": "ISO string or natural language", "duration": "e.g., 30 minutes, 1 hour", "description": "event details", "location": "event location", "attendees": "array of email addresses"}
+    - Example: User says "Schedule 'Team Sync' for next Monday at 10 AM for 45 minutes with alice@example.com" -> {"intent": "CreateCalendarEvent", "entities": {"summary": "Team Sync", "start_time": "next Monday 10:00 AM", "duration": "45 minutes", "attendees": ["alice@example.com"]}}
 ... (Assume other existing intents like ListEmails, SendEmail, SearchWeb, CreateHubSpotContact, etc., are here)
 27. Intent: "ScheduleTeamMeeting"
     - Entities: {"attendees": "array of email addresses or names", "purpose": "meeting subject", "duration_preference": "e.g., 30 minutes, 1 hour", "time_preference_details": "e.g., next Monday morning, this week afternoon"}
@@ -65,6 +68,28 @@ New Autopilot Intents:
     - Entities: {"raw_query": "The full user query.", "autopilot_id": "The ID of the autopilot instance to check, if specified."}
     - Example: User says "What's the status of autopilot task 67890?" -> {"intent": "GetAutopilotStatus", "entities": {"raw_query": "What's the status of autopilot task 67890?", "autopilot_id": "67890"}}
     - Example: User says "Show me my autopilot status" -> {"intent": "GetAutopilotStatus", "entities": {"raw_query": "Show me my autopilot status"}}
+
+New Task Management Intents:
+31. Intent: "CreateTask"
+    - Entities: {"task_description": "string, required - The full description of the task.", "due_date_time": "string, optional - e.g., tomorrow, next Friday 5pm, specific date/time", "priority": "string, optional - e.g., high, medium, low", "list_name": "string, optional - e.g., work, personal, shopping list"}
+    - Example: User says "Atom, remind me to submit the TPS report by end of day Friday" -> {"intent": "CreateTask", "entities": {"task_description": "submit the TPS report", "due_date_time": "Friday end of day"}}
+    - Example: User says "add a task to call the plumber" -> {"intent": "CreateTask", "entities": {"task_description": "call the plumber"}}
+    - Example: User says "new task for my shopping list: buy milk and eggs" -> {"intent": "CreateTask", "entities": {"list_name": "shopping list", "task_description": "buy milk and eggs"}}
+    - Example: User says "remind me to pick up laundry tomorrow morning with high priority" -> {"intent": "CreateTask", "entities": {"task_description": "pick up laundry", "due_date_time": "tomorrow morning", "priority": "high"}}
+
+32. Intent: "QueryTasks"
+    - Entities: {"date_range": "string, optional - e.g., today, tomorrow, this week, next month", "list_name": "string, optional - e.g., work, personal", "status": "string, optional - e.g., pending, completed, overdue"}
+    - Example: User says "what are my tasks for today" -> {"intent": "QueryTasks", "entities": {"date_range": "today"}}
+    - Example: User says "show me my work tasks" -> {"intent": "QueryTasks", "entities": {"list_name": "work"}}
+    - Example: User says "list all completed tasks for this week" -> {"intent": "QueryTasks", "entities": {"status": "completed", "date_range": "this week"}}
+    - Example: User says "do I have any overdue tasks on my personal list" -> {"intent": "QueryTasks", "entities": {"status": "overdue", "list_name": "personal"}}
+
+33. Intent: "UpdateTask"
+    - Entities: {"task_identifier": "string, required - Description or part of description of the task to update.", "update_action": "string, required - e.g., complete, set_due_date, change_description, set_priority", "new_due_date_time": "string, optional - New due date/time", "new_description": "string, optional - New task description", "new_priority": "string, optional - New priority level"}
+    - Example: User says "mark task 'buy milk' as done" -> {"intent": "UpdateTask", "entities": {"task_identifier": "buy milk", "update_action": "complete"}}
+    - Example: User says "change due date for 'review proposal' to tomorrow afternoon" -> {"intent": "UpdateTask", "entities": {"task_identifier": "review proposal", "update_action": "set_due_date", "new_due_date_time": "tomorrow afternoon"}}
+    - Example: User says "update task 'call client' to 'call client about new quote'" -> {"intent": "UpdateTask", "entities": {"task_identifier": "call client", "update_action": "change_description", "new_description": "call client about new quote"}}
+    - Example: User says "set priority for 'finish report' to high" -> {"intent": "UpdateTask", "entities": {"task_identifier": "finish report", "update_action": "set_priority", "new_priority": "high"}}
 
 If the user's intent is unclear or does not match any of the above single intents, set "intent" to null and "entities" to an empty object.
 


### PR DESCRIPTION
This commit updates the NLU service and agent handler to support more natural voice commands for your task and calendar management.

**1. NLU Service Enhancements (`atom-agent/skills/nluService.ts`):**

The `SYSTEM_PROMPT` used for the OpenAI LLM-based NLU has been updated to include:

*   **New Task Management Intents:**
    *   `CreateTask`:
        - Entities: `task_description` (required), `due_date_time` (optional), `priority` (optional), `list_name` (optional).
        - Examples provided for various phrasings.
    *   `QueryTasks`:
        - Entities: `date_range` (optional), `list_name` (optional), `status` (optional).
        - Examples provided for querying tasks.
    *   `UpdateTask`:
        - Entities: `task_identifier` (required), `update_action` (required, e.g., 'complete', 'set_due_date'), `new_due_date_time` (optional), etc.
        - Examples provided for marking tasks complete and changing due dates.

*   **Refined Calendar Intents (Entity Extraction):**
    *   `CreateCalendarEvent`:
        - Prompt examples now encourage extraction of `duration` in addition to existing entities.
    *   `GetCalendarEvents`:
        - Prompt examples now encourage extraction of `time_query` (e.g., "at 3 PM") and `query_type` (e.g., "check_availability", "list_events").

These changes aim to improve my ability to understand more nuanced requests from you for these domains.

**2. Agent Handler Updates (`atom-agent/handler.ts`):**

The `_internalHandleMessage` function's main intent routing `switch` statement has been updated:

*   **New `case` statements added for:**
    *   `CreateTask`: Extracts defined entities, logs the request, and returns a placeholder message indicating the feature is under development.
    *   `QueryTasks`: Extracts defined entities, logs the request, and returns a placeholder message.
    *   `UpdateTask`: Extracts defined entities, logs the request, and returns a placeholder message.
*   **Enhanced `case` statements for Calendar Intents:**
    *   `CreateCalendarEvent`: Now attempts to extract `duration` from NLU entities and includes it in the `eventDetails` passed to the skill (actual use of `duration` depends on the skill's implementation).
    *   `GetCalendarEvents`: Now extracts `time_query` and `query_type` from NLU entities and logs them (actual use depends on skill implementation).

These handler updates provide the basic routing for the new NLU capabilities. Full implementation of task management actions (e.g., saving to Notion, querying a task database) and full utilization of refined calendar entities in the respective skills are subjects for future work.