### PR TITLE
feat: Implement agent-side logic for Notion-based task management

### DIFF
--- a/atomic-docker/project/functions/atom-agent/_libs/constants.ts
+++ b/atomic-docker/project/functions/atom-agent/_libs/constants.ts
@@ -110,6 +110,7 @@ export const NOTION_API_TOKEN = process.env.NOTION_API_TOKEN || '';
 export const NOTION_NOTES_DATABASE_ID = process.env.NOTION_NOTES_DATABASE_ID || ''; // General notes
 export const NOTION_RESEARCH_PROJECTS_DB_ID = process.env.NOTION_RESEARCH_PROJECTS_DB_ID || '';
 export const NOTION_RESEARCH_TASKS_DB_ID = process.env.NOTION_RESEARCH_TASKS_DB_ID || '';
+export const ATOM_NOTION_TASKS_DATABASE_ID = process.env.ATOM_NOTION_TASKS_DATABASE_ID || ''; // For task management
 
 // Deepgram API Key for Transcription
 // This must be set for audio transcription features.

--- a/atomic-docker/project/functions/atom-agent/skills/tests/notionAndResearchSkills.test.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/tests/notionAndResearchSkills.test.ts
@@ -1,0 +1,232 @@
+import axios from 'axios';
+import {
+  createNotionTask,
+  queryNotionTasks,
+  updateNotionTask,
+} from '../notionAndResearchSkills';
+import {
+  CreateNotionTaskParams,
+  QueryNotionTasksParams,
+  UpdateNotionTaskParams,
+  NotionTaskStatus,
+  NotionTaskPriority,
+  NotionTask, // For mock task data in queryNotionTasks
+  SkillResponse,
+  CreateTaskData,
+  UpdateTaskData,
+  TaskQueryResponse,
+} from '../../types';
+import * as constants from '../../_libs/constants';
+
+// Mock axios
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Mock constants that are imported and used by notionAndResearchSkills.ts
+// The path '../../_libs/constants' is relative to the module being tested (notionAndResearchSkills.ts)
+// when it imports constants. However, jest.mock needs the path relative to THIS test file.
+jest.mock('../../_libs/constants', () => ({
+  ...jest.requireActual('../../_libs/constants'), // Preserve other constants if any
+  PYTHON_NOTE_API_URL: 'http://mock-python-api.com/notes',
+  NOTION_API_TOKEN: 'mock_notion_token',
+  ATOM_NOTION_TASKS_DATABASE_ID: 'mock_tasks_db_id_from_constant', // Default fallback DB ID
+}));
+
+describe('Notion Task Management Skills', () => {
+  const userId = 'testUser123';
+
+  afterEach(() => {
+    jest.clearAllMocks(); // Clear mocks after each test
+  });
+
+  // --- Tests for createNotionTask ---
+  describe('createNotionTask', () => {
+    const params: CreateNotionTaskParams = {
+      description: 'Test Task',
+      dueDate: '2024-12-31',
+      status: 'To Do' as NotionTaskStatus,
+      priority: 'High' as NotionTaskPriority,
+      listName: 'Work',
+      notes: 'Some notes',
+      notionTasksDbId: 'custom_tasks_db_id', // Test with specific DB ID
+    };
+
+    it('should create a task successfully using specific notionTasksDbId', async () => {
+      const mockApiResponse = {
+        ok: true,
+        data: { taskId: 'newPage123', taskUrl: 'http://notion.so/newPage123', message: 'Task created' },
+      };
+      mockedAxios.post.mockResolvedValueOnce({ data: mockApiResponse });
+
+      const result = await createNotionTask(userId, params);
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        `${constants.PYTHON_NOTE_API_URL}/create-notion-task`,
+        expect.objectContaining({
+          // description: 'Test Task', // These are spread from params
+          // dueDate: '2024-12-31',
+          user_id: userId,
+          notion_api_token: constants.NOTION_API_TOKEN,
+          notion_db_id: 'custom_tasks_db_id', // Ensure this specific one is used
+        })
+      );
+      expect(result.ok).toBe(true);
+      expect(result.data?.taskId).toBe('newPage123');
+      expect(result.data?.taskUrl).toBe('http://notion.so/newPage123');
+    });
+
+    it('should use ATOM_NOTION_TASKS_DATABASE_ID if params.notionTasksDbId is not provided', async () => {
+      const mockApiResponse = { ok: true, data: { taskId: 'newPage456', taskUrl: 'http://notion.so/newPage456' }};
+      mockedAxios.post.mockResolvedValueOnce({ data: mockApiResponse });
+
+      const paramsWithoutDbId: CreateNotionTaskParams = {
+        description: 'Another task',
+        // notionTasksDbId is omitted here
+      };
+
+      await createNotionTask(userId, paramsWithoutDbId);
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        `${constants.PYTHON_NOTE_API_URL}/create-notion-task`,
+        expect.objectContaining({
+          notion_db_id: constants.ATOM_NOTION_TASKS_DATABASE_ID, // Check fallback
+        })
+      );
+    });
+
+    it('should return error if Python API service fails', async () => {
+      const mockApiErrorResponse = {
+        ok: false,
+        error: { code: 'PYTHON_ERROR', message: 'Python backend exploded' },
+      };
+      mockedAxios.post.mockResolvedValueOnce({ data: mockApiErrorResponse });
+      const result = await createNotionTask(userId, params);
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe('PYTHON_ERROR');
+      expect(result.error?.message).toBe('Python backend exploded');
+    });
+
+    it('should return error if axios call itself fails (network error)', async () => {
+      mockedAxios.post.mockRejectedValueOnce(new Error('Network Error'));
+      const result = await createNotionTask(userId, params);
+      expect(result.ok).toBe(false);
+      expect(result.error?.message).toContain('Failed to create Notion task: Network Error');
+    });
+
+    it('should return config error if PYTHON_NOTE_API_URL is not set', async () => {
+      const originalUrl = constants.PYTHON_NOTE_API_URL;
+      // To modify constants for a single test, ensure the mock setup allows it or re-mock per test.
+      // This type of direct modification is tricky with jest.mock at module level.
+      // A better way is to have constants injectable or use a more granular mock for this specific test.
+      // For now, this test highlights the dependency. If constants were not module-level mocked, this would be easier.
+      // Given the current jest.mock, this test might not reflect an actual scenario where only one const is missing.
+      // However, the function's internal check is what's being "tested".
+      jest.isolateModules(() => { // To ensure a fresh mock for constants for this test
+        jest.mock('../../_libs/constants', () => ({
+            ...jest.requireActual('../../_libs/constants'),
+            PYTHON_NOTE_API_URL: '', // Mock as empty for this test
+            NOTION_API_TOKEN: 'mock_notion_token', // Keep others valid
+            ATOM_NOTION_TASKS_DATABASE_ID: 'mock_tasks_db_id_from_constant',
+        }));
+        // Need to re-import the skill to use the modified constants for this isolated test
+        const skillWithMockedConst = require('../notionAndResearchSkills');
+        const promise = skillWithMockedConst.createNotionTask(userId, params);
+        promise.then((result: SkillResponse<CreateTaskData>) => {
+            expect(result.ok).toBe(false);
+            expect(result.error?.code).toBe('CONFIG_ERROR');
+            expect(result.error?.message).toContain('Python Note API URL is not configured');
+        });
+      });
+    });
+  });
+
+  // --- Tests for queryNotionTasks ---
+  describe('queryNotionTasks', () => {
+    const params: QueryNotionTasksParams = {
+      status: 'To Do' as NotionTaskStatus,
+      listName: 'Personal',
+      notionTasksDbId: 'custom_query_db_id', // Specific DB for this query
+    };
+    const mockTasksResult: NotionTask[] = [
+      { id: 'task1', description: 'Query Task 1', status: 'To Do', createdDate: '2023-01-01T00:00:00Z', url: 'http://notion.so/task1', priority: 'High', listName: 'Personal' },
+    ];
+
+    it('should query tasks successfully', async () => {
+      const mockApiResponse = { ok: true, data: mockTasksResult, message: 'Tasks retrieved' };
+      mockedAxios.post.mockResolvedValueOnce({ data: mockApiResponse });
+
+      const result = await queryNotionTasks(userId, params);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        `${constants.PYTHON_NOTE_API_URL}/query-notion-tasks`,
+        expect.objectContaining({
+          // status: 'To Do', // These are spread from params
+          // listName: 'Personal',
+          user_id: userId,
+          notion_api_token: constants.NOTION_API_TOKEN,
+          notion_db_id: 'custom_query_db_id',
+        })
+      );
+      expect(result.success).toBe(true);
+      expect(result.tasks).toEqual(mockTasksResult);
+      expect(result.message).toBe('Tasks retrieved');
+    });
+
+    it('should return empty array if no tasks found but API call is ok', async () => {
+        const mockApiResponse = { ok: true, data: [], message: 'No tasks found matching criteria' };
+        mockedAxios.post.mockResolvedValueOnce({ data: mockApiResponse });
+        const result = await queryNotionTasks(userId, params);
+        expect(result.success).toBe(true);
+        expect(result.tasks).toEqual([]);
+        expect(result.message).toBe('No tasks found matching criteria');
+    });
+
+    it('should adapt Python API error to TaskQueryResponse error', async () => {
+      const mockApiErrorResponse = { ok: false, error: { code: 'PYTHON_ERROR', message: 'DB query failed', details: 'Some detail' }};
+      mockedAxios.post.mockResolvedValueOnce({ data: mockApiErrorResponse });
+      const result = await queryNotionTasks(userId, params);
+      expect(result.success).toBe(false);
+      expect(result.tasks).toEqual([]);
+      expect(result.error).toBe('DB query failed');
+      expect(result.message).toBe('Some detail');
+    });
+  });
+
+  // --- Tests for updateNotionTask ---
+  describe('updateNotionTask', () => {
+    const params: UpdateNotionTaskParams = {
+      taskId: 'taskToUpdate123',
+      status: 'Done' as NotionTaskStatus,
+      notes: 'Updated notes.',
+    };
+    const mockUpdateData: UpdateTaskData = { taskId: 'taskToUpdate123', updatedProperties: ['status', 'notes'], message: 'Task updated' };
+
+    it('should update a task successfully', async () => {
+      const mockApiResponse = { ok: true, data: mockUpdateData };
+      mockedAxios.post.mockResolvedValueOnce({ data: mockApiResponse });
+
+      const result = await updateNotionTask(userId, params);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        `${constants.PYTHON_NOTE_API_URL}/update-notion-task`,
+        expect.objectContaining({
+          taskId: 'taskToUpdate123',
+          status: 'Done',
+          notes: 'Updated notes.',
+          user_id: userId,
+          notion_api_token: constants.NOTION_API_TOKEN,
+        })
+      );
+      expect(result.ok).toBe(true);
+      expect(result.data).toEqual(mockUpdateData);
+    });
+
+    it('should return error if taskId is missing', async () => {
+        const paramsWithoutId = { ...params };
+        // Casting to any to delete a required property for testing purposes
+        delete (paramsWithoutId as any).taskId;
+        const result = await updateNotionTask(userId, paramsWithoutId as UpdateNotionTaskParams); // Cast back
+        expect(result.ok).toBe(false);
+        expect(result.error?.code).toBe('VALIDATION_ERROR');
+        expect(result.error?.message).toContain('Task ID (taskId) is required for update.');
+    });
+  });
+});

--- a/atomic-docker/project/functions/atom-agent/types.ts
+++ b/atomic-docker/project/functions/atom-agent/types.ts
@@ -588,4 +588,85 @@ export interface ZoomMeeting {
   [key: string]: any;
 }
 
+// --- Notion Task Management Types ---
+
+export type NotionTaskStatus = "To Do" | "In Progress" | "Done" | "Blocked" | "Cancelled";
+
+export type NotionTaskPriority = "High" | "Medium" | "Low";
+
+export interface NotionTask {
+  id: string; // Notion Page ID
+  description: string;
+  dueDate?: string | null; // ISO date string or null
+  status: NotionTaskStatus;
+  priority?: NotionTaskPriority | null;
+  listName?: string | null;
+  createdDate: string; // ISO date string (from Notion's created_time)
+  url: string; // Notion page URL
+  notes?: string | null;
+}
+
+export interface CreateNotionTaskParams {
+  description: string;
+  dueDate?: string | null;
+  status?: NotionTaskStatus;
+  priority?: NotionTaskPriority | null;
+  listName?: string | null;
+  notes?: string | null;
+  notionTasksDbId: string;
+}
+
+export interface NotionTaskResponse {
+  success: boolean;
+  message: string;
+  taskId?: string;
+  taskUrl?: string;
+  error?: string;
+}
+
+export interface QueryNotionTasksParams {
+  status?: NotionTaskStatus | NotionTaskStatus[];
+  dueDateBefore?: string | null;
+  dueDateAfter?: string | null;
+  dateQuery?: string | null; // For NLU like "today", "next week" to be parsed by backend
+  priority?: NotionTaskPriority | null;
+  listName?: string | null;
+  descriptionContains?: string | null;
+  notionTasksDbId: string;
+  limit?: number;
+}
+
+export interface TaskQueryResponse {
+  success: boolean;
+  tasks: NotionTask[];
+  message?: string;
+  error?: string;
+}
+
+export interface UpdateNotionTaskParams {
+  taskId: string;
+  description?: string;
+  dueDate?: string | null;
+  status?: NotionTaskStatus;
+  priority?: NotionTaskPriority | null;
+  listName?: string | null;
+  notes?: string | null;
+  // notionTasksDbId: string; // Usually not needed for page update by ID
+}
+
+// Specific data types for responses from Python backend for task operations
+// These align with the 'data' field within PythonApiResponse<T>
+
+export interface CreateTaskData {
+  taskId: string; // Notion Page ID of the created task
+  taskUrl: string; // URL to the Notion task page
+  message?: string; // Optional success message from backend
+}
+
+export interface UpdateTaskData {
+  taskId: string; // Notion Page ID of the updated task
+  updatedProperties: string[]; // List of properties that were actually changed
+  message?: string; // Optional success message from backend
+}
+
 [end of atomic-docker/project/functions/atom-agent/types.ts]


### PR DESCRIPTION
This commit introduces the TypeScript components within my internal systems necessary for managing tasks via Notion. It defines the data structures, skill functions, and handler integrations for creating, querying, and updating tasks.

Key changes:

1.  **Type Definitions (`atom-agent/types.ts`):**
    *   Added `NotionTaskStatus`, `NotionTaskPriority` types.
    *   Added interfaces: `NotionTask` (for representing a task), `CreateNotionTaskParams`, `NotionTaskResponse`, `QueryNotionTasksParams`, `TaskQueryResponse`, `UpdateNotionTaskParams`, `CreateTaskData`, `UpdateTaskData`. These define the structure for task objects and parameters for skill functions.

2.  **Notion Task Skills (`atom-agent/skills/notionAndResearchSkills.ts`):**
    *   Implemented `createNotionTask`: This function constructs a payload and calls a new (to-be-implemented) Python backend endpoint (`/create-notion-task`) to create a task in Notion.
    *   Implemented `queryNotionTasks`: This function constructs a payload and calls a new Python backend endpoint (`/query-notion-tasks`) to fetch tasks from Notion.
    *   Implemented `updateNotionTask`: This function constructs a payload and calls a new Python backend endpoint (`/update-notion-task`) to update tasks in Notion.
    *   These functions handle API responses and errors.

3.  **Constants (`_libs/constants.ts`):**
    *   Added `ATOM_NOTION_TASKS_DATABASE_ID` to allow configuration of the default Notion database for tasks.

4.  **Agent Handler Integration (`atom-agent/handler.ts`):**
    *   Imported the new task skill functions and types.
    *   Replaced placeholder logic for NLU intents `CreateTask`, `QueryTasks`, and `UpdateTask` with calls to the respective new skill functions (`createNotionTask`, `queryNotionTasks`, `updateNotionTask`).
    *   Includes extraction of NLU entities and formatting of responses for you.

5.  **Unit Tests (`atom-agent/skills/tests/notionAndResearchSkills.test.ts`):**
    *   Created a new test file with comprehensive unit tests for `createNotionTask`, `queryNotionTasks`, and `updateNotionTask`.
    *   Tests use Jest and mock `axios` calls to simulate Python backend interactions, covering success and error scenarios.

This commit lays the groundwork on my side (TypeScript) for full task management via voice commands using Notion as the backend. The corresponding Python API endpoints (`/create-notion-task`, `/query-notion-tasks`, `/update-notion-task`) will need to be implemented separately in the `python_api_service`.