### PR TITLE
feat: Add utility functions for Hasura client and AWS Secrets Manager

### DIFF
--- a/atomic-docker/project/functions/_utils/aws-secrets-manager.ts
+++ b/atomic-docker/project/functions/_utils/aws-secrets-manager.ts
@@ -1,0 +1,126 @@
+// File: atomic-docker/project/functions/_utils/aws-secrets-manager.ts
+
+import { SecretsManagerClient, GetSecretValueCommand, GetSecretValueCommandInput, GetSecretValueCommandOutput } from "@aws-sdk/client-secrets-manager";
+
+// Environment variables expected (for AWS SDK configuration, typically handled by Lambda execution environment):
+// - AWS_REGION (implicitly used by SDK if not specified in client constructor)
+
+const secretsManagerClient = new SecretsManagerClient({
+    region: process.env.AWS_REGION || "us-east-1", // Default to us-east-1 or your specific primary region
+});
+
+interface SecretCacheEntry {
+    value: string;
+    timestamp: number;
+}
+const secretCache: Record<string, SecretCacheEntry> = {};
+const CACHE_DURATION_MS = 5 * 60 * 1000; // Cache secrets for 5 minutes by default
+
+/**
+ * Retrieves a secret string from AWS Secrets Manager.
+ * Caches secrets in memory for a short duration to reduce API calls.
+ *
+ * @param secretId The ARN or name of the secret to retrieve.
+ * @param versionId (Optional) Specifies the unique identifier of the version of the secret to retrieve.
+ *                  If you specify this parameter then stage is ignored. Defaults to AWSCURRENT.
+ * @param versionStage (Optional) Specifies the secret version stage that you want to retrieve.
+ *                     If you specify this parameter then versionId is ignored. Defaults to AWSCURRENT.
+ * @returns {Promise<string | undefined>} The secret string, or undefined if an error occurs or secret is not found.
+ * @throws {Error} If fetching the secret fails and is not handled gracefully (e.g. access denied).
+ */
+export const getSecret = async (
+    secretId: string,
+    versionId?: string,
+    versionStage?: string
+): Promise<string | undefined> => {
+    const cacheKey = `${secretId}:${versionId || 'defaultVersionId'}:${versionStage || 'AWSCURRENT'}`;
+    const cachedItem = secretCache[cacheKey];
+
+    if (cachedItem && (Date.now() - cachedItem.timestamp < CACHE_DURATION_MS)) {
+        console.log(`[SecretsManager] Returning cached secret for ID: ${secretId.split('/').pop()?.split('-')[0]}...`); // Log part of secret name
+        return cachedItem.value;
+    }
+
+    console.log(`[SecretsManager] Fetching secret from AWS Secrets Manager for ID: ${secretId.split('/').pop()?.split('-')[0]}...`);
+
+    const params: GetSecretValueCommandInput = {
+        SecretId: secretId,
+    };
+    if (versionId) params.VersionId = versionId;
+    if (versionStage && !versionId) params.VersionStage = versionStage;
+
+    try {
+        const command = new GetSecretValueCommand(params);
+        const data: GetSecretValueCommandOutput = await secretsManagerClient.send(command);
+
+        let secretString: string | undefined;
+        if (data.SecretString) {
+            secretString = data.SecretString;
+        } else if (data.SecretBinary) {
+            // If secret is binary, decode it. For API keys, usually it's a string.
+            // This example assumes SecretString is used. If binary, uncomment and adjust:
+            // const buff = Buffer.from(data.SecretBinary); // For Node.js v14+ direct Buffer from Uint8Array
+            // secretString = buff.toString('utf-8');
+            console.warn(`[SecretsManager] Secret for ID ${secretId} is binary. This utility currently processes SecretString directly.`);
+        } else {
+            console.warn(`[SecretsManager] Secret for ID ${secretId} has no SecretString or SecretBinary content.`);
+        }
+
+        if (secretString) {
+            secretCache[cacheKey] = { value: secretString, timestamp: Date.now() };
+        }
+        return secretString;
+
+    } catch (error: any) {
+        console.error(`[SecretsManager] Error retrieving secret for ID ${secretId}: ${error.name} - ${error.message}`);
+        if (error.name === 'ResourceNotFoundException' || error.name === 'InvalidParameterException') {
+            return undefined; // Secret not found or bad identifier, return undefined gracefully.
+        }
+        // For other errors like AccessDeniedException, InternalServiceErrorException, etc., re-throw.
+        throw error;
+    }
+};
+
+/**
+ * Clears a specific secret or the entire cache.
+ * @param secretId (Optional) The ARN or name of the secret to clear from cache. If not provided, clears all cached secrets.
+ */
+export const clearSecretCache = (secretId?: string): void => {
+    if (secretId) {
+        // Clear all versions/stages for this secretId that might be cached
+        Object.keys(secretCache).forEach(key => {
+            if (key.startsWith(secretId + ':')) {
+                delete secretCache[key];
+            }
+        });
+        console.log(`[SecretsManager] Cleared cache for secret ID: ${secretId}`);
+    } else {
+        Object.keys(secretCache).forEach(key => delete secretCache[key]);
+        console.log('[SecretsManager] All secrets cleared from cache.');
+    }
+};
+
+// Example Usage:
+/*
+import { getSecret } from './aws-secrets-manager'; // Adjust path as necessary
+
+export const exampleLambdaHandler = async () => {
+    const myApiTokenArn = process.env.MY_API_TOKEN_SECRET_ARN;
+    if (!myApiTokenArn) {
+        console.error("MY_API_TOKEN_SECRET_ARN environment variable is not set.");
+        return;
+    }
+
+    try {
+        const apiToken = await getSecret(myApiTokenArn);
+        if (apiToken) {
+            console.log("Successfully retrieved API token (first few chars):", apiToken.substring(0, 5));
+            // Use the apiToken...
+        } else {
+            console.log("API token not found or is empty.");
+        }
+    } catch (error) {
+        console.error("Failed to process secret:", error);
+    }
+};
+*/

--- a/atomic-docker/project/functions/_utils/hasura-client.ts
+++ b/atomic-docker/project/functions/_utils/hasura-client.ts
@@ -1,0 +1,77 @@
+// File: atomic-docker/project/functions/_utils/hasura-client.ts
+
+import { GraphQLClient } from 'graphql-request';
+
+// Environment variables expected:
+// - HASURA_GRAPHQL_ENDPOINT_URL: The HTTP(S) endpoint for your Hasura GraphQL API.
+// - HASURA_GRAPHQL_ADMIN_SECRET: The admin secret for Hasura.
+
+let clientInstance: GraphQLClient | null = null;
+
+/**
+ * Initializes and returns a GraphQLClient instance configured for Hasura.
+ * It uses environment variables for the endpoint and admin secret.
+ * The client is cached for subsequent calls within the same Lambda invocation.
+ *
+ * @returns {GraphQLClient} An instance of GraphQLClient.
+ * @throws {Error} If Hasura endpoint or admin secret environment variables are not set.
+ */
+export const getGraphQLClient = (): GraphQLClient => {
+    if (clientInstance) {
+        return clientInstance;
+    }
+
+    const endpoint = process.env.HASURA_GRAPHQL_ENDPOINT_URL;
+    const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
+
+    if (!endpoint) {
+        console.error('[HasuraClient] HASURA_GRAPHQL_ENDPOINT_URL environment variable is not set.');
+        throw new Error('Hasura GraphQL endpoint URL is not configured.');
+    }
+
+    if (!adminSecret) {
+        console.error('[HasuraClient] HASURA_GRAPHQL_ADMIN_SECRET environment variable is not set.');
+        throw new Error('Hasura admin secret is not configured.');
+    }
+
+    // Basic logging to confirm initialization, avoid logging full endpoint if too sensitive.
+    const urlScheme = endpoint.startsWith('https://') ? 'https://' : 'http://';
+    console.log(`[HasuraClient] Initializing GraphQL client for endpoint starting with: ${urlScheme}...`);
+
+
+    clientInstance = new GraphQLClient(endpoint, {
+        headers: {
+            'x-hasura-admin-secret': adminSecret,
+            'Content-Type': 'application/json',
+        },
+    });
+
+    return clientInstance;
+};
+
+/**
+ * Clears the cached GraphQLClient instance.
+ * Useful for testing or if credentials need to be re-evaluated in a long-running process.
+ */
+export const clearCachedClient = (): void => {
+    clientInstance = null;
+    console.log('[HasuraClient] Cached GraphQL client instance cleared.');
+};
+
+// Example of how a Lambda might use it:
+/*
+import { getGraphQLClient } from './hasura-client'; // Adjust path as needed
+import { gql } from 'graphql-request';
+
+export const someLambdaHandler = async (event: any) => {
+    try {
+        const client = getGraphQLClient();
+        const query = gql`query MyQuery { your_table { id } }`;
+        const data = await client.request(query);
+        console.log(data);
+    } catch (error) {
+        console.error("Error in someLambdaHandler:", error);
+        // handle error
+    }
+};
+*/


### PR DESCRIPTION
Introduces two shared utility functions for backend Lambdas:

1. `getGraphQLClient` (in `_utils/hasura-client.ts`):
   - Provides a cached, authenticated GraphQL client (`graphql-request`) for Hasura.
   - Uses `HASURA_GRAPHQL_ENDPOINT_URL` and `HASURA_GRAPHQL_ADMIN_SECRET` environment variables.

2. `getSecret` (in `_utils/aws-secrets-manager.ts`):
   - Retrieves secrets from AWS Secrets Manager using `@aws-sdk/client-secrets-manager`.
   - Includes in-memory caching for retrieved secrets.
   - Requires appropriate IAM permissions for Lambda execution roles.

These utilities will be used by notification Lambdas (SES, Slack, Teams) and other backend services to interact with Hasura and securely manage secrets.