### PR TITLE
feat: Finalize Searchable Meeting Archive feature

### DIFF
--- a/atomic-docker/project/functions/atom-agent/_libs/constants.ts
+++ b/atomic-docker/project/functions/atom-agent/_libs/constants.ts
@@ -124,3 +124,6 @@ export const PYTHON_RESEARCH_API_URL = process.env.PYTHON_RESEARCH_API_URL || ''
 export const PYTHON_NOTE_API_URL = process.env.PYTHON_NOTE_API_URL || '';
 // Example for local development: http://localhost:5058
 export const PYTHON_TRAINING_API_URL = process.env.PYTHON_TRAINING_API_URL || '';
+
+// Base URL for the main Python API service (which might consolidate note_handler, task_handler, etc.)
+export const PYTHON_API_SERVICE_BASE_URL = process.env.PYTHON_API_SERVICE_BASE_URL || 'http://localhost:8080';

--- a/atomic-docker/project/functions/atom-agent/handler.ts
+++ b/atomic-docker/project/functions/atom-agent/handler.ts
@@ -1083,39 +1083,28 @@ async function _internalHandleMessage(message: string, userId: string): Promise<
         break;
       // --- End Autopilot Intents ---
 
-      /*
-            case "SemanticSearchMeetingNotes": // This intent needs to be defined in your NLU service
-              try {
-                // Construct SkillArgs. Ensure 'message' (original user input) is accessible in this scope.
-                // If 'message' is not in scope, args.raw_message might need to be omitted or sourced differently.
-                const skillArgs: SkillArgs = {
-                  command: "search_meeting_notes", // Command name for context
-                  params: nluResponse.entities || {}, // NLU entities, expecting 'query'
-                  user_id: userId, // userId is available in _internalHandleMessage
-                  raw_message: message // Assuming 'message' (raw user text) is in scope
-                };
+      case "SemanticSearchMeetingNotes": // This intent needs to be defined and recognized by your NLU service
+        try {
+          const skillArgs: SkillArgs = {
+            command: "search_meeting_notes",
+            params: nluResponse.entities || {},
+            user_id: userId,
+            raw_message: message
+          };
 
-                // ApiHelper instance:
-                // handler.ts structure needs review for how ApiHelper is best provided to skill handlers.
-                // For this placeholder, we acknowledge it's needed.
-                // Example if an apiHelper instance was available:
-                // import { ApiHelper } from '../../_libs/api-helper'; // At top of file
-                // const apiHelper = new ApiHelper(); // Needs proper instantiation with config from agent's context
-                // textResponse = await handleSemanticSearchMeetingNotesSkill(skillArgs, apiHelper);
+          if (!skillArgs.params.query || typeof skillArgs.params.query !== 'string' || skillArgs.params.query.trim() === '') {
+              textResponse = "Please specify what you'd like to search for in your meeting notes.";
+          } else {
+              console.log(`[Handler] Calling handleSemanticSearchMeetingNotesSkill with query: "${skillArgs.params.query}" for user ${userId}`);
+              textResponse = await handleSemanticSearchMeetingNotesSkill(skillArgs); // No ApiHelper needed now
+          }
 
-                textResponse = "DEBUG: SemanticSearchMeetingNotes intent recognized. Handler needs ApiHelper to be properly instantiated and passed for full functionality.";
-                // logger.info(`[Handler] Intent "SemanticSearchMeetingNotes" recognized. Placeholder response. Entities: ${JSON.stringify(nluResponse.entities)}`);
-                // Using console.log if logger is not defined in this scope, or import it.
-                console.log(`[Handler] Intent "SemanticSearchMeetingNotes" recognized. Placeholder response. Entities: ${JSON.stringify(nluResponse.entities)}`);
-
-
-              } catch (error: any) {
-                // logger.error(`Error in NLU Intent "SemanticSearchMeetingNotes":`, error.message, error.stack);
-                console.error(`Error in NLU Intent "SemanticSearchMeetingNotes":`, error.message, error.stack);
-                textResponse = "Sorry, an error occurred while searching your meeting notes.";
-              }
-              break;
-      */
+          console.log(`[Handler] SemanticSearchMeetingNotes response: ${textResponse.substring(0, 200)}...`);
+        } catch (error: any) {
+          console.error(`Error in NLU Intent "SemanticSearchMeetingNotes":`, error.message, error.stack);
+          textResponse = "Sorry, an error occurred while searching your meeting notes.";
+        }
+        break;
 
       default:
         if (nluResponse.error) {

--- a/atomic-docker/project/functions/atom-agent/skills/tests/semanticSearchSkills.test.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/tests/semanticSearchSkills.test.ts
@@ -1,0 +1,159 @@
+import axios, { AxiosError, AxiosResponse } from 'axios';
+import {
+    // SemanticSearchSkills, // Class is not directly tested, but through the handler
+    handleSemanticSearchMeetingNotesSkill,
+} from '../semanticSearchSkills';
+// Assuming BackendSearchResponse and MeetingSearchResult are exported from semanticSearchSkills.ts
+// If they were moved to a central types file, the import path would change.
+// For now, let's assume they are co-located or re-exported by semanticSearchSkills.ts if defined elsewhere.
+// If they are not exported from semanticSearchSkills.ts, this will cause a type error.
+// Based on previous subtask, they are defined locally in semanticSearchSkills.ts but not exported.
+// For this test to compile, they need to be exported from semanticSearchSkills.ts OR
+// defined again here, OR imported from a shared types location.
+// Let's assume they are exported from semanticSearchSkills.ts for this test to work as written.
+// If not, this would be a required modification to semanticSearchSkills.ts or this test file.
+
+// For the subtask, I will define them here to make the test file self-contained for these types,
+// as modifying semanticSearchSkills.ts to export them is outside this specific subtask's scope.
+interface MeetingSearchResult {
+    notion_page_id: string;
+    meeting_title: string;
+    meeting_date: string; // ISO date string
+    score: number;
+}
+interface BackendSearchResponse {
+    status: "success" | "error";
+    data?: MeetingSearchResult[];
+    message?: string;
+    ok?: boolean;
+    error?: { code: string; message: string; details?: any };
+}
+
+
+import { SkillArgs } from '../../../types'; // Path from skills/tests/ to atom-agent/types.ts
+import * as constants from '../../_libs/constants'; // Path from skills/tests/ to atom-agent/_libs/constants.ts
+
+// Mock axios
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Mock constants
+// Path is relative to this test file's location.
+jest.mock('../../_libs/constants', () => ({
+  ...jest.requireActual('../../_libs/constants'), // Preserve other constants
+  PYTHON_API_SERVICE_BASE_URL: 'http://mock-python-api.com',
+}));
+
+describe('SemanticSearchSkills & handleSemanticSearchMeetingNotesSkill', () => {
+  const userId = 'testUser123';
+  const baseArgs: Omit<SkillArgs, 'params' | 'raw_message'> = { // raw_message might not always be needed if not used by skill for this test
+    command: 'search_meeting_notes',
+    user_id: userId,
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks(); // Clear mocks after each test
+  });
+
+  // Test the exported handler function, which internally uses the class logic
+  describe('handleSemanticSearchMeetingNotesSkill', () => {
+    it('should return formatted results on successful search with data', async () => {
+      const mockBackendResults: MeetingSearchResult[] = [
+        { notion_page_id: 'id-1-no-hyphen', meeting_title: 'Test Meeting Alpha', meeting_date: '2023-01-01T10:00:00Z', score: 0.9123 },
+        { notion_page_id: 'id2withhyphen', meeting_title: 'Planning Session Beta', meeting_date: '2023-01-05T14:30:00Z', score: 0.8567 },
+      ];
+      // This is the structure the Python backend /api/semantic_search_meetings sends
+      const mockPythonApiResponse = { status: 'success', data: mockBackendResults };
+      mockedAxios.post.mockResolvedValueOnce({ data: mockPythonApiResponse } as AxiosResponse<BackendSearchResponse>);
+
+      const args: SkillArgs = { ...baseArgs, params: { query: 'relevant topic' }, raw_message: 'search for relevant topic' };
+      const result = await handleSemanticSearchMeetingNotesSkill(args);
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        `${constants.PYTHON_API_SERVICE_BASE_URL}/api/semantic_search_meetings`,
+        { query: 'relevant topic', user_id: userId }
+      );
+      expect(result).toContain("Found these meetings related to your query:");
+      expect(result).toContain("Test Meeting Alpha");
+      // Use toLocaleDateString with undefined locale to use system's default, making test more portable
+      const date1 = new Date('2023-01-01T10:00:00Z');
+      const expectedDate1Str = date1.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+      expect(result).toContain(`(${expectedDate1Str})`);
+      expect(result).toContain("notion://page/id1nohyphen"); // Hyphens removed
+      expect(result).toContain("(Similarity: 0.91)");
+      expect(result).toContain("Planning Session Beta");
+      expect(result).toContain("notion://page/id2withhyphen");
+      expect(result).toContain("(Similarity: 0.86)");
+    });
+
+    it('should return "no results" message on successful search with empty data', async () => {
+      const mockApiResponse: BackendSearchResponse = { status: 'success', data: [] };
+      mockedAxios.post.mockResolvedValueOnce({ data: mockApiResponse } as AxiosResponse<BackendSearchResponse>);
+
+      const args: SkillArgs = { ...baseArgs, params: { query: 'obscure topic' }, raw_message: 'search obscure topic' };
+      const result = await handleSemanticSearchMeetingNotesSkill(args);
+
+      // The skill formats this slightly differently now based on its internal logic
+      expect(result).toBe("Sorry, I couldn't find any meeting notes matching your query.");
+    });
+
+    it('should return error message if backend returns status "error"', async () => {
+      const mockApiResponse: BackendSearchResponse = { status: 'error', message: 'Backend search exploded' };
+      mockedAxios.post.mockResolvedValueOnce({ data: mockApiResponse } as AxiosResponse<BackendSearchResponse>);
+
+      const args: SkillArgs = { ...baseArgs, params: { query: 'trigger error' }, raw_message: 'search trigger error' };
+      const result = await handleSemanticSearchMeetingNotesSkill(args);
+
+      expect(result).toBe("I encountered an error while searching: Backend search exploded");
+    });
+
+    it('should return generic error message if backend response is malformed (e.g. unexpected structure)', async () => {
+      const mockMalformedResponse = { some_unexpected_key: "some_value" }; // Does not match BackendSearchResponse
+      mockedAxios.post.mockResolvedValueOnce({ data: mockMalformedResponse } as any);
+
+      const args: SkillArgs = { ...baseArgs, params: { query: 'test malformed' }, raw_message: 'search test malformed' };
+      const result = await handleSemanticSearchMeetingNotesSkill(args);
+      expect(result).toBe("I received an unexpected response from the search service. Please try again later.");
+    });
+
+    it('should return generic error message on axios network error', async () => {
+      mockedAxios.post.mockRejectedValueOnce(new Error('Network connection failed'));
+
+      const args: SkillArgs = { ...baseArgs, params: { query: 'network fail test' }, raw_message: 'search network fail test' };
+      const result = await handleSemanticSearchMeetingNotesSkill(args);
+
+      expect(result).toBe("I'm sorry, I ran into a problem trying to search your meeting notes. Please try again later.");
+    });
+
+    it('should return specific error message if axios error has response data from backend', async () => {
+        const errorResponseData = { message: "Specific backend error from Axios response" };
+        const axiosError = new AxiosError("Request failed with status code 500");
+        axiosError.response = { data: errorResponseData, status: 500, statusText: 'Internal Server Error', headers: {}, config: {} } as AxiosResponse;
+        axiosError.isAxiosError = true;
+
+        mockedAxios.post.mockRejectedValueOnce(axiosError);
+
+        const args: SkillArgs = { ...baseArgs, params: { query: 'axios error with data' }, raw_message: 'search axios error with data' };
+        const result = await handleSemanticSearchMeetingNotesSkill(args);
+        // The skill's catch block logs axiosError.response?.data but returns a generic message
+        // Let's check if the logged message (if we could capture it) or the returned message is as expected.
+        // The current skill implementation returns generic message for AxiosError.
+        expect(result).toBe("I'm sorry, I ran into a problem trying to search your meeting notes. Please try again later.");
+    });
+
+
+    it('should ask for a query if query parameter is missing in params', async () => {
+      const args: SkillArgs = { ...baseArgs, params: {}, raw_message: 'search' }; // No query in params
+      const result = await handleSemanticSearchMeetingNotesSkill(args);
+      expect(result).toBe("Please provide a search query. For example, 'search_meeting_notes what were the decisions about project alpha?'");
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('should ask for a query if query parameter is an empty string', async () => {
+      const args: SkillArgs = { ...baseArgs, params: { query: '   ' }, raw_message: 'search    ' }; // Empty string query
+      const result = await handleSemanticSearchMeetingNotesSkill(args);
+      expect(result).toBe("Please provide a search query. For example, 'search_meeting_notes what were the decisions about project alpha?'");
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This commit completes the work for the "Searchable Meeting Archive" feature.

Key changes include:

1.  **Refactor `semanticSearchSkills.ts`**:
    *   I removed the `ApiHelper` dependency. The skill now uses `axios` directly to call the Python backend service for semantic search.
    *   A new constant `PYTHON_API_SERVICE_BASE_URL` was added to `_libs/constants.ts` and is used to construct the endpoint URL (`/api/semantic_search_meetings`).
    *   The exported `handleSemanticSearchMeetingNotesSkill` function signature was updated to reflect this change (no longer accepts `apiHelper`).

2.  **Activate Intent in `handler.ts`**:
    *   The `case "SemanticSearchMeetingNotes":` block in `_internalHandleMessage` is now active.
    *   It correctly constructs `SkillArgs` and calls the refactored `handleSemanticSearchMeetingNotesSkill`.
    *   Includes input validation to ensure you provide a search query.

3.  **Unit Tests for `semanticSearchSkills.ts`**:
    *   I added a new test file `skills/tests/semanticSearchSkills.test.ts`.
    *   I implemented comprehensive unit tests using Jest, mocking `axios` and constants.
    *   Tests cover successful search scenarios (with and without results), backend error responses, network errors, and input validation for the search query.

This makes the semantic search feature fully integrated into my logic and well-tested at the unit level for the TypeScript skill.