### PR TITLE
feat: Add MongoDB service to Docker Compose for Agenda

### DIFF
--- a/atomic-docker/project/docker-compose.yaml
+++ b/atomic-docker/project/docker-compose.yaml
@@ -88,6 +88,19 @@ services:
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: public
       HASURA_GRAPHQL_LOG_LEVEL: debug
       HASURA_GRAPHQL_ENABLE_CONSOLE: 'true'
+
+  mongo:
+    image: mongo:5.0
+    container_name: mongo
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+    # environment: # Optional: Add if MongoDB authentication is needed
+    #   MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USER:-mongoadmin} # Example default
+    #   MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-secretmongo} # Example default
+
   functions:
     build: ../functions_build_docker
     container_name: 'functions'
@@ -98,6 +111,7 @@ services:
       - optaplanner
       - postgres
       - graphql-engine
+      - mongo # Added mongo dependency
     environment:
       BASIC_AUTH: ${BASIC_AUTH}
       FUNCTION_SERVER_URL: ${FUNCTION_SERVER_URL}
@@ -386,3 +400,4 @@ services:
 volumes:
   project_node_modules:
   functions_node_modules:
+  mongo-data: {}

--- a/atomic-docker/project/functions/agendaService.ts
+++ b/atomic-docker/project/functions/agendaService.ts
@@ -11,7 +11,7 @@ export interface ScheduledAgentTaskData {
 }
 
 // Default MongoDB connection string - replace with your actual URI in production
-const mongoConnectionString = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/atomicAgentJobs';
+const mongoConnectionString = process.env.MONGODB_URI || 'mongodb://mongo:27017/atomicAgentJobs';
 
 // URL for the agent's internal invocation endpoint
 const AGENT_INTERNAL_INVOKE_URL = process.env.AGENT_INTERNAL_INVOKE_URL || 'http://localhost:7071/api/agentMessageHandler'; // Adjust if your agent runs elsewhere or on a different port

--- a/atomic-docker/project/functions/docs/agenda-scheduling.md
+++ b/atomic-docker/project/functions/docs/agenda-scheduling.md
@@ -45,6 +45,11 @@ The system uses `Agenda`, a Node.js job scheduling library, to manage and execut
 
 ## Local Development
 
-*   Ensure a MongoDB instance is running and accessible.
-*   Set the `MONGODB_URI` and `AGENT_INTERNAL_INVOKE_URL` environment variables for the `functions` service.
-*   The `agendaService.ts` needs to be started (e.g. `startAgenda()`) as part of the application's bootstrap process to begin processing jobs.
+*   **MongoDB Setup**:
+    *   MongoDB is configured as a service (`mongo`) in the main `docker-compose.yaml` file (`atomic-docker/project/docker-compose.yaml`).
+    *   It will be started automatically when you run `docker-compose up`.
+    *   Data is persisted in a Docker volume named `mongo-data`.
+*   **Environment Variables**:
+    *   If `MONGODB_URI` is not set in your environment, `agendaService.ts` defaults to `mongodb://mongo:27017/atomicAgentJobs`, allowing the `functions` container to connect to the `mongo` container on the Docker network.
+    *   Set the `AGENT_INTERNAL_INVOKE_URL` environment variable for the `functions` service (e.g., in your `.env` file).
+*   **Starting Agenda**: The `agendaService.ts` needs to have its `startAgenda()` function called as part of the `functions` application's bootstrap process to begin processing jobs.


### PR DESCRIPTION
This commit introduces MongoDB as a service in the Docker Compose setup to support the Agenda-based scheduling system.

Key changes:

1.  **`atomic-docker/project/docker-compose.yaml`**:
    *   Added a new service definition for `mongo` using the `mongo:5.0` image.
    *   Configured port mapping (`27017:27017`) and a named volume (`mongo-data`) for persistent data storage.
    *   The `functions` service now includes `mongo` in its `depends_on` list to ensure proper startup order.

2.  **`atomic-docker/project/functions/agendaService.ts`**:
    *   Modified the default MongoDB connection URI to `mongodb://mongo:27017/atomicAgentJobs`. This allows the `functions` service (running in a Docker container) to connect to the `mongo` service container using Docker's internal DNS.

3.  **`atomic-docker/project/functions/docs/agenda-scheduling.md`**:
    *   Updated the "Local Development" section to reflect that MongoDB is managed by Docker Compose.
    *   Clarified how the `functions` service connects to the `mongo` service within the Docker environment.

These changes provide the necessary infrastructure support for the Agenda library, enabling persistent task scheduling in a Dockerized environment. This commit should be paired with the `feature/agent-agenda-scheduler` branch/commit, which contains the core Agenda integration logic.