### PR TITLE
Refactor: Separate text and voice conversation contexts

### DIFF
--- a/atomic-docker/project/functions/atom-agent/conversationState.ts
+++ b/atomic-docker/project/functions/atom-agent/conversationState.ts
@@ -5,6 +5,8 @@ import { HandleMessageResponse } from './handler'; // Assuming handler.ts export
 const IDLE_TIMEOUT_MS = 30 * 1000; // 30 seconds
 const MAX_TURN_HISTORY_LENGTH = 10; // Limit for STM turn history
 
+export type InterfaceType = 'text' | 'voice';
+
 interface ConversationState {
   isActive: boolean;
   isAgentResponding: boolean; // New state: true if agent is currently "speaking" or processing a response
@@ -26,133 +28,149 @@ interface ConversationState {
   ltmContext: any[] | null; // For storing results from LTM queries
 }
 
-// In-memory store for conversation state.
-const globalConversationState: ConversationState = {
-  isActive: false,
-  isAgentResponding: false,
-  lastInteractionTime: null,
-  conversationHistory: [], // Retained for existing detailed history
-  idleTimer: null,
+// In-memory store for conversation states, keyed by InterfaceType.
+const conversationStates = new Map<InterfaceType, ConversationState>();
 
-  // Initialize STM fields
-  currentIntent: null,
-  identifiedEntities: null,
-  userGoal: null,
-  turnHistory: [],
-  ltmContext: null,
-};
-
-function log(message: string) {
-  console.log(`[ConversationState] ${new Date().toISOString()}: ${message}`);
+function getOrCreateConversationState(interfaceType: InterfaceType): ConversationState {
+  if (!conversationStates.has(interfaceType)) {
+    conversationStates.set(interfaceType, {
+      isActive: false,
+      isAgentResponding: false,
+      lastInteractionTime: null,
+      conversationHistory: [],
+      idleTimer: null,
+      currentIntent: null,
+      identifiedEntities: null,
+      userGoal: null,
+      turnHistory: [],
+      ltmContext: null,
+    });
+  }
+  return conversationStates.get(interfaceType)!;
 }
 
-export function getConversationStateSnapshot(): Readonly<ConversationState> {
+function log(interfaceType: InterfaceType, message: string) {
+  console.log(`[ConversationState][${interfaceType}] ${new Date().toISOString()}: ${message}`);
+}
+
+export function getConversationStateSnapshot(interfaceType: InterfaceType): Readonly<ConversationState> {
+  const state = getOrCreateConversationState(interfaceType);
   // Return a copy to prevent direct modification of the state object
-  return JSON.parse(JSON.stringify(globalConversationState));
+  return JSON.parse(JSON.stringify(state));
 }
 
-function clearIdleTimer() {
-  if (globalConversationState.idleTimer) {
-    clearTimeout(globalConversationState.idleTimer);
-    globalConversationState.idleTimer = null;
+function clearIdleTimer(interfaceType: InterfaceType) {
+  const state = getOrCreateConversationState(interfaceType);
+  if (state.idleTimer) {
+    clearTimeout(state.idleTimer);
+    state.idleTimer = null;
   }
 }
 
-export function setAgentResponding(isResponding: boolean) {
-  globalConversationState.isAgentResponding = isResponding;
-  log(`Agent responding state set to: ${isResponding}`);
+export function setAgentResponding(interfaceType: InterfaceType, isResponding: boolean) {
+  const state = getOrCreateConversationState(interfaceType);
+  state.isAgentResponding = isResponding;
+  log(interfaceType, `Agent responding state set to: ${isResponding}`);
   if (isResponding) {
     // If agent starts responding, we might want to temporarily pause the idle timer,
     // or handle it such that user can interrupt without idle timeout issues.
     // For now, an explicit interrupt signal will be the primary mechanism.
-    // clearIdleTimer(); // Option: clear idle timer when agent starts responding
+    // clearIdleTimer(interfaceType); // Option: clear idle timer when agent starts responding
   } else {
     // If agent finished responding and conversation is still active, restart idle timer
-    if (globalConversationState.isActive) {
-      startIdleTimer();
+    if (state.isActive) {
+      startIdleTimer(interfaceType);
     }
   }
 }
 
-export function checkIfAgentIsResponding(): boolean {
-  return globalConversationState.isAgentResponding;
+export function checkIfAgentIsResponding(interfaceType: InterfaceType): boolean {
+  const state = getOrCreateConversationState(interfaceType);
+  return state.isAgentResponding;
 }
 
-export function deactivateConversation(reason: string = "timeout") {
-  clearIdleTimer();
-  if (globalConversationState.isActive || globalConversationState.isAgentResponding) {
-    globalConversationState.isActive = false;
-    globalConversationState.isAgentResponding = false; // Ensure this is also reset
-    globalConversationState.lastInteractionTime = null;
-    globalConversationState.ltmContext = null; // Reset LTM context
-    log(`Conversation deactivated due to ${reason}. LTM context cleared.`);
+export function deactivateConversation(interfaceType: InterfaceType, reason: string = "timeout") {
+  clearIdleTimer(interfaceType);
+  const state = getOrCreateConversationState(interfaceType);
+  if (state.isActive || state.isAgentResponding) {
+    state.isActive = false;
+    state.isAgentResponding = false; // Ensure this is also reset
+    state.lastInteractionTime = null;
+    state.ltmContext = null; // Reset LTM context
+    log(interfaceType, `Conversation deactivated due to ${reason}. LTM context cleared.`);
   }
 }
 
-function startIdleTimer() {
-  clearIdleTimer();
+function startIdleTimer(interfaceType: InterfaceType) {
+  clearIdleTimer(interfaceType);
+  const state = getOrCreateConversationState(interfaceType);
   // Only start idle timer if agent is NOT responding, and conversation IS active
-  if (!globalConversationState.isAgentResponding && globalConversationState.isActive) {
-    globalConversationState.idleTimer = setTimeout(() => {
-      if (globalConversationState.isActive && !globalConversationState.isAgentResponding) { // Double check state
-        deactivateConversation("idle_timeout");
+  if (!state.isAgentResponding && state.isActive) {
+    state.idleTimer = setTimeout(() => {
+      const currentState = getOrCreateConversationState(interfaceType); // Re-fetch current state
+      if (currentState.isActive && !currentState.isAgentResponding) { // Double check state
+        deactivateConversation(interfaceType, "idle_timeout");
       }
     }, IDLE_TIMEOUT_MS);
-    log(`Idle timer started for ${IDLE_TIMEOUT_MS / 1000} seconds.`);
-  } else if (globalConversationState.isAgentResponding) {
-    log("Idle timer not started because agent is currently responding.");
-  } else if (!globalConversationState.isActive) {
-    log("Idle timer not started because conversation is not active.");
+    log(interfaceType, `Idle timer started for ${IDLE_TIMEOUT_MS / 1000} seconds.`);
+  } else if (state.isAgentResponding) {
+    log(interfaceType, "Idle timer not started because agent is currently responding.");
+  } else if (!state.isActive) {
+    log(interfaceType, "Idle timer not started because conversation is not active.");
   }
 }
 
-export function activateConversation(): { status: string; active: boolean } {
-  const wasActive = globalConversationState.isActive;
-  globalConversationState.isActive = true;
-  globalConversationState.isAgentResponding = false; // Agent is not responding at point of activation
-  globalConversationState.lastInteractionTime = Date.now();
-  globalConversationState.ltmContext = null; // Reset LTM context on new activation
-  startIdleTimer();
+export function activateConversation(interfaceType: InterfaceType): { status: string; active: boolean } {
+  const state = getOrCreateConversationState(interfaceType);
+  const wasActive = state.isActive;
+  state.isActive = true;
+  state.isAgentResponding = false; // Agent is not responding at point of activation
+  state.lastInteractionTime = Date.now();
+  state.ltmContext = null; // Reset LTM context on new activation
+  startIdleTimer(interfaceType);
 
   if (!wasActive) {
-    log("Conversation activated. LTM context cleared.");
+    log(interfaceType, "Conversation activated. LTM context cleared.");
     return { status: "Conversation activated.", active: true };
   } else {
-    log("Conversation was already active. Interaction time and timer reset. Agent responding state ensured false. LTM context cleared.");
+    log(interfaceType, "Conversation was already active. Interaction time and timer reset. Agent responding state ensured false. LTM context cleared.");
     return { status: "Conversation was already active. State reset for new interaction.", active: true };
   }
 }
 
-export function recordUserInteraction(text: string) {
-  if (!globalConversationState.isActive) {
-    log("Interaction recorded (text received) while conversation is inactive. This shouldn't lead to processing by agent logic.");
+export function recordUserInteraction(interfaceType: InterfaceType, text: string) {
+  const state = getOrCreateConversationState(interfaceType);
+  if (!state.isActive) {
+    log(interfaceType, "Interaction recorded (text received) while conversation is inactive. This shouldn't lead to processing by agent logic.");
     return; // Don't update interaction time or restart timer if not active
   }
   // If user speaks, it implies they are interrupting or starting new turn.
   // Agent should no longer be considered "responding" from this point for this new input.
   // However, the /interrupt endpoint is the more explicit way to stop agent actions.
   // This function primarily resets the idle timer for the user's current speech.
-  globalConversationState.lastInteractionTime = Date.now();
-  startIdleTimer();
-  log(`User interaction recorded. Time and timer reset. Text: "${text.substring(0, 50)}..."`);
+  state.lastInteractionTime = Date.now();
+  startIdleTimer(interfaceType);
+  log(interfaceType, `User interaction recorded. Time and timer reset. Text: "${text.substring(0, 50)}..."`);
 }
 
 export function recordAgentResponse(
+  interfaceType: InterfaceType,
   userText: string,
   agentResponse: HandleMessageResponse,
   intent?: string,
   entities?: Record<string, any>
 ) {
+    const state = getOrCreateConversationState(interfaceType);
     // Record to existing conversationHistory
-    globalConversationState.conversationHistory.push({
+    state.conversationHistory.push({
         user: userText,
         agent: agentResponse,
         timestamp: Date.now()
     });
-    if (globalConversationState.conversationHistory.length > 20) { // Existing limit
-        globalConversationState.conversationHistory.shift();
+    if (state.conversationHistory.length > 20) { // Existing limit
+        state.conversationHistory.shift();
     }
-    log("Agent response recorded in detailed history.");
+    log(interfaceType, "Agent response recorded in detailed history.");
 
     // Update new turnHistory for STM
     const turn = {
@@ -162,60 +180,66 @@ export function recordAgentResponse(
         entities: entities,
         timestamp: Date.now()
     };
-    globalConversationState.turnHistory.push(turn);
-    if (globalConversationState.turnHistory.length > MAX_TURN_HISTORY_LENGTH) {
-        globalConversationState.turnHistory.shift();
+    state.turnHistory.push(turn);
+    if (state.turnHistory.length > MAX_TURN_HISTORY_LENGTH) {
+        state.turnHistory.shift();
     }
-    log(`Turn recorded in STM history. Current STM history length: ${globalConversationState.turnHistory.length}`);
+    log(interfaceType, `Turn recorded in STM history. Current STM history length: ${state.turnHistory.length}`);
 
     // Potentially update currentIntent and identifiedEntities from the latest turn
     if (intent) {
-        globalConversationState.currentIntent = intent;
-        log(`Current intent updated to: ${intent}`);
+        state.currentIntent = intent;
+        log(interfaceType, `Current intent updated to: ${intent}`);
     }
     if (entities) {
-        globalConversationState.identifiedEntities = entities;
-        log(`Identified entities updated.`);
+        state.identifiedEntities = entities;
+        log(interfaceType, `Identified entities updated.`);
     }
 }
 
-export function updateIntentAndEntities(intent: string | null, entities: Record<string, any> | null) {
-  globalConversationState.currentIntent = intent;
-  globalConversationState.identifiedEntities = entities;
-  log(`Intent and entities updated: Intent - ${intent}, Entities - ${JSON.stringify(entities)}`);
+export function updateIntentAndEntities(interfaceType: InterfaceType, intent: string | null, entities: Record<string, any> | null) {
+  const state = getOrCreateConversationState(interfaceType);
+  state.currentIntent = intent;
+  state.identifiedEntities = entities;
+  log(interfaceType, `Intent and entities updated: Intent - ${intent}, Entities - ${JSON.stringify(entities)}`);
 }
 
-export function updateUserGoal(goal: string | null) {
-  globalConversationState.userGoal = goal;
-  log(`User goal updated to: ${goal}`);
+export function updateUserGoal(interfaceType: InterfaceType, goal: string | null) {
+  const state = getOrCreateConversationState(interfaceType);
+  state.userGoal = goal;
+  log(interfaceType, `User goal updated to: ${goal}`);
 }
 
-export function updateLTMContext(context: any[] | null) {
-  globalConversationState.ltmContext = context;
+export function updateLTMContext(interfaceType: InterfaceType, context: any[] | null) {
+  const state = getOrCreateConversationState(interfaceType);
+  state.ltmContext = context;
   if (context) {
-    log(`LTM context updated with ${context.length} items.`);
+    log(interfaceType, `LTM context updated with ${context.length} items.`);
   } else {
-    log('LTM context cleared.');
+    log(interfaceType, 'LTM context cleared.');
   }
 }
 
-export function isConversationActive(): boolean {
-  return globalConversationState.isActive;
+export function isConversationActive(interfaceType: InterfaceType): boolean {
+  const state = getOrCreateConversationState(interfaceType);
+  return state.isActive;
 }
 
-export function getConversationHistory(): Readonly<Array<{ user: string; agent: HandleMessageResponse; timestamp: number }>> {
-    return globalConversationState.conversationHistory;
+export function getConversationHistory(interfaceType: InterfaceType): Readonly<Array<{ user: string; agent: HandleMessageResponse; timestamp: number }>> {
+    const state = getOrCreateConversationState(interfaceType);
+    return state.conversationHistory;
 }
 
 // Example of how to expose a function to manually set state for testing (as requested)
 // This would typically be part of a testing setup, not production code.
-export function _test_setConversationActive(active: boolean) {
+export function _test_setConversationActive(interfaceType: InterfaceType, active: boolean) {
   if (active) {
-    activateConversation();
+    activateConversation(interfaceType);
   } else {
-    deactivateConversation("manual test override");
+    deactivateConversation(interfaceType, "manual test override");
   }
-  log(`Conversation state manually set to active: ${active} for testing.`);
+  log(interfaceType, `Conversation state manually set to active: ${active} for testing.`);
 }
 
-log("Conversation state manager initialized.");
+log('text', "Conversation state manager initialized for text interface.");
+log('voice', "Conversation state manager initialized for voice interface.");


### PR DESCRIPTION
- Modified `conversationState.ts` to manage distinct states for 'text' and 'voice' interfaces. Each interface now has its own isolated conversation lifecycle, history, and status flags.

- Updated `handler.ts`:
    - `_internalHandleMessage` now accepts an `InterfaceType` to interact with the correct conversation state.
    - `handleMessage` (for text-based interactions, e.g., Hasura actions) now exclusively uses the 'text' context. It activates and deactivates this context per call and no longer invokes TTS, returning only the text response.
    - `handleConversationInputWrapper` (for voice-based interactions) now exclusively uses the 'voice' context and continues to invoke TTS for audio output.
    - Wrapper functions `activateConversationWrapper`, `deactivateConversationWrapper`, and `handleInterruptWrapper` now operate on the 'voice' context by default.

- Revised `handler.test.ts` to align with these changes:
    - Tests for `handleMessage` now verify 'text' context usage and the absence of TTS calls.
    - Tests for `handleConversationInputWrapper` verify 'voice' context usage and TTS invocation.
    - Mocks for `conversationState` functions updated to reflect `InterfaceType` parameter.
    - Ensured test coverage for both text and voice interaction paths and states.

This change provides a clear separation for handling different types of agent interfaces, allowing for distinct conversation flows and output modalities. Integration of scheduled tasks from `agendaService.ts` will require separate updates to the API endpoint that `agendaService.ts` calls, which will now be able to leverage these distinct contexts.