### PR TITLE
feat: Implement AI-powered MS Teams chat features with delegated perm…

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -145,6 +145,17 @@ Atom connects with a wide range of third-party services to create a unified prod
     *   **Configuration:** Requires `ATOM_SLACK_BOT_TOKEN` with appropriate scopes (see Slack integration guide).
     *   **Developer Documentation:** Comprehensive guide for setup, API details, required scopes, and agent integration logic.
 
+*   **Microsoft Teams Integration (Enhanced AI-Powered Chat Interaction & Delegated Permissions):**
+    *   **Secure User-Contextual Connection:** Connect on behalf of the user via OAuth 2.0 (delegated permissions) to access their Microsoft Teams environment. User-specific tokens are securely stored.
+    *   **Natural Language Message Search:** Ask the agent in natural language to find Teams messages (e.g., "find Teams messages from Alex about the Q1 budget in our 'Strategy Chat' from last week"). The agent uses an LLM to understand complex queries and map them to Microsoft Graph Search API queries.
+    *   **Targeted Information Extraction:** Request specific information from found Teams messages (e.g., "What action items were assigned to me in the Teams message from Lee in the 'Project Phoenix' channel?"). The agent uses an LLM to read message content and extract details.
+    *   **Message Content Retrieval:** Fetch and display content of specific Teams chat or channel messages the user has access to.
+    *   **Permalink (WebURL) Generation:** Get direct links to Teams messages.
+    *   **Agent Skills:** Core agent skills developed to search Teams messages, read content, extract information, and get webUrls via the Microsoft Graph API, operating within the user's permissions.
+    *   **Existing Functionality:** Continues to support integration for calendar events and online meetings (details may vary based on app or delegated permissions for calendar access).
+    *   **Configuration:** Requires Azure AD App Registration with appropriate delegated permissions (e.g., `Chat.Read`, `ChannelMessage.Read.All`, `User.Read`, `offline_access`) and corresponding environment variables (see MS Teams integration guide).
+    *   **Developer Documentation:** New comprehensive guide (`docs/msteams_integration_guide.md`) for setup, Azure AD configuration, API details, required delegated scopes, and agent integration logic.
+
 ### User Settings & Preferences
 Tailor Atom to your specific needs with a range of customizable settings:
 *   **General Preferences:** Configure core settings during onboarding and later, such as your typical workday hours, default alarm/reminder times, and primary calendar selection.

--- a/atomic-docker/project/functions/atom-agent/command_handlers/msteams_command_handler.ts
+++ b/atomic-docker/project/functions/atom-agent/command_handlers/msteams_command_handler.ts
@@ -1,0 +1,189 @@
+import { understandMSTeamsSearchQueryLLM } from '../skills/llm_msteams_query_understander';
+import { buildMSTeamsSearchQuery } from '../skills/nlu_msteams_helper';
+import {
+  searchMyMSTeamsMessages,
+  readMSTeamsMessage,
+  extractInformationFromMSTeamsMessage,
+  getMSTeamsMessageWebUrl,
+  GetMSTeamsMessageDetailInput, // Input type for readMSTeamsMessage
+} from '../skills/msTeamsSkills';
+import { MSTeamsMessage } from '../types';
+import { logger } from '../../_utils/logger';
+
+export type MSTeamsActionType =
+  | 'GET_MSTEAMS_MESSAGE_CONTENT'
+  | 'FIND_INFO_IN_MSTEAMS_MESSAGE'
+  | 'GET_MSTEAMS_MESSAGE_LINK'
+  | 'SUMMARIZE_MSTEAMS_MESSAGE'; // Future capability
+
+export interface MSTeamsActionRequest {
+  actionType: MSTeamsActionType;
+  infoKeywords?: string[];
+  naturalLanguageQuestion?: string;
+}
+
+export interface ParsedNluMSTeamsRequest {
+  userId: string;
+  rawMSTeamsSearchQuery: string;
+  actionRequested: MSTeamsActionRequest;
+  // Fields to directly target a message if NLU identifies them
+  targetMessageId?: string;
+  targetChatId?: string;
+  targetTeamId?: string;
+  targetChannelId?: string;
+}
+
+export async function handleMSTeamsInquiry(request: ParsedNluMSTeamsRequest): Promise<string> {
+  const {
+    userId,
+    rawMSTeamsSearchQuery,
+    actionRequested,
+    targetMessageId,
+    targetChatId,
+    targetTeamId,
+    targetChannelId,
+  } = request;
+  let messageToUser = "";
+
+  logger.debug(`[MSTeamsCommandHandler] Handling MS Teams inquiry for user ${userId}:`, request);
+
+  try {
+    let targetMessage: MSTeamsMessage | null = null;
+
+    // Step 1: Obtain the target message
+    if (targetMessageId && (targetChatId || (targetTeamId && targetChannelId))) {
+      const identifier: GetMSTeamsMessageDetailInput = { messageId: targetMessageId };
+      if (targetChatId) identifier.chatId = targetChatId;
+      if (targetTeamId) identifier.teamId = targetTeamId;
+      if (targetChannelId) identifier.channelId = targetChannelId;
+
+      logger.info(`[MSTeamsCommandHandler] Attempting to read specified MS Teams message:`, identifier);
+      targetMessage = await readMSTeamsMessage(userId, identifier);
+      if (!targetMessage) {
+        messageToUser = `Sorry, I couldn't find or read the specific Teams message you referred to.`;
+        logger.warn(`[MSTeamsCommandHandler] Failed to read specific message: ${messageToUser}`);
+        return messageToUser;
+      }
+    } else {
+      logger.info(`[MSTeamsCommandHandler] Understanding MS Teams search query: "${rawMSTeamsSearchQuery}"`);
+      const structuredSearchParams = await understandMSTeamsSearchQueryLLM(rawMSTeamsSearchQuery);
+
+      if (Object.keys(structuredSearchParams).length === 0 && !rawMSTeamsSearchQuery.toLowerCase().includes('latest')) {
+        messageToUser = "I couldn't determine specific search criteria for Teams from your request. Could you be more precise?";
+        logger.warn(`[MSTeamsCommandHandler] LLM returned empty search params for query: "${rawMSTeamsSearchQuery}"`);
+        return messageToUser;
+      }
+
+      const kqlQueryString = buildMSTeamsSearchQuery(structuredSearchParams);
+      logger.info(`[MSTeamsCommandHandler] Searching MS Teams messages with KQL query: "${kqlQueryString}" (Limit 5)`);
+      const messagesFound = await searchMyMSTeamsMessages(userId, kqlQueryString, 5);
+
+      if (!messagesFound || messagesFound.length === 0) {
+        messageToUser = "I couldn't find any Teams messages matching your criteria.";
+        logger.info(`[MSTeamsCommandHandler] No messages found for KQL query: "${kqlQueryString}"`);
+        return messageToUser;
+      }
+
+      if (messagesFound.length > 1 && actionRequested.actionType !== 'FIND_INFO_IN_MSTEAMS_MESSAGE') {
+        messageToUser = "I found a few Teams messages matching your criteria:\n";
+        messagesFound.slice(0, 3).forEach((msg, index) => {
+          const msgTextPreview = msg.content ? (msg.content.replace(/<[^>]+>/g, ' ').substring(0, 70) + "...") : "No text content";
+          const context = msg.channelName ? `in ${msg.channelName}` : (msg.chatId ? `in chat ${msg.chatId.substring(0,10)}...` : '');
+          messageToUser += `${index + 1}. From ${msg.userName || 'Unknown User'} ${context}: "${msgTextPreview}" (ID: ...${msg.id.slice(-6)})\n`;
+        });
+        if (messagesFound.length > 3) messageToUser += `And ${messagesFound.length - 3} more.\n`;
+        messageToUser += "Which one are you interested in? You can tell me the number or provide more details (like its ID).";
+        logger.info(`[MSTeamsCommandHandler] Multiple messages found, clarification needed.`);
+        return messageToUser;
+      }
+      targetMessage = messagesFound[0];
+      logger.info(`[MSTeamsCommandHandler] Single message identified for processing. ID: ${targetMessage.id}`);
+
+      // Ensure full content if search result was partial (heuristic: check if content seems too short or lacks detail)
+      // This might require a more robust check or always fetching full details if search API returns summaries.
+      // For now, assume search returns enough, or readMSTeamsMessage is called if specific ID is known.
+      // If targetMessage.content seems like a snippet, fetch full.
+      // This check is simplified; Graph search results for messages usually contain the full body.
+    }
+
+    if (!targetMessage) {
+      messageToUser = "I couldn't identify a specific Teams message to process.";
+      logger.warn(`[MSTeamsCommandHandler] No target message identified.`);
+      return messageToUser;
+    }
+
+    // Step 2: Perform the requested action
+    const messageDesc = `the Teams message from ${targetMessage.userName || 'Unknown User'}` +
+                        (targetMessage.channelName ? ` in ${targetMessage.channelName}` : (targetMessage.chatId ? ` in chat` : ''));
+
+    switch (actionRequested.actionType) {
+      case 'GET_MSTEAMS_MESSAGE_CONTENT':
+        const contentPreview = targetMessage.content
+          ? (targetMessage.content.replace(/<[^>]+>/g, ' ').substring(0, 200) + "...")
+          : "it appears to have no readable content.";
+        messageToUser = `The content of ${messageDesc} (ID: ...${targetMessage.id.slice(-6)}) starts with: "${contentPreview}".`;
+        break;
+
+      case 'FIND_INFO_IN_MSTEAMS_MESSAGE':
+        if (!targetMessage.content) {
+          messageToUser = `${messageDesc} (ID: ...${targetMessage.id.slice(-6)}) doesn't seem to have any content for me to analyze.`;
+          break;
+        }
+        const keywords = actionRequested.infoKeywords || [];
+        if (keywords.length === 0) {
+          messageToUser = `You asked me to find specific information in ${messageDesc}, but didn't specify what to look for.`;
+          break;
+        }
+        logger.info(`[MSTeamsCommandHandler] Extracting info for keywords [${keywords.join(', ')}] from message ID ${targetMessage.id}`);
+        const extracted = await extractInformationFromMSTeamsMessage(targetMessage.content, keywords);
+        let foundAnyInfo = false;
+        let parts: string[] = [`Regarding ${messageDesc} (ID: ...${targetMessage.id.slice(-6)}):`];
+        for (const keyword of keywords) {
+          const val = extracted[keyword];
+          if (val) {
+            parts.push(`- For "${keyword}", I found: ${val}.`);
+            foundAnyInfo = true;
+          } else {
+            parts.push(`- I couldn't find specific information about "${keyword}".`);
+          }
+        }
+        messageToUser = foundAnyInfo ? parts.join('\n') : `I scanned ${messageDesc} for "${keywords.join(', ')}", but couldn't find those details.`;
+        break;
+
+      case 'GET_MSTEAMS_MESSAGE_LINK':
+        if (targetMessage.webUrl) {
+          messageToUser = `Here's the link to ${messageDesc} (ID: ...${targetMessage.id.slice(-6)}): ${targetMessage.webUrl}`;
+        } else {
+           // Attempt to fetch it if not directly on the object (though our service populates it)
+           const identifier: GetMSTeamsMessageDetailInput = { messageId: targetMessage.id };
+           if (targetMessage.chatId) identifier.chatId = targetMessage.chatId;
+           if (targetMessage.teamId) identifier.teamId = targetMessage.teamId;
+           if (targetMessage.channelId) identifier.channelId = targetMessage.channelId;
+           const link = await getMSTeamsMessageWebUrl(userId, identifier);
+           if (link) {
+            messageToUser = `Here's the link to ${messageDesc} (ID: ...${targetMessage.id.slice(-6)}): ${link}`;
+           } else {
+            messageToUser = `I tried, but I couldn't get a direct link for ${messageDesc} (ID: ...${targetMessage.id.slice(-6)}).`;
+           }
+        }
+        break;
+
+      case 'SUMMARIZE_MSTEAMS_MESSAGE':
+        messageToUser = `I can't summarize Teams messages yet, but I found ${messageDesc} (ID: ...${targetMessage.id.slice(-6)}).`;
+        break;
+
+      default:
+        // @ts-expect-error actionType might be an unexpected value
+        messageToUser = `I found ${messageDesc} (ID: ...${targetMessage.id.slice(-6)}). I'm not sure how to handle your request: ${actionRequested.actionType}.`;
+        logger.warn(`[MSTeamsCommandHandler] Unknown actionType: ${actionRequested.actionType}`);
+    }
+
+    logger.info(`[MSTeamsCommandHandler] Final response for user ${userId}: "${messageToUser.substring(0,150)}..."`);
+    return messageToUser;
+
+  } catch (error: any) {
+    logger.error(`[MSTeamsCommandHandler] Critical error in handleMSTeamsInquiry for user ${userId}:`, error);
+    messageToUser = `I encountered an issue while processing your Microsoft Teams request: ${error.message || 'Unknown error'}. Please try again.`;
+    return messageToUser;
+  }
+}

--- a/atomic-docker/project/functions/atom-agent/skills/llm_msteams_query_understander.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/llm_msteams_query_understander.ts
@@ -1,0 +1,160 @@
+import OpenAI from 'openai';
+import { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import { ATOM_OPENAI_API_KEY, ATOM_NLU_MODEL_NAME } from '../_libs/constants';
+import { logger } from '../../_utils/logger';
+
+// Interface for structured Microsoft Teams search queries
+export interface StructuredMSTeamsQuery {
+  fromUser?: string;          // Sender's name or email (Graph search can often resolve names)
+  inChatOrChannel?: string;   // Chat ID, Channel ID, or name (e.g., "General", "Project Alpha Chat with Bob")
+  mentionsUser?: string;      // User mentioned (name or email)
+  hasFile?: boolean;          // True if files/attachments are mentioned
+  hasLink?: boolean;          // True if links are mentioned (less common as direct KQL, might be part of textKeywords)
+  onDate?: string;            // Specific date in YYYY-MM-DD format.
+  beforeDate?: string;        // Before this date (YYYY-MM-DD).
+  afterDate?: string;         // After this date (YYYY-MM-DD).
+  textKeywords?: string;      // General keywords for message content.
+  subjectContains?: string;   // For channel messages that might have a subject.
+  exactPhrase?: string;       // An exact phrase to search for.
+}
+
+let openAIClientForMSTeamsQueryUnderstanding: OpenAI | null = null;
+
+function getOpenAIClient(): OpenAI {
+  if (openAIClientForMSTeamsQueryUnderstanding) {
+    return openAIClientForMSTeamsQueryUnderstanding;
+  }
+  if (!ATOM_OPENAI_API_KEY) {
+    logger.error('[LLMMSTeamsQueryUnderstander] OpenAI API Key (ATOM_OPENAI_API_KEY) is not configured.');
+    throw new Error('OpenAI API Key not configured for LLM MS Teams Query Understander.');
+  }
+  openAIClientForMSTeamsQueryUnderstanding = new OpenAI({ apiKey: ATOM_OPENAI_API_KEY });
+  logger.info('[LLMMSTeamsQueryUnderstander] OpenAI client initialized.');
+  return openAIClientForMSTeamsQueryUnderstanding;
+}
+
+// System prompt for MS Teams query understanding. {{CURRENT_DATE}} will be replaced.
+// Microsoft Graph Search API uses Keyword Query Language (KQL) or natural language queries.
+// This prompt aims for structured output that can then be easily converted to a KQL query or parts of a search request.
+const MSTEAMS_QUERY_UNDERSTANDING_SYSTEM_PROMPT = `
+You are an expert system that converts a user's natural language request about finding Microsoft Teams messages into a structured JSON object.
+Respond ONLY with a single, valid JSON object. Do not include any explanatory text before or after the JSON.
+The JSON object should conform to the 'StructuredMSTeamsQuery' interface:
+interface StructuredMSTeamsQuery {
+  fromUser?: string;          // Sender's name or email (e.g., "John Doe", "john.doe@example.com").
+  inChatOrChannel?: string;   // Name of the chat (e.g., "Chat with Jane", "Project Discussion") or channel (e.g., "General", "Q4 Planning").
+  mentionsUser?: string;      // User mentioned in the message (name or email).
+  hasFile?: boolean;          // True if files/attachments are mentioned.
+  hasLink?: boolean;          // True if links are mentioned.
+  onDate?: string;            // Specific date in YYYY-MM-DD. Current date is {{CURRENT_DATE}}.
+  beforeDate?: string;        // Before this date (YYYY-MM-DD).
+  afterDate?: string;         // After this date (YYYY-MM-DD).
+  textKeywords?: string;      // Keywords for message content. Combine multiple concepts if appropriate.
+  subjectContains?: string;   // Keywords for the subject of a channel message.
+  exactPhrase?: string;       // An exact phrase if specified (e.g., "search for 'urgent review needed'").
+}
+
+Guidelines for date inference (Current Date: {{CURRENT_DATE}}):
+- "yesterday": 'onDate' for yesterday's date.
+- "today": 'onDate' for today's date.
+- "last week": 'afterDate' for the start of the previous calendar week (e.g., Monday) and 'beforeDate' for its end (e.g., Sunday).
+- "this week": 'afterDate' for the start of the current calendar week and 'beforeDate' for its end.
+- "on [DayOfWeek]": e.g., "on Monday". If in the past, use the most recent Monday. If a future Monday, use that. Set 'onDate'.
+- "in [MonthName]": e.g., "in July". If year not specified, assume current year. Set 'afterDate' for month start, 'beforeDate' for month end.
+- "since [Date/Event]": e.g., "since last Tuesday". Set 'afterDate'.
+- "until [Date/Event]" or "before [Date/Event]": Set 'beforeDate'.
+
+Examples:
+- "Teams messages from Bob about the budget in 'Marketing Campaign Chat' last Monday"
+  -> {"fromUser": "Bob", "textKeywords": "budget", "inChatOrChannel": "Marketing Campaign Chat", "onDate": "YYYY-MM-DD (last Monday's date)"}
+- "find messages with an Excel file shared by alice@contoso.com two weeks ago"
+  -> {"hasFile": true, "fromUser": "alice@contoso.com", "textKeywords": "Excel", "afterDate": "YYYY-MM-DD (start of 2 weeks ago)", "beforeDate": "YYYY-MM-DD (end of 2 weeks ago)"}
+- "search for 'client feedback' in the General channel of Project X team"
+  -> {"exactPhrase": "client feedback", "inChatOrChannel": "Project X General"} (Assume channel name implies team if specific enough)
+- "messages mentioning me with a link"
+  -> {"mentionsUser": "me", "hasLink": true}
+
+Only include keys in the JSON if the information is present or clearly implied.
+If the request is very vague (e.g., "find Teams messages"), return an empty JSON object {}.
+If user says "mentioning me", use "me" for mentionsUser. The system will resolve "me" to the actual user ID.
+`;
+
+/**
+ * Uses an LLM to understand a natural language MS Teams query and transform it
+ * into a StructuredMSTeamsQuery object.
+ * @param rawUserQuery The user's natural language query about finding Teams messages.
+ * @returns A Promise resolving to a Partial<StructuredMSTeamsQuery> object.
+ */
+export async function understandMSTeamsSearchQueryLLM(rawUserQuery: string): Promise<Partial<StructuredMSTeamsQuery>> {
+  const client = getOpenAIClient();
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = (now.getMonth() + 1).toString().padStart(2, '0');
+  const day = now.getDate().toString().padStart(2, '0');
+  const currentDate = `${year}-${month}-${day}`; // YYYY-MM-DD
+
+  const systemPromptWithDate = MSTEAMS_QUERY_UNDERSTANDING_SYSTEM_PROMPT.replace(/{{CURRENT_DATE}}/g, currentDate);
+
+  const messages: ChatCompletionMessageParam[] = [
+    { role: 'system', content: systemPromptWithDate },
+    { role: 'user', content: rawUserQuery },
+  ];
+
+  logger.debug(`[LLMMSTeamsQueryUnderstander] Processing query: "${rawUserQuery}" with current date ${currentDate}`);
+
+  try {
+    const completion = await client.chat.completions.create({
+      model: ATOM_NLU_MODEL_NAME,
+      messages: messages,
+      temperature: 0.1,
+      response_format: { type: 'json_object' },
+    });
+
+    const llmResponse = completion.choices[0]?.message?.content;
+    if (!llmResponse) {
+      logger.error('[LLMMSTeamsQueryUnderstander] Received an empty response from AI.');
+      throw new Error('LLM MS Teams Query Understander: Empty response from AI.');
+    }
+
+    logger.debug('[LLMMSTeamsQueryUnderstander] Raw LLM JSON response:', llmResponse);
+    let parsedResponse = JSON.parse(llmResponse);
+
+    const cleanedResponse: Partial<StructuredMSTeamsQuery> = {};
+    for (const key in parsedResponse) {
+      if (Object.prototype.hasOwnProperty.call(parsedResponse, key) &&
+          parsedResponse[key] !== null &&
+          parsedResponse[key] !== "") {
+        // @ts-ignore
+        cleanedResponse[key] = parsedResponse[key];
+      }
+    }
+
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+    if (cleanedResponse.onDate && !dateRegex.test(cleanedResponse.onDate)) {
+        logger.warn(`[LLMMSTeamsQueryUnderstander] LLM provided 'onDate' in unexpected format: ${cleanedResponse.onDate}. Discarding.`);
+        delete cleanedResponse.onDate;
+    }
+    if (cleanedResponse.beforeDate && !dateRegex.test(cleanedResponse.beforeDate)) {
+        logger.warn(`[LLMMSTeamsQueryUnderstander] LLM provided 'beforeDate' in unexpected format: ${cleanedResponse.beforeDate}. Discarding.`);
+        delete cleanedResponse.beforeDate;
+    }
+    if (cleanedResponse.afterDate && !dateRegex.test(cleanedResponse.afterDate)) {
+        logger.warn(`[LLMMSTeamsQueryUnderstander] LLM provided 'afterDate' in unexpected format: ${cleanedResponse.afterDate}. Discarding.`);
+        delete cleanedResponse.afterDate;
+    }
+
+    logger.info('[LLMMSTeamsQueryUnderstander] Cleaned structured MS Teams query:', cleanedResponse);
+    return cleanedResponse;
+
+  } catch (error: any) {
+    logger.error('[LLMMSTeamsQueryUnderstander] Error processing MS Teams search query with OpenAI:', error.message);
+    if (error instanceof SyntaxError) {
+        logger.error('[LLMMSTeamsQueryUnderstander] Failed to parse JSON response from LLM:', llmResponse);
+        throw new Error('LLM MS Teams Query Understander: Failed to parse response from AI.');
+    }
+    if (error.response?.data?.error?.message) {
+        throw new Error(`LLM MS Teams Query Understander: API Error - ${error.response.data.error.message}`);
+    }
+    throw new Error(`LLM MS Teams Query Understander: Failed to understand MS Teams search query. ${error.message}`);
+  }
+}

--- a/atomic-docker/project/functions/atom-agent/skills/msTeamsSkills.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/msTeamsSkills.ts
@@ -1,232 +1,430 @@
-import axios, { AxiosError } from 'axios';
-import {
-  ConfidentialClientApplication,
-  Configuration,
-  AuthenticationResult,
-  LogLevel,
-} from '@azure/msal-node';
-import {
-  ATOM_MSGRAPH_CLIENT_ID,
-  ATOM_MSGRAPH_CLIENT_SECRET,
-  ATOM_MSGRAPH_TENANT_ID,
-  ATOM_MSGRAPH_AUTHORITY,
-  ATOM_MSGRAPH_SCOPES,
-} from '../_libs/constants';
-import {
-  MSGraphEvent,
-  // ListMSTeamsMeetingsResponse, // Superseded by GraphSkillResponse<ListMSGraphEventsData>
-  // GetMSTeamsMeetingDetailsResponse, // Superseded by GraphSkillResponse<MSGraphEvent>
-  GraphSkillResponse, // New generic response type
-  ListMSGraphEventsData, // New data payload type for listing events
-  SkillError, // Standardized error type
-  // MSGraphTokenResponse is implicitly handled by AuthenticationResult from msal-node
-} from '../types';
+import { logger } from '../../_utils/logger';
+import { callHasuraActionGraphQL } from './utils'; // Assuming a shared Hasura call utility
+import { MSTeamsMessage, GraphSkillResponse, SkillError } from '../types'; // Import MSTeamsMessage and response types
 
-const MSGRAPH_API_BASE_URL = 'https://graph.microsoft.com/v1.0';
-
-let msalClientApp: ConfidentialClientApplication | null = null;
-let msGraphAccessToken: { token: string; expiresOnTimestamp: number } | null = null;
-
-// Export for testing token cache reset
-export const resetMSGraphTokenCache = () => {
-  msGraphAccessToken = null;
-  // msalClientApp is not reset here as its configuration is static based on constants
-};
-
-
-function getMsalClient(): ConfidentialClientApplication | null {
-  if (msalClientApp) {
-    return msalClientApp;
+// GraphQL mutation for searching MS Teams messages via Hasura action
+const GQL_SEARCH_MS_TEAMS_MESSAGES = `
+  mutation SearchUserMSTeamsMessages($input: SearchMSTeamsMessagesInput!) {
+    searchUserMSTeamsMessages(input: $input) {
+      success
+      message
+      results { # This structure should match the MSTeamsMessageObject in actions.graphql
+        id
+        chatId
+        teamId
+        channelId
+        replyToId
+        userId
+        userName
+        content
+        contentType
+        createdDateTime
+        lastModifiedDateTime
+        webUrl
+        attachments {
+          id
+          name
+          contentType
+          contentUrl
+          size
+        }
+        mentions {
+          id
+          mentionText
+          mentioned {
+            user {
+              id
+              displayName
+              userIdentityType
+            }
+          }
+        }
+        # raw # If raw is passed by Hasura action
+      }
+    }
   }
+`;
 
-  if (!ATOM_MSGRAPH_CLIENT_ID || !ATOM_MSGRAPH_AUTHORITY || !ATOM_MSGRAPH_CLIENT_SECRET) {
-    console.error('MS Graph API client credentials (Client ID, Authority, Client Secret) not configured.');
+/**
+ * Searches Microsoft Teams messages for the user via a Hasura action.
+ * @param userId The ID of the user making the request.
+ * @param searchQuery The KQL search query string.
+ * @param limit Max number of messages to return.
+ * @returns A promise resolving to an array of MSTeamsMessage objects.
+ */
+export async function searchMyMSTeamsMessages(
+  userId: string,
+  searchQuery: string,
+  limit: number = 10
+): Promise<MSTeamsMessage[]> {
+  logger.debug(`[MSTeamsSkills] searchMyMSTeamsMessages called for user ${userId}, query: "${searchQuery}", limit: ${limit}`);
+
+  try {
+    // The Hasura action 'searchUserMSTeamsMessages' will call 'searchTeamsMessages' in 'msteams-service.ts'.
+    // Input for Hasura action: { query: String!, maxResults: Int }
+    const responseData = await callHasuraActionGraphQL(userId, "SearchUserMSTeamsMessages", GQL_SEARCH_MS_TEAMS_MESSAGES, {
+      input: { query: searchQuery, maxResults: limit }
+    });
+
+    const searchResult = responseData.searchUserMSTeamsMessages;
+
+    if (!searchResult.success) {
+      logger.error(`[MSTeamsSkills] searchUserMSTeamsMessages action failed for user ${userId}: ${searchResult.message}`);
+      return []; // Or throw new Error(searchResult.message) or return a more structured error
+    }
+
+    // Transform results from Hasura (MSTeamsMessageObject) to agent's MSTeamsMessage type.
+    // This mapping assumes the GraphQL MSTeamsMessageObject closely matches MSTeamsMessage.
+    return (searchResult.results || []).map((item: any): MSTeamsMessage => ({
+      id: item.id,
+      chatId: item.chatId,
+      teamId: item.teamId,
+      channelId: item.channelId,
+      replyToId: item.replyToId,
+      userId: item.userId,
+      userName: item.userName,
+      content: item.content,
+      contentType: item.contentType as 'html' | 'text',
+      createdDateTime: item.createdDateTime,
+      lastModifiedDateTime: item.lastModifiedDateTime,
+      webUrl: item.webUrl,
+      attachments: item.attachments?.map((att: any) => ({
+        id: att.id,
+        name: att.name,
+        contentType: att.contentType,
+        contentUrl: att.contentUrl,
+        size: att.size,
+      })) || [],
+      mentions: item.mentions?.map((men: any) => ({
+        id: men.id,
+        mentionText: men.mentionText,
+        mentioned: men.mentioned ? {
+            user: men.mentioned.user ? {
+                id: men.mentioned.user.id,
+                displayName: men.mentioned.user.displayName,
+                userIdentityType: men.mentioned.user.userIdentityType,
+            } : undefined,
+            // Include other mentioned types if necessary (application, conversation, tag)
+        } : undefined,
+      })) || [],
+      raw: item.raw, // If raw is passed and desired
+    }));
+
+  } catch (error) {
+    logger.error(`[MSTeamsSkills] Error in searchMyMSTeamsMessages for user ${userId}, query "${searchQuery}":`, error);
+    return [];
+  }
+}
+
+const GQL_GET_MS_TEAMS_MESSAGE_WEB_URL = `
+  mutation GetMSTeamsMessageWebUrl($input: GetMSTeamsMessageWebUrlInput!) {
+    getMSTeamsMessageWebUrl(input: $input) {
+      success
+      message
+      webUrl
+    }
+  }
+`;
+
+// Input type for the Hasura action, mirrors GetMSTeamsMessageDetailInput for identifying the message
+export interface GetMSTeamsMessageWebUrlInput extends GetMSTeamsMessageDetailInput {}
+
+
+/**
+ * Gets a permalink (webUrl) for a specific MS Teams message.
+ * This might call a specific Hasura action that in turn calls a service function
+ * to retrieve just the webUrl, or it could potentially reuse getMSTeamsMessageDetail
+ * if the overhead is acceptable and webUrl is consistently populated.
+ * For this implementation, we'll assume a dedicated Hasura action for focused retrieval if possible,
+ * or rely on readMSTeamsMessage to have populated it.
+ * Since webUrl is part of the MSTeamsMessage, this skill could simply ensure the message is read
+ * and then return the webUrl property.
+ * However, to align with a potential direct permalink fetching in service layer (if Graph has such specific endpoint or if it's part of minimal fetch):
+ *
+ * @param userId The ID of the user.
+ * @param identifier An object to identify the message.
+ * @returns A promise resolving to the webUrl string or null.
+ */
+export async function getMSTeamsMessageWebUrl(
+  userId: string,
+  identifier: GetMSTeamsMessageWebUrlInput
+): Promise<string | null> {
+  logger.debug(`[MSTeamsSkills] getMSTeamsMessageWebUrl called for user ${userId}, identifier:`, identifier);
+
+  if (!identifier.messageId || (!identifier.chatId && (!identifier.teamId || !identifier.channelId))) {
+    logger.error('[MSTeamsSkills] Invalid identifier for getMSTeamsMessageWebUrl.');
     return null;
   }
 
-  const msalConfig: Configuration = {
-    auth: {
-      clientId: ATOM_MSGRAPH_CLIENT_ID,
-      authority: ATOM_MSGRAPH_AUTHORITY, // e.g., https://login.microsoftonline.com/YOUR_TENANT_ID
-      clientSecret: ATOM_MSGRAPH_CLIENT_SECRET,
-    },
-    system: {
-      loggerOptions: { // Optional: Configure logging for MSAL
-        loggerCallback(loglevel, message, containsPii) {
-          // console.log(`MSAL Log (Level ${loglevel}): ${message}`);
-        },
-        piiLoggingEnabled: false,
-        logLevel: LogLevel.Warning, // Adjust as needed: Error, Warning, Info, Verbose, Trace
-      },
-    },
-  };
-  msalClientApp = new ConfidentialClientApplication(msalConfig);
-  return msalClientApp;
-}
-
-async function getMSGraphToken(): Promise<GraphSkillResponse<string>> {
-  if (msGraphAccessToken && Date.now() < msGraphAccessToken.expiresOnTimestamp) {
-    console.log('Using cached MS Graph access token.');
-    return { ok: true, data: msGraphAccessToken.token };
-  }
-
-  const clientApp = getMsalClient();
-  if (!clientApp) {
-    const errorMsg = 'MSAL client application could not be initialized due to missing configuration.';
-    console.error(errorMsg);
-    return { ok: false, error: { code: 'MSGRAPH_CONFIG_ERROR', message: errorMsg } };
-  }
-
-  if (!ATOM_MSGRAPH_SCOPES || ATOM_MSGRAPH_SCOPES.length === 0) {
-      const errorMsg = 'MS Graph API scopes are not configured.';
-      console.error(errorMsg);
-      return { ok: false, error: { code: 'MSGRAPH_CONFIG_ERROR', message: errorMsg } };
-  }
-
-  const tokenRequest = {
-    scopes: ATOM_MSGRAPH_SCOPES,
-  };
-
+  // Option 1: Call a specific Hasura action for the permalink
   try {
-    console.log('Requesting new MS Graph access token...');
-    const response: AuthenticationResult | null = await clientApp.acquireTokenByClientCredential(tokenRequest);
-    if (response && response.accessToken && response.expiresOn) {
-      msGraphAccessToken = {
-        token: response.accessToken,
-        expiresOnTimestamp: response.expiresOn.getTime() - 300000, // 5 minutes buffer
-      };
-      console.log('Successfully obtained new MS Graph access token.');
-      return { ok: true, data: response.accessToken };
+    const responseData = await callHasuraActionGraphQL(userId, "GetMSTeamsMessageWebUrl", GQL_GET_MS_TEAMS_MESSAGE_WEB_URL, {
+      input: identifier
+    });
+    const getResult = responseData.getMSTeamsMessageWebUrl;
+    if (getResult.success && getResult.webUrl) {
+      return getResult.webUrl as string;
     } else {
-      console.error('Failed to acquire MS Graph token. Response was null or invalid.');
-      msGraphAccessToken = null;
-      return { ok: false, error: { code: 'MSGRAPH_AUTH_ERROR', message: 'Failed to acquire MS Graph token from MSAL.', details: response } };
+      logger.warn(`[MSTeamsSkills] getMSTeamsMessageWebUrl action failed or webUrl not found: ${getResult.message}`, identifier);
+      // Fallback: Try reading the whole message if direct permalink failed
+      // This might be redundant if the Hasura action itself already does this.
+      // const message = await readMSTeamsMessage(userId, identifier);
+      // return message?.webUrl || null;
+      return null;
     }
-  } catch (error: any) {
-    console.error('Error acquiring MS Graph token by client credential:', error);
-    msGraphAccessToken = null;
-    // Attempt to get more specific error information from MSAL error
-    const errorCode = error.errorCode || 'MSGRAPH_AUTH_REQUEST_FAILED';
-    const errorMessage = error.errorMessage || error.message || 'Error acquiring MS Graph token.';
-    return { ok: false, error: { code: errorCode, message: errorMessage, details: error } };
+  } catch (error) {
+    logger.error(`[MSTeamsSkills] Error in getMSTeamsMessageWebUrl for user ${userId}, identifier:`, identifier, error);
+    return null;
   }
 }
 
-export async function listMicrosoftTeamsMeetings(
-  userPrincipalNameOrId: string,
-  options?: {
-    limit?: number;
-    nextLink?: string;
-    filterForTeams?: boolean;
+// --- LLM Information Extraction from MS Teams Message ---
+import OpenAI from 'openai'; // Assuming OpenAI is standard for LLM tasks
+import { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import { ATOM_OPENAI_API_KEY, ATOM_NLU_MODEL_NAME } from '../_libs/constants';
+
+let openAIClientForMSTeamsExtraction: OpenAI | null = null;
+
+function getMSTeamsExtractionOpenAIClient(): OpenAI {
+  if (openAIClientForMSTeamsExtraction) {
+    return openAIClientForMSTeamsExtraction;
   }
-): Promise<GraphSkillResponse<ListMSGraphEventsData>> {
-  console.log(`listMicrosoftTeamsMeetings called for user: ${userPrincipalNameOrId}, options:`, options);
+  if (!ATOM_OPENAI_API_KEY) {
+    logger.error('[MSTeamsSkills] OpenAI API Key not configured for LLM MS Teams Extractor.');
+    throw new Error('OpenAI API Key not configured for LLM MS Teams Extractor.');
+  }
+  openAIClientForMSTeamsExtraction = new OpenAI({ apiKey: ATOM_OPENAI_API_KEY });
+  logger.info('[MSTeamsSkills] OpenAI client for MS Teams extraction initialized.');
+  return openAIClientForMSTeamsExtraction;
+}
 
-  if (!userPrincipalNameOrId) {
-    return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'userPrincipalNameOrId is required.' }};
+// System prompt for extracting info from MS Teams messages.
+// Similar to Slack/Email, but can be tailored for Teams message nuances.
+const MSTEAMS_EXTRACTION_SYSTEM_PROMPT_TEMPLATE = `
+You are an expert system designed to extract specific pieces of information from a Microsoft Teams message.
+The user will provide the message content (which might be HTML or plain text) and a list of information points (keywords).
+For each keyword, find the corresponding information in the message.
+Respond ONLY with a single, valid JSON object. Do not include any explanatory text before or after the JSON.
+The JSON object should have keys corresponding to the user's original keywords.
+The value for each key should be the extracted information as a string.
+If information for a keyword is not found, the value for that key should be null.
+
+Example:
+User provides keywords: ["task details", "assigned to", "deadline"]
+Message content: "<div><p>Hey @Alex, please look into the <b>spec review for feature X</b>. It needs to be completed by エンドオブデー Friday.</p></div>"
+Your JSON response (assuming EOD Friday is understood as a deadline):
+{
+  "task details": "spec review for feature X",
+  "assigned to": "@Alex",
+  "deadline": "EOD Friday"
+}
+
+The keywords you need to extract information for are: {{KEYWORDS_JSON_ARRAY_STRING}}
+Extract the information from the Teams message content provided by the user. If the content is HTML, focus on the textual information.
+`;
+
+/**
+ * Uses an LLM to extract specific pieces of information from an MS Teams message body.
+ * @param messageContent The content of the MS Teams message (can be HTML or plain text).
+ * @param infoKeywords An array of strings representing the concepts/keywords to search for.
+ * @returns A Promise resolving to a record where keys are infoKeywords and values are the extracted strings (or null).
+ */
+export async function extractInformationFromMSTeamsMessage(
+  messageContent: string,
+  infoKeywords: string[]
+): Promise<Record<string, string | null>> {
+  if (!infoKeywords || infoKeywords.length === 0) {
+    logger.debug('[MSTeamsSkills] extractInformationFromMSTeamsMessage: No infoKeywords provided.');
+    return {};
+  }
+  if (!messageContent || messageContent.trim() === '') {
+    logger.debug('[MSTeamsSkills] extractInformationFromMSTeamsMessage: Empty messageContent provided.');
+    const emptyResult: Record<string, string | null> = {};
+    infoKeywords.forEach(kw => emptyResult[kw] = null);
+    return emptyResult;
   }
 
-  const tokenResponse = await getMSGraphToken();
-  if (!tokenResponse.ok || !tokenResponse.data) {
-    return { ok: false, error: tokenResponse.error || { code: 'MSGRAPH_AUTH_ERROR', message: 'Failed to obtain MS Graph access token for listing meetings.'} };
+  logger.debug(`[MSTeamsSkills] LLM Extractor: Attempting to extract from MS Teams message for keywords: [${infoKeywords.join(', ')}]`);
+  const client = getMSTeamsExtractionOpenAIClient();
+
+  const keywordsJsonArrayString = JSON.stringify(infoKeywords);
+  const systemPrompt = MSTEAMS_EXTRACTION_SYSTEM_PROMPT_TEMPLATE.replace("{{KEYWORDS_JSON_ARRAY_STRING}}", keywordsJsonArrayString);
+
+  // Simple HTML to text conversion if content type is HTML, for cleaner input to LLM
+  // More sophisticated stripping might be needed for complex HTML.
+  let processedContent = messageContent;
+  // Basic stripping of HTML tags for LLM processing if it's likely HTML
+  if (messageContent.includes("<") && messageContent.includes(">")) {
+      processedContent = messageContent.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+      logger.debug('[MSTeamsSkills] LLM Extractor: Stripped HTML from message content.');
   }
-  const token = tokenResponse.data;
 
-  let requestUrl = options?.nextLink;
 
-  if (!requestUrl) {
-    const selectParams = 'id,subject,start,end,isOnlineMeeting,onlineMeeting,webLink,bodyPreview';
-    const orderByParams = 'start/dateTime ASC';
-    const topParams = options?.limit || 10;
-    let filterParamsValue = '';
-
-    if (options?.filterForTeams !== false) {
-        filterParamsValue = `isOnlineMeeting eq true and onlineMeeting/onlineMeetingProvider eq 'teamsForBusiness'`;
-    }
-
-    const queryParams = new URLSearchParams();
-    queryParams.append('$select', selectParams);
-    queryParams.append('$orderby', orderByParams);
-    queryParams.append('$top', topParams.toString());
-    if (filterParamsValue) {
-        queryParams.append('$filter', filterParamsValue);
-    }
-    requestUrl = `${MSGRAPH_API_BASE_URL}/users/${userPrincipalNameOrId}/calendar/events?${queryParams.toString()}`;
-  }
+  const messages: ChatCompletionMessageParam[] = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: `MS Teams Message Content:\n---\n${processedContent}\n---` },
+  ];
 
   try {
-    const response = await axios.get(requestUrl, { // MS Graph returns 'value' for items and '@odata.nextLink'
-      headers: { 'Authorization': `Bearer ${token}` },
+    const completion = await client.chat.completions.create({
+      model: ATOM_NLU_MODEL_NAME,
+      messages: messages,
+      temperature: 0.1,
+      response_format: { type: 'json_object' },
     });
 
-    return {
-      ok: true,
-      data: {
-        events: response.data.value as MSGraphEvent[],
-        nextLink: response.data['@odata.nextLink'] || undefined,
-      }
-    };
+    const llmResponse = completion.choices[0]?.message?.content;
+    if (!llmResponse) {
+      logger.error('[MSTeamsSkills] LLM Extractor: Received an empty response from AI for MS Teams message.');
+      throw new Error('LLM Extractor (MS Teams): Empty response from AI.');
+    }
+
+    logger.debug('[MSTeamsSkills] LLM Extractor: Raw LLM JSON response for MS Teams:', llmResponse);
+    const parsedResponse = JSON.parse(llmResponse);
+
+    const result: Record<string, string | null> = {};
+    for (const keyword of infoKeywords) {
+      result[keyword] = parsedResponse.hasOwnProperty(keyword) ? parsedResponse[keyword] : null;
+    }
+
+    logger.debug('[MSTeamsSkills] LLM Extractor: Parsed and reconciled extraction from MS Teams:', result);
+    return result;
+
   } catch (error: any) {
-    const axiosError = error as AxiosError;
-    console.error(`Error listing MS Teams meetings for user ${userPrincipalNameOrId}:`, axiosError.message);
-    const errorData = axiosError.response?.data as any; // MS Graph errors are often in errorData.error
-    return {
-      ok: false,
-      error: {
-        code: errorData?.error?.code || 'MSGRAPH_API_ERROR',
-        message: errorData?.error?.message || axiosError.message || 'Failed to list MS Teams meetings',
-        details: errorData?.error || errorData
-      }
-    };
+    logger.error('[MSTeamsSkills] LLM Extractor: Error processing information extraction from MS Teams message with OpenAI:', error.message);
+    if (error instanceof SyntaxError) {
+        logger.error('[MSTeamsSkills] LLM Extractor: Failed to parse JSON response from LLM for MS Teams message.');
+        throw new Error('LLM Extractor (MS Teams): Failed to parse response from AI.');
+    }
+    const fallbackResult: Record<string, string | null> = {};
+    infoKeywords.forEach(kw => fallbackResult[kw] = null);
+    return fallbackResult;
   }
 }
 
-export async function getMicrosoftTeamsMeetingDetails(
-  userPrincipalNameOrId: string,
-  eventId: string
-): Promise<GraphSkillResponse<MSGraphEvent>> {
-  console.log(`getMicrosoftTeamsMeetingDetails called for user: ${userPrincipalNameOrId}, eventId: ${eventId}`);
+// Placeholder for callHasuraActionGraphQL utility if it's not in a shared location yet.
+// Ensure this is implemented or imported correctly. For now, using a simplified version.
+// import fetch from 'node-fetch';
+// const HASURA_GRAPHQL_ENDPOINT = process.env.HASURA_GRAPHQL_ENDPOINT || 'http://hasura:8080/v1/graphql';
 
-  if (!userPrincipalNameOrId || !eventId) {
-    return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'userPrincipalNameOrId and eventId are required.' }};
-  }
+// async function callHasuraActionGraphQL(userId: string, operationName: string, query: string, variables: Record<string, any>): Promise<any> {
+//   logger.debug(`[MSTeamsSkills] Calling Hasura Action GQL: ${operationName} for user ${userId}`);
+//   try {
+//       const response = await fetch(HASURA_GRAPHQL_ENDPOINT, {
+//           method: 'POST',
+//           headers: {
+//               'Content-Type': 'application/json',
+//               'X-Hasura-Role': 'user',
+//               'X-Hasura-User-Id': userId,
+//               ...(process.env.HASURA_ADMIN_SECRET && !userId ? { 'x-hasura-admin-secret': process.env.HASURA_ADMIN_SECRET } : {})
+//           },
+//           body: JSON.stringify({ query, variables }),
+//       });
+//       if (!response.ok) { /* ... error handling ... */ throw new Error(`Hasura GQL call to ${operationName} failed: ${response.statusText}`); }
+//       const jsonResponse = await response.json();
+//       if (jsonResponse.errors) { /* ... error handling ... */ throw new Error(`Hasura GQL call to ${operationName} returned errors: ${jsonResponse.errors.map((e: any) => e.message).join(', ')}`);}
+//       return jsonResponse.data;
+//   } catch (error) { /* ... error handling ... */ throw error; }
+// }
 
-  const tokenResponse = await getMSGraphToken();
-  if (!tokenResponse.ok || !tokenResponse.data) {
-    return { ok: false, error: tokenResponse.error || { code: 'MSGRAPH_AUTH_ERROR', message: 'Failed to obtain MS Graph access token for getting meeting details.'} };
-  }
-  const token = tokenResponse.data;
 
-  const selectParams = 'id,subject,start,end,isOnlineMeeting,onlineMeeting,webLink,bodyPreview,body,attendees,location,locations,organizer';
-  const requestUrl = `${MSGRAPH_API_BASE_URL}/users/${userPrincipalNameOrId}/events/${eventId}?$select=${selectParams}`;
-
-  try {
-    const response = await axios.get<MSGraphEvent>(requestUrl, { // Expecting a single MSGraphEvent
-      headers: { 'Authorization': `Bearer ${token}` },
-    });
-    return { ok: true, data: response.data };
-  } catch (error: any) {
-    const axiosError = error as AxiosError;
-    console.error(`Error getting MS Teams meeting details for event ${eventId}, user ${userPrincipalNameOrId}:`, axiosError.message);
-    const errorData = axiosError.response?.data as any; // MS Graph errors are often in errorData.error
-
-    if (axiosError.response?.status === 404) {
-      return {
-          ok: false,
-          error: {
-              code: 'EVENT_NOT_FOUND',
-              message: `Meeting event not found (ID: ${eventId}). ${errorData?.error?.message || ''}`.trim(),
-              details: errorData?.error || errorData
+const GQL_GET_MS_TEAMS_MESSAGE_DETAIL = `
+  mutation GetMSTeamsMessageDetail($input: GetMSTeamsMessageDetailInput!) {
+    getMSTeamsMessageDetail(input: $input) {
+      success
+      message
+      msTeamsMessage { # This structure should match MSTeamsMessageObject
+        id
+        chatId
+        teamId
+        channelId
+        replyToId
+        userId
+        userName
+        content
+        contentType
+        createdDateTime
+        lastModifiedDateTime
+        webUrl
+        attachments { id name contentType contentUrl size }
+        mentions {
+          id
+          mentionText
+          mentioned {
+            user { id displayName userIdentityType }
           }
-      };
-    }
-    return {
-      ok: false,
-      error: {
-        code: errorData?.error?.code || 'MSGRAPH_API_ERROR',
-        message: errorData?.error?.message || axiosError.message || 'Failed to get MS Teams meeting details',
-        details: errorData?.error || errorData
+        }
+        # raw
       }
+    }
+  }
+`;
+
+export interface GetMSTeamsMessageDetailInput {
+  messageId: string;
+  chatId?: string; // Provide if it's a chat message
+  teamId?: string; // Provide with channelId if it's a channel message
+  channelId?: string; // Provide with teamId if it's a channel message
+}
+
+
+/**
+ * Reads the detailed content of a specific MS Teams message.
+ * @param userId The ID of the user.
+ * @param identifier An object to identify the message, containing messageId and context (chatId or teamId/channelId).
+ * @returns A promise resolving to an MSTeamsMessage object or null if not found/error.
+ */
+export async function readMSTeamsMessage(
+  userId: string,
+  identifier: GetMSTeamsMessageDetailInput
+): Promise<MSTeamsMessage | null> {
+  logger.debug(`[MSTeamsSkills] readMSTeamsMessage called for user ${userId}, identifier:`, identifier);
+
+  if (!identifier.messageId || (!identifier.chatId && (!identifier.teamId || !identifier.channelId))) {
+    logger.error('[MSTeamsSkills] Invalid identifier for readMSTeamsMessage. Need messageId and (chatId or teamId+channelId).');
+    return null;
+  }
+
+  try {
+    const responseData = await callHasuraActionGraphQL(userId, "GetMSTeamsMessageDetail", GQL_GET_MS_TEAMS_MESSAGE_DETAIL, {
+      input: identifier
+    });
+
+    const getResult = responseData.getMSTeamsMessageDetail;
+
+    if (!getResult.success || !getResult.msTeamsMessage) {
+      logger.warn(`[MSTeamsSkills] getMSTeamsMessageDetail action failed or message not found for user ${userId}: ${getResult.message}`, identifier);
+      return null;
+    }
+
+    // Direct cast if GraphQL output matches agent's MSTeamsMessage type.
+    // Ensure nested structures like attachments and mentions are also correctly typed/mapped if needed.
+    const message: MSTeamsMessage = {
+        ...getResult.msTeamsMessage,
+        contentType: getResult.msTeamsMessage.contentType as 'html' | 'text', // Ensure enum type if not guaranteed by GQL
+         attachments: getResult.msTeamsMessage.attachments?.map((att: any) => ({
+            id: att.id,
+            name: att.name,
+            contentType: att.contentType,
+            contentUrl: att.contentUrl,
+            size: att.size,
+        })) || [],
+        mentions: getResult.msTeamsMessage.mentions?.map((men: any) => ({
+            id: men.id,
+            mentionText: men.mentionText,
+            mentioned: men.mentioned ? {
+                user: men.mentioned.user ? {
+                    id: men.mentioned.user.id,
+                    displayName: men.mentioned.user.displayName,
+                    userIdentityType: men.mentioned.user.userIdentityType,
+                } : undefined,
+            } : undefined,
+        })) || [],
     };
+    return message;
+
+  } catch (error) {
+    logger.error(`[MSTeamsSkills] Error in readMSTeamsMessage for user ${userId}, identifier:`, identifier, error);
+    return null;
   }
 }

--- a/atomic-docker/project/functions/atom-agent/skills/nlu_msteams_helper.test.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/nlu_msteams_helper.test.ts
@@ -1,0 +1,110 @@
+import { buildMSTeamsSearchQuery } from './nlu_msteams_helper';
+import { StructuredMSTeamsQuery } from './llm_msteams_query_understander';
+
+describe('buildMSTeamsSearchQuery', () => {
+  it('should build a KQL query with textKeywords and fromUser', () => {
+    const params: StructuredMSTeamsQuery = {
+      textKeywords: 'project update',
+      fromUser: 'john.doe@example.com',
+    };
+    // Order of terms joined by AND might vary, so check for components.
+    const result = buildMSTeamsSearchQuery(params);
+    expect(result).toContain('project update');
+    expect(result).toContain('from:john.doe@example.com');
+    expect(result.split(' AND ').length).toBe(2);
+  });
+
+  it('should build a KQL query with subjectContains and onDate', () => {
+    const params: StructuredMSTeamsQuery = {
+      subjectContains: 'Weekly Sync',
+      onDate: '2024-03-10',
+    };
+    const result = buildMSTeamsSearchQuery(params);
+    expect(result).toContain('subject:Weekly Sync');
+    expect(result).toContain('created:2024-03-10');
+    expect(result.split(' AND ').length).toBe(2);
+  });
+
+  it('should build a KQL query with exactPhrase and hasFile', () => {
+    const params: StructuredMSTeamsQuery = {
+      exactPhrase: 'must review this document',
+      hasFile: true,
+    };
+    const result = buildMSTeamsSearchQuery(params);
+    expect(result).toContain('"must review this document"');
+    expect(result).toContain('hasattachment:true');
+    expect(result.split(' AND ').length).toBe(2);
+  });
+
+  it('should build a KQL query with date range (afterDate and beforeDate)', () => {
+    const params: StructuredMSTeamsQuery = {
+      afterDate: '2024-01-01',
+      beforeDate: '2024-01-31',
+      textKeywords: 'planning session',
+    };
+    const result = buildMSTeamsSearchQuery(params);
+    expect(result).toContain('created:2024-01-01..2024-01-31');
+    expect(result).toContain('planning session');
+  });
+
+  it('should handle only afterDate', () => {
+    const params: StructuredMSTeamsQuery = { afterDate: '2024-02-15' };
+    expect(buildMSTeamsSearchQuery(params)).toBe('created>=2024-02-15');
+  });
+
+  it('should handle only beforeDate', () => {
+    const params: StructuredMSTeamsQuery = { beforeDate: '2024-02-20' };
+    expect(buildMSTeamsSearchQuery(params)).toBe('created<=2024-02-20');
+  });
+
+  it('should include mentionsUser and inChatOrChannel as text keywords', () => {
+    const params: StructuredMSTeamsQuery = {
+      mentionsUser: 'Sarah Connor',
+      inChatOrChannel: 'Project Terminator Chat',
+    };
+    const result = buildMSTeamsSearchQuery(params);
+    expect(result).toContain('"Sarah Connor"');
+    expect(result).toContain('"Project Terminator Chat"');
+  });
+
+  it('should handle hasLink by adding (http OR https)', () => {
+    const params: StructuredMSTeamsQuery = {
+      hasLink: true,
+    };
+    expect(buildMSTeamsSearchQuery(params)).toBe('(http OR https)');
+  });
+
+  it('should combine multiple parameters with AND', () => {
+    const params: StructuredMSTeamsQuery = {
+      fromUser: 'test@example.com',
+      textKeywords: 'urgent task',
+      subjectContains: 'Action Required',
+      onDate: '2023-01-15',
+      hasFile: true,
+    };
+    const result = buildMSTeamsSearchQuery(params);
+    expect(result).toContain('urgent task');
+    expect(result).toContain('from:test@example.com');
+    expect(result).toContain('subject:Action Required');
+    expect(result).toContain('created:2023-01-15');
+    expect(result).toContain('hasattachment:true');
+    // Check that terms are ANDed together
+    const parts = result.split(' AND ');
+    expect(parts.length).toBe(5); // 5 terms should be ANDed
+  });
+
+  it('should return an empty string for an empty params object', () => {
+    const params: StructuredMSTeamsQuery = {};
+    expect(buildMSTeamsSearchQuery(params)).toBe('');
+  });
+
+  it('should trim whitespace from parameters', () => {
+    const params: StructuredMSTeamsQuery = {
+      textKeywords: '  leading and trailing spaces  ',
+      fromUser: '  user@example.com  ',
+    };
+    const result = buildMSTeamsSearchQuery(params);
+    expect(result).toContain('leading and trailing spaces');
+    expect(result).toContain('from:user@example.com');
+  });
+});

--- a/atomic-docker/project/functions/atom-agent/skills/nlu_msteams_helper.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/nlu_msteams_helper.ts
@@ -1,0 +1,116 @@
+import { StructuredMSTeamsQuery } from './llm_msteams_query_understander';
+import { logger } from '../../_utils/logger';
+
+/**
+ * Constructs a Keyword Query Language (KQL) string for Microsoft Graph Search API
+ * from structured parameters.
+ * Ref for KQL: https://learn.microsoft.com/en-us/sharepoint/dev/general-development/keyword-query-language-kql-syntax-reference
+ * Ref for Graph Search on messages: https://learn.microsoft.com/en-us/graph/search-concept-chatmessage
+ *
+ * @param params StructuredMSTeamsQuery object containing various search criteria.
+ * @returns A KQL string formatted for Microsoft Graph API's search query.
+ */
+export function buildMSTeamsSearchQuery(params: StructuredMSTeamsQuery): string {
+  const kqlParts: string[] = [];
+
+  // Free-text keywords (these usually come first or without a specific property)
+  if (params.textKeywords) {
+    kqlParts.push(params.textKeywords.trim());
+  }
+  if (params.exactPhrase) {
+    kqlParts.push(`"${params.exactPhrase.trim()}"`);
+  }
+
+  // Property-restricted queries
+  if (params.fromUser) {
+    // Graph search can often resolve names/emails for 'from'
+    kqlParts.push(`from:${params.fromUser.trim()}`);
+  }
+  if (params.mentionsUser) {
+    // KQL for mentions might be `participants:"John Doe"` or checking body/content.
+    // For simplicity, we can add it as a keyword or assume Graph Search handles "mentions:User Name".
+    // A more specific KQL might be `mentions:${params.mentionsUser.trim()}` if supported or by adding to text.
+    // Let's assume for now that adding it as a keyword is a starting point,
+    // or specific Graph properties like `summary` might include mentions.
+    // For direct KQL, `participants` is more about who is in the chat.
+    // `mentions` isn't a standard KQL property for messages in the same way as `from`.
+    // So, we might add it to the general text search or expect the LLM to have incorporated it.
+    // Adding as a keyword for now:
+     kqlParts.push(`"${params.mentionsUser.trim()}"`); // Treat as part of text search
+  }
+
+  if (params.inChatOrChannel) {
+    // This is complex. KQL doesn't have a direct "inChatOrChannel" property.
+    // This usually needs to be handled by targeting the search scope (e.g. a specific chat ID or channel ID in the API call)
+    // or by using properties like `parentfolderid` or `siteid` if searching within SharePoint context of Teams files.
+    // For messages, the search endpoint itself might be scoped, or `chatId` / `channelId` used in a different way.
+    // For a general search query, we might include it as text:
+    kqlParts.push(`"${params.inChatOrChannel.trim()}"`);
+  }
+
+  if (params.subjectContains) {
+    // `subject` is a common KQL property
+    kqlParts.push(`subject:${params.subjectContains.trim()}`);
+  }
+
+  if (params.hasFile) {
+    // KQL for attachments: `hasattachment:true`
+    kqlParts.push('hasattachment:true');
+  }
+  if (params.hasLink) {
+    // KQL for links: `containslink:true` (this is more SharePoint specific)
+    // For messages, might need to search for "http" or "https" as keywords.
+    kqlParts.push('(http OR https)');
+  }
+
+  // Date filters
+  // KQL date format is YYYY-MM-DD. Can also use relative terms like 'today', 'yesterday'.
+  // Or ranges: created:YYYY-MM-DD..YYYY-MM-DD
+  if (params.onDate) {
+    kqlParts.push(`created:${params.onDate}`);
+  } else if (params.afterDate && params.beforeDate) {
+    kqlParts.push(`created:${params.afterDate}..${params.beforeDate}`);
+  } else if (params.afterDate) {
+    kqlParts.push(`created>=${params.afterDate}`);
+  } else if (params.beforeDate) {
+    kqlParts.push(`created<=${params.beforeDate}`);
+  }
+
+  // EntityType filter is applied in the search request body, not typically in KQL string for messages directly.
+  // e.g. entityTypes: ['chatMessage']
+
+  const finalKqlQuery = kqlParts.filter(part => part.length > 0).join(' AND ').trim();
+  // Note: KQL often uses implicit AND, but explicitly adding it can be clearer.
+  // Depending on Graph Search behavior, just joining by space might also work for some terms.
+  // Using 'AND' for more precise conjunction.
+
+  logger.debug(`[NluMSTeamsHelper] Built MS Teams KQL query: "${finalKqlQuery}" from params:`, params);
+  return finalKqlQuery;
+}
+
+/*
+// Example Usage:
+const exampleParams1: StructuredMSTeamsQuery = {
+  fromUser: 'bob@example.com',
+  textKeywords: 'Q1 budget report',
+  onDate: '2023-10-26',
+};
+console.log(`Example 1 KQL: ${buildMSTeamsSearchQuery(exampleParams1)}`);
+// Expected: Q1 budget report AND from:bob@example.com AND created:2023-10-26 (order may vary)
+
+const exampleParams2: StructuredMSTeamsQuery = {
+  hasFile: true,
+  afterDate: '2023-09-01',
+  beforeDate: '2023-09-30',
+  subjectContains: 'Project Phoenix Update'
+};
+console.log(`Example 2 KQL: ${buildMSTeamsSearchQuery(exampleParams2)}`);
+// Expected: subject:Project Phoenix Update AND hasattachment:true AND created:2023-09-01..2023-09-30
+
+const exampleParams3: StructuredMSTeamsQuery = {
+  exactPhrase: 'final sign-off needed',
+  mentionsUser: 'Sarah Day',
+};
+console.log(`Example 3 KQL: ${buildMSTeamsSearchQuery(exampleParams3)}`);
+// Expected: "final sign-off needed" AND "Sarah Day"
+*/

--- a/atomic-docker/project/functions/atom-agent/types.ts
+++ b/atomic-docker/project/functions/atom-agent/types.ts
@@ -616,6 +616,51 @@ export interface MSGraphTokenResponse {
   access_token: string;
 }
 
+// --- Microsoft Teams Message Types for Agent ---
+export interface MSTeamsMessageAttachment {
+  id: string;
+  name?: string | null;
+  contentType?: string | null;
+  contentUrl?: string | null; // Direct link to the content if available
+  size?: number | null;
+  // Add other relevant fields from Graph API's attachment resource type if needed
+}
+
+export interface MSTeamsMessageMentionedUser {
+  id?: string | null; // User's AAD ID if available from mention object
+  displayName?: string | null;
+  userIdentityType?: string | null; // e.g., "aadUser"
+}
+export interface MSTeamsMessageMention {
+  id: number; // The ID of the mention in the message.
+  mentionText?: string | null; // The display text of the mention.
+  mentioned?: { // Details of the entity mentioned.
+    user?: MSTeamsMessageMentionedUser | null;
+    application?: any | null; // if an app is mentioned
+    conversation?: any | null; // if a channel/chat is mentioned
+    tag?: any | null; // if a tag is mentioned
+  } | null;
+}
+
+export interface MSTeamsMessage {
+  id: string; // Message ID from Graph API
+  chatId?: string | null; // ID of the 1:1 or group chat (if applicable)
+  teamId?: string | null; // ID of the Team (if a channel message)
+  channelId?: string | null; // ID of the Channel (if a channel message)
+  replyToId?: string | null; // ID of the parent message if this is a reply
+  userId?: string | null; // Sender's AAD User ID
+  userName?: string | null; // Sender's display name
+  content: string; // Message body content (HTML or text)
+  contentType: 'html' | 'text';
+  createdDateTime: string; // ISO 8601 timestamp
+  lastModifiedDateTime?: string | null; // ISO 8601 timestamp
+  webUrl?: string | null; // Permalink to the message
+  attachments?: MSTeamsMessageAttachment[] | null;
+  mentions?: MSTeamsMessageMention[] | null;
+  raw?: any; // Store the original raw Graph API message object for extensibility
+}
+
+
 // --- Zoom Types ---
 export interface ZoomTokenResponse {
   access_token: string;

--- a/atomic-docker/project/functions/msteams-service/service.ts
+++ b/atomic-docker/project/functions/msteams-service/service.ts
@@ -1,0 +1,633 @@
+import axios, { AxiosError } from 'axios';
+import {
+  ConfidentialClientApplication,
+  Configuration,
+  AuthenticationResult,
+  LogLevel,
+  PublicClientApplication,
+  AuthorizationCodeRequest,
+  AccountInfo,
+  SilentFlowRequest,
+} from '@azure/msal-node'; // Added PublicClientApplication and related types
+import {
+} from '@azure/msal-node';
+import {
+  // ATOM_MSGRAPH_CLIENT_ID, // Replaced by MSGRAPH_DELEGATED_CLIENT_ID
+  // ATOM_MSGRAPH_CLIENT_SECRET, // Replaced by MSGRAPH_DELEGATED_CLIENT_SECRET
+  // ATOM_MSGRAPH_TENANT_ID, // Replaced by MSGRAPH_DELEGATED_TENANT_ID
+  // ATOM_MSGRAPH_AUTHORITY, // Replaced by MSGRAPH_DELEGATED_AUTHORITY
+  // ATOM_MSGRAPH_SCOPES, // Replaced by MSGRAPH_DELEGATED_SCOPES
+  // Import new Delegated Auth Constants from a central place if available, otherwise use process.env
+  MSGRAPH_DELEGATED_CLIENT_ID,
+  MSGRAPH_DELEGATED_CLIENT_SECRET,
+  MSGRAPH_DELEGATED_AUTHORITY,
+  MSGRAPH_DELEGATED_REDIRECT_URL,
+  MSGRAPH_DELEGATED_SCOPES,
+  MSTEAMS_TOKEN_ENCRYPTION_KEY,
+} from '../atom-agent/_libs/constants'; // Adjusted path assuming constants are well-defined
+import {
+  MSGraphEvent,
+  GraphSkillResponse,
+  ListMSGraphEventsData,
+  SkillError,
+} from '../atom-agent/types'; // Adjusted path
+import { logger } from '../_utils/logger';
+import { createAdminGraphQLClient } from '../_utils/dbService';
+// import { encrypt, decrypt } from '../_utils/encryption'; // TODO: Create and use a shared encryption utility
+
+const MSGRAPH_API_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+// MSAL ConfidentialClientApplication instance for the backend
+let msalConfidentialClientApp: ConfidentialClientApplication | null = null;
+
+// Database interaction functions (placeholders - to be implemented with actual DB calls)
+// These would typically interact with a table like 'user_msteams_tokens'
+// interface StoredTokenData {
+//   encryptedAccessToken: string;
+//   encryptedRefreshToken?: string | null;
+//   accountJson: string; // Store MSAL AccountInfo as JSON
+//   tokenExpiryTimestamp: Date;
+// }
+
+// TODO: Implement these functions properly
+// These are conceptual and need to be implemented based on your DB schema and encryption utility
+const getStoredUserMSTeamsTokens = async (userId: string): Promise<{ refreshToken: string; account: AccountInfo } | null> => {
+  logger.debug(`[MSTeamsService] Attempting to fetch stored MS Teams tokens for user ${userId}. (DB Call - Placeholder)`);
+  // Example:
+  // const adminClient = createAdminGraphQLClient();
+  // const query = `QUERY_GET_MSTEAMS_TOKEN_BY_USER_ID($userId: uuid!) { user_msteams_tokens(where: {user_id: {_eq: $userId}}) { encrypted_refresh_token account_json } }`;
+  // const data = await adminClient.request(query, { userId });
+  // if (data.user_msteams_tokens && data.user_msteams_tokens.length > 0) {
+  //   const tokenRecord = data.user_msteams_tokens[0];
+  //   if (!tokenRecord.encrypted_refresh_token || !tokenRecord.account_json) return null;
+  //   const refreshToken = decrypt(tokenRecord.encrypted_refresh_token, MSTEAMS_TOKEN_ENCRYPTION_KEY!);
+  //   const account = JSON.parse(tokenRecord.account_json) as AccountInfo;
+  //   return { refreshToken, account };
+  // }
+  return null; // Placeholder
+};
+
+const storeUserMSTeamsTokens = async (userId: string, authResult: AuthenticationResult): Promise<void> => {
+  logger.debug(`[MSTeamsService] Storing MS Teams tokens for user ${userId}. (DB Call - Placeholder)`);
+  if (!authResult.account) {
+    logger.error('[MSTeamsService] Account info missing in AuthenticationResult. Cannot store tokens.');
+    throw new Error('Account info missing, cannot store tokens.');
+  }
+  // const accessToken = encrypt(authResult.accessToken, MSTEAMS_TOKEN_ENCRYPTION_KEY!);
+  // const refreshToken = authResult.refreshToken ? encrypt(authResult.refreshToken, MSTEAMS_TOKEN_ENCRYPTION_KEY!) : null;
+  // const accountJson = JSON.stringify(authResult.account); // Store the MSAL AccountInfo object
+  // const expiry = authResult.expiresOn;
+
+  // Example:
+  // const adminClient = createAdminGraphQLClient();
+  // const mutation = `MUTATION_UPSERT_MSTEAMS_TOKEN($userId:uuid!, $accessToken:String!, $refreshToken:String, $accountJson:jsonb!, $expiry:timestamptz!) { ... }`;
+  // await adminClient.request(mutation, { userId, accessToken, refreshToken, accountJson, expiry });
+  logger.info(`[MSTeamsService] Tokens for user ${userId} would be stored/updated here.`);
+};
+
+
+function initializeConfidentialClientApp(): ConfidentialClientApplication | null {
+  if (msalConfidentialClientApp) {
+    return msalConfidentialClientApp;
+  }
+
+  if (!MSGRAPH_DELEGATED_CLIENT_ID || !MSGRAPH_DELEGATED_AUTHORITY || !MSGRAPH_DELEGATED_CLIENT_SECRET) {
+    logger.error('[MSTeamsService] MS Graph API delegated client credentials not fully configured.');
+    return null;
+  }
+  if (!MSTEAMS_TOKEN_ENCRYPTION_KEY) {
+    // This check is crucial because if the key is missing, we can't decrypt/encrypt tokens for storage.
+    logger.error('[MSTeamsService] MSTEAMS_TOKEN_ENCRYPTION_KEY is not configured. Cannot proceed with token operations.');
+    // Depending on desired behavior, you might throw an error or return null.
+    // For service initialization, returning null is safer.
+    return null;
+  }
+
+
+  const msalConfig: Configuration = {
+    auth: {
+      clientId: MSGRAPH_DELEGATED_CLIENT_ID,
+      authority: MSGRAPH_DELEGATED_AUTHORITY,
+      clientSecret: MSGRAPH_DELEGATED_CLIENT_SECRET,
+    },
+    system: {
+      loggerOptions: {
+        loggerCallback(loglevel, message, containsPii) {
+          // Avoid logging tokens or PII in production
+          if (!containsPii) logger.debug(`[MSAL-${LogLevel[loglevel]}] ${message}`);
+        },
+        piiLoggingEnabled: false, // Set to true ONLY for local debugging of auth flows
+        logLevel: LogLevel.Warning, // Adjust as needed: Error, Warning, Info, Verbose
+      },
+    },
+  };
+  msalConfidentialClientApp = new ConfidentialClientApplication(msalConfig);
+  logger.info('[MSTeamsService] MSAL ConfidentialClientApplication initialized for delegated flow.');
+  return msalConfidentialClientApp;
+}
+
+
+export async function getDelegatedMSGraphTokenForUser(userId: string): Promise<GraphSkillResponse<string>> {
+  const clientApp = initializeConfidentialClientApp();
+  if (!clientApp) {
+    const errorMsg = 'MSAL client application could not be initialized.';
+    logger.error(`[MSTeamsService] ${errorMsg}`);
+    return { ok: false, error: { code: 'MSGRAPH_CONFIG_ERROR', message: errorMsg } };
+  }
+
+  // Check for encryption key before attempting token operations
+  if (!MSTEAMS_TOKEN_ENCRYPTION_KEY) {
+    logger.error('[MSTeamsService] MSTEAMS_TOKEN_ENCRYPTION_KEY is not configured. Cannot get/refresh tokens.');
+    return { ok: false, error: { code: 'MSGRAPH_CONFIG_ERROR', message: 'Token encryption key not configured.'}};
+  }
+
+  const storedTokenInfo = await getStoredUserMSTeamsTokens(userId); // Uses placeholder
+  if (!storedTokenInfo || !storedTokenInfo.account || !storedTokenInfo.refreshToken) {
+    logger.warn(`[MSTeamsService] No stored MS Teams refresh token or account info for user ${userId}. User needs to authenticate.`);
+    // This is not an error per se if the user simply hasn't auth'd yet.
+    // The caller (e.g., a Hasura action handler) might use this to redirect to auth.
+    return { ok: false, error: { code: 'MSGRAPH_AUTH_REQUIRED', message: 'User authentication required for MS Teams (no refresh token or account info).' } };
+  }
+
+  try {
+    // Attempt to acquire token silently using the refresh token if available
+    // MSAL's acquireTokenSilent will use a cached access token if valid,
+    // or use the refresh token to get a new access token if the cached one is expired.
+    const silentRequest: SilentFlowRequest = {
+      account: storedTokenInfo.account, // AccountInfo object from when token was first acquired
+      scopes: MSGRAPH_DELEGATED_SCOPES!, // Ensure scopes are defined as an array
+      forceRefresh: false, // Set to true only if you suspect the cached AT is stale but not expired
+    };
+
+    let authResult: AuthenticationResult | null = null;
+    try {
+        logger.debug(`[MSTeamsService] Attempting to acquire token silently for user ${userId} with account ${storedTokenInfo.account.homeAccountId}`);
+        authResult = await clientApp.acquireTokenSilent(silentRequest);
+    } catch (error: any) {
+        logger.warn(`[MSTeamsService] Silent token acquisition failed for user ${userId} (Error: ${error.errorCode || error.name}). Attempting refresh via stored refresh token if applicable.`);
+        // Check if error is due to needing a refresh token or if it's an InteractionRequired error
+        // Some errors (like no_tokens_found) might mean we should try acquireTokenByRefreshToken
+        if (error.name === "ClientAuthError" && (error.errorCode === "no_tokens_found" || error.errorCode === "token_expired_error" || error.message?.includes(" Při pokusu o získání tokenu z mezipaměti nebyl nalezen žádný platný přístupový token."))) {
+            // The last error message is an example of a localized error that might indicate no valid AT in cache.
+            try {
+                logger.info(`[MSTeamsService] Attempting acquireTokenByRefreshToken for user ${userId}.`);
+                const refreshTokenRequest = {
+                    refreshToken: storedTokenInfo.refreshToken,
+                    scopes: MSGRAPH_DELEGATED_SCOPES!,
+                };
+                authResult = await clientApp.acquireTokenByRefreshToken(refreshTokenRequest);
+            } catch (refreshError: any) {
+                logger.error(`[MSTeamsService] Failed to acquire token by refresh token for user ${userId}:`, refreshError);
+                // If refresh token itself is invalid/expired, user must re-authenticate.
+                 if (refreshError.name === "InteractionRequiredAuthError" || refreshError.errorCode === 'invalid_grant' || refreshError.message?.includes("AADSTS70008")) { // invalid_grant or similar
+                    return { ok: false, error: { code: 'MSGRAPH_INTERACTION_REQUIRED', message: 'Refresh token invalid or expired. User must re-authenticate with Microsoft Teams.'}};
+                }
+                return { ok: false, error: { code: 'MSGRAPH_REFRESH_FAILED', message: `Failed to refresh token: ${refreshError.message}`, details: refreshError } };
+            }
+        } else {
+            throw error; // Re-throw other silent errors not handled by refresh token attempt
+        }
+    }
+
+    if (authResult && authResult.accessToken) {
+      // Account object in authResult might be updated (e.g. if tokens were refreshed with a new account state from IdP)
+      // It's important to store the account object returned by MSAL after successful token acquisition.
+      await storeUserMSTeamsTokens(userId, authResult); // Store updated tokens (placeholder)
+      logger.info(`[MSTeamsService] Successfully acquired/refreshed token for user ${userId}`);
+      return { ok: true, data: authResult.accessToken };
+    } else {
+      // This path should ideally not be reached if acquireTokenSilent/acquireTokenByRefreshToken works as expected (they throw on failure)
+      logger.warn(`[MSTeamsService] Token acquisition yielded null/empty accessToken for user ${userId} without throwing an error. This is unexpected.`);
+      return { ok: false, error: { code: 'MSGRAPH_AUTH_UNEXPECTED_NO_TOKEN', message: 'Token acquisition returned no access token unexpectedly.' } };
+    }
+  } catch (error: any) {
+    logger.error(`[MSTeamsService] General error in getDelegatedMSGraphTokenForUser for ${userId}:`, error);
+    if (error.name === 'InteractionRequiredAuthError' || (error.name === 'ClientAuthError' && error.errorCode === 'no_account_in_silent_request')) {
+        // This error means the user needs to go through the interactive sign-in process again.
+        return { ok: false, error: { code: 'MSGRAPH_INTERACTION_REQUIRED', message: 'User interaction required. Please re-authenticate with Microsoft Teams.' } };
+    }
+    return { ok: false, error: { code: 'MSGRAPH_AUTH_ERROR', message: `Failed to acquire MS Graph token for user ${userId}: ${error.message}`, details: error } };
+  }
+}
+
+export async function generateTeamsAuthUrl(userIdForContext: string, state?: string): Promise<string | null> {
+  const clientApp = initializeConfidentialClientApp(); // Correctly use the confidential client app
+  if (!clientApp) {
+    logger.error('[MSTeamsService] MSAL client not initialized, cannot generate auth URL.');
+    return null;
+  }
+
+  if (!MSGRAPH_DELEGATED_SCOPES || MSGRAPH_DELEGATED_SCOPES.length === 0) {
+    logger.error('[MSTeamsService] MSGRAPH_DELEGATED_SCOPES are not configured.');
+    return null;
+  }
+  if (!MSGRAPH_DELEGATED_REDIRECT_URL) {
+    logger.error('[MSTeamsService] MSGRAPH_DELEGATED_REDIRECT_URL is not configured.');
+    return null;
+  }
+
+  try {
+    const authCodeUrlParameters = {
+      scopes: MSGRAPH_DELEGATED_SCOPES,
+      redirectUri: MSGRAPH_DELEGATED_REDIRECT_URL,
+      state: state, // For CSRF protection; should be generated, temporarily stored, and validated by caller on callback
+    };
+    const authUrl = await clientApp.getAuthCodeUrl(authCodeUrlParameters);
+    logger.info(`[MSTeamsService] Generated MS Teams auth URL for context user: ${userIdForContext}.`);
+    return authUrl;
+  } catch (error: any) {
+    logger.error(`[MSTeamsService] Error generating MS Teams auth URL for context user ${userIdForContext}:`, error);
+    return null;
+  }
+}
+
+export async function handleTeamsAuthCallback(userId: string, authorizationCode: string): Promise<GraphSkillResponse<boolean>> {
+  const clientApp = initializeConfidentialClientApp(); // Correctly use the confidential client app
+  if (!clientApp) {
+    logger.error('[MSTeamsService] MSAL client not initialized, cannot handle auth callback.');
+    return { ok: false, error: { code: 'MSGRAPH_CONFIG_ERROR', message: 'MSAL client not initialized.' } };
+  }
+
+  if (!MSTEAMS_TOKEN_ENCRYPTION_KEY) {
+    logger.error('[MSTeamsService] MSTEAMS_TOKEN_ENCRYPTION_KEY is not configured. Cannot store tokens post callback.');
+    return { ok: false, error: { code: 'MSGRAPH_CONFIG_ERROR', message: 'Token encryption key not configured for callback.'}};
+  }
+   if (!MSGRAPH_DELEGATED_SCOPES || MSGRAPH_DELEGATED_SCOPES.length === 0) {
+    logger.error('[MSTeamsService] MSGRAPH_DELEGATED_SCOPES are not configured for callback token request.');
+    return { ok: false, error: { code: 'MSGRAPH_CONFIG_ERROR', message: 'Scopes not configured for callback.'}};
+  }
+  if (!MSGRAPH_DELEGATED_REDIRECT_URL) {
+    logger.error('[MSTeamsService] MSGRAPH_DELEGATED_REDIRECT_URL is not configured for callback token request.');
+    return { ok: false, error: { code: 'MSGRAPH_CONFIG_ERROR', message: 'Redirect URL not configured for callback.'}};
+  }
+
+
+  try {
+    const tokenRequest: AuthorizationCodeRequest = {
+      code: authorizationCode,
+      scopes: MSGRAPH_DELEGATED_SCOPES,
+      redirectUri: MSGRAPH_DELEGATED_REDIRECT_URL,
+    };
+    const authResult = await clientApp.acquireTokenByCode(tokenRequest);
+
+    if (authResult && authResult.accessToken && authResult.account) {
+      await storeUserMSTeamsTokens(userId, authResult); // Uses placeholder
+      logger.info(`[MSTeamsService] Successfully handled MS Teams auth callback and initiated token storage for user ${userId}.`);
+      return { ok: true, data: true };
+    } else {
+      logger.error(`[MSTeamsService] Failed to acquire token by code for user ${userId}. AuthResult invalid or account missing.`, authResult);
+      return { ok: false, error: { code: 'MSGRAPH_AUTH_CALLBACK_FAILED', message: 'Could not process auth code or vital token/account info missing.' } };
+    }
+  } catch (error: any) {
+    logger.error(`[MSTeamsService] Error in handleTeamsAuthCallback for user ${userId}:`, error);
+    // Provide more specific error if MSAL gives one (e.g. invalid_grant for used/expired code)
+    const errorCode = error.errorCode || 'MSGRAPH_AUTH_ERROR';
+    return { ok: false, error: { code: errorCode, message: `Callback handling error: ${error.message}`, details: error } };
+  }
+}
+
+
+// Existing meeting functions need to be adapted to use getDelegatedMSGraphTokenForUser
+// For example:
+export async function listMicrosoftTeamsMeetings(
+  atomUserId: string, // Changed from userPrincipalNameOrId to Atom's internal userId
+  options?: {
+    limit?: number;
+    nextLink?: string;
+    filterForTeamsMeetings?: boolean; // More descriptive name
+  }
+): Promise<GraphSkillResponse<ListMSGraphEventsData>> {
+  logger.debug(`[MSTeamsService] listMicrosoftTeamsMeetings called for Atom user: ${atomUserId}, options:`, options);
+
+  const tokenResponse = await getDelegatedMSGraphTokenForUser(atomUserId);
+  if (!tokenResponse.ok || !tokenResponse.data) {
+    return { ok: false, error: tokenResponse.error || { code: 'MSGRAPH_AUTH_ERROR', message: 'Failed to obtain MS Graph access token for listing meetings.'} };
+  }
+  const token = tokenResponse.data;
+
+  let requestUrl = options?.nextLink;
+
+  if (!requestUrl) {
+    const selectParams = 'id,subject,start,end,isOnlineMeeting,onlineMeeting,webLink,bodyPreview';
+    const orderByParams = 'start/dateTime ASC'; // Graph API uses PascalCase for OData query params
+    const topParams = options?.limit || 10;
+    let filterParamsValue = '';
+
+    // Filter for actual Teams meetings if requested, otherwise fetch all calendar events for the user
+    if (options?.filterForTeamsMeetings === true) {
+        filterParamsValue = `isOnlineMeeting eq true and onlineMeeting/onlineMeetingProvider eq 'teamsForBusiness'`;
+    }
+
+    const queryParams = new URLSearchParams();
+    queryParams.append('$select', selectParams);
+    queryParams.append('$orderBy', orderByParams); // Corrected from '$orderby'
+    queryParams.append('$top', topParams.toString());
+    if (filterParamsValue) {
+        queryParams.append('$filter', filterParamsValue);
+    }
+    // Use '/me/calendar/events' for delegated permissions to get events from the signed-in user's primary calendar
+    requestUrl = `${MSGRAPH_API_BASE_URL}/me/calendar/events?${queryParams.toString()}`;
+  }
+
+  try {
+    logger.debug(`[MSTeamsService] Requesting meetings from MS Graph: ${requestUrl}`);
+    const response = await axios.get(requestUrl, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+    return {
+      ok: true,
+      data: {
+        events: response.data.value as MSGraphEvent[],
+        nextLink: response.data['@odata.nextLink'] || undefined,
+      }
+    };
+  } catch (error: any) {
+    const axiosError = error as AxiosError;
+    logger.error(`[MSTeamsService] Error listing MS Teams meetings for Atom user ${atomUserId}:`, axiosError.message, axiosError.response?.data);
+    const errorData = axiosError.response?.data as any;
+    return {
+      ok: false,
+      error: {
+        code: errorData?.error?.code || 'MSGRAPH_API_ERROR',
+        message: errorData?.error?.message || axiosError.message || 'Failed to list MS Teams meetings',
+        details: errorData?.error || errorData
+      }
+    };
+  }
+}
+
+export async function getMicrosoftTeamsMeetingDetails(
+  atomUserId: string, // Changed from userPrincipalNameOrId to Atom's internal userId
+  eventId: string
+): Promise<GraphSkillResponse<MSGraphEvent>> {
+  logger.debug(`[MSTeamsService] getMicrosoftTeamsMeetingDetails called for Atom user: ${atomUserId}, eventId: ${eventId}`);
+
+  const tokenResponse = await getDelegatedMSGraphTokenForUser(atomUserId);
+  if (!tokenResponse.ok || !tokenResponse.data) {
+    return { ok: false, error: tokenResponse.error || { code: 'MSGRAPH_AUTH_ERROR', message: 'Failed to obtain MS Graph access token for meeting details.'} };
+  }
+  const token = tokenResponse.data;
+
+  const selectParams = 'id,subject,start,end,isOnlineMeeting,onlineMeeting,webLink,bodyPreview,body,attendees,location,locations,organizer';
+  // Use '/me/events/{id}' for delegated permissions to get a specific event from the signed-in user's default calendar
+  const requestUrl = `${MSGRAPH_API_BASE_URL}/me/events/${eventId}?$select=${selectParams}`;
+
+  try {
+    logger.debug(`[MSTeamsService] Requesting meeting details from MS Graph: ${requestUrl}`);
+    const response = await axios.get<MSGraphEvent>(requestUrl, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+    return { ok: true, data: response.data };
+  } catch (error: any) {
+    const axiosError = error as AxiosError;
+    logger.error(`[MSTeamsService] Error getting MS Teams meeting details for event ${eventId}, Atom user ${atomUserId}:`, axiosError.message, axiosError.response?.data);
+    const errorData = axiosError.response?.data as any;
+     if (axiosError.response?.status === 404) {
+      return { ok: false, error: { code: 'EVENT_NOT_FOUND', message: `Meeting event not found (ID: ${eventId}). Details: ${errorData?.error?.message || ''}`.trim()}};
+    }
+    return {
+      ok: false,
+      error: {
+        code: errorData?.error?.code || 'MSGRAPH_API_ERROR',
+        message: errorData?.error?.message || axiosError.message || 'Failed to get MS Teams meeting details',
+        details: errorData?.error || errorData
+      }
+    };
+  }
+}
+
+// Placeholder for msalClientApp, this was the old one for client credentials, can be removed.
+// let msalClientApp: ConfidentialClientApplication | null = null;
+
+
+// --- New functions for chat message interactions ---
+
+/**
+ * Defines the structure for a Teams message object within the agent.
+ * This should align with what the agent needs and what Graph API provides.
+ */
+export interface AgentMSTeamsMessage {
+  id: string;
+  chatId?: string; // For 1:1 or group chats
+  channelId?: string; // For channel messages (within a team)
+  teamId?: string; // For channel messages
+  replyToId?: string; // ID of the message this one is a reply to
+  userId?: string; // Sender's AAD User ID
+  userName?: string; // Sender's display name
+  content: string; // HTML content of the message
+  contentType: 'html' | 'text';
+  createdDateTime: string; // ISO 8601
+  lastModifiedDateTime?: string; // ISO 8601
+  webUrl?: string; // Permalink
+  attachments?: { id: string; name?: string; contentType?: string; contentUrl?: string; size?: number; }[];
+  mentions?: { id: number; mentionText?: string; mentioned?: { user?: { id: string; displayName?: string; userIdentityType?: string; }; }; }[];
+  raw?: any; // Store the raw Graph API message object
+}
+
+/**
+ * Searches Microsoft Teams messages using the Graph Search API.
+ * @param atomUserId Atom's internal user ID.
+ * @param searchQuery KQL query string.
+ * @param maxResults Maximum number of messages to return.
+ * @returns A promise resolving to an array of AgentMSTeamsMessage objects.
+ */
+export async function searchTeamsMessages(
+  atomUserId: string,
+  searchQuery: string,
+  maxResults: number = 20
+): Promise<GraphSkillResponse<AgentMSTeamsMessage[]>> {
+  logger.debug(`[MSTeamsService] searchTeamsMessages called for Atom user ${atomUserId}, query: "${searchQuery}", maxResults: ${maxResults}`);
+
+  const tokenResponse = await getDelegatedMSGraphTokenForUser(atomUserId);
+  if (!tokenResponse.ok || !tokenResponse.data) {
+    return { ok: false, error: tokenResponse.error || { code: 'MSGRAPH_AUTH_ERROR', message: 'Failed to obtain MS Graph token for searching messages.'} };
+  }
+  const token = tokenResponse.data;
+
+  const searchRequest = {
+    requests: [
+      {
+        entityTypes: ['chatMessage'],
+        query: {
+          queryString: searchQuery,
+        },
+        from: 0,
+        size: maxResults,
+        sortProperties: [ // Optional: Sort by createdDateTime descending
+          { name: "createdDateTime", isDescending: true }
+        ]
+        // fields: ["id", "chatId", "from", "body", "createdDateTime", "lastModifiedDateTime", "webUrl", "channelIdentity", "replyToId"] // Specify fields to retrieve
+      },
+    ],
+  };
+
+  const requestUrl = `${MSGRAPH_API_BASE_URL}/search/query`;
+
+  try {
+    logger.debug(`[MSTeamsService] Searching Teams messages with query: ${searchQuery}`);
+    const response = await axios.post(requestUrl, searchRequest, {
+      headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+    });
+
+    const messages: AgentMSTeamsMessage[] = [];
+    if (response.data && response.data.value && response.data.value.length > 0) {
+      const searchHitsContainers = response.data.value[0]?.hitsContainers;
+      if (searchHitsContainers && searchHitsContainers.length > 0) {
+        searchHitsContainers.forEach((container: any) => {
+          if (container.hits) {
+            container.hits.forEach((hit: any) => {
+              const resource = hit.resource;
+              if (resource) {
+                messages.push({
+                  id: resource.id,
+                  chatId: resource.chatId,
+                  channelId: resource.channelIdentity?.channelId,
+                  teamId: resource.channelIdentity?.teamId,
+                  replyToId: resource.replyToId,
+                  userId: resource.from?.user?.id,
+                  userName: resource.from?.user?.displayName,
+                  content: resource.body?.content,
+                  contentType: resource.body?.contentType,
+                  createdDateTime: resource.createdDateTime,
+                  lastModifiedDateTime: resource.lastModifiedDateTime,
+                  webUrl: resource.webUrl,
+                  // attachments: resource.attachments, // Graph search might not return full attachments here
+                  // mentions: resource.mentions,
+                  raw: resource,
+                });
+              }
+            });
+          }
+        });
+      }
+    }
+    logger.info(`[MSTeamsService] Found ${messages.length} Teams messages for query "${searchQuery}" for Atom user ${atomUserId}.`);
+    return { ok: true, data: messages };
+
+  } catch (error: any) {
+    const axiosError = error as AxiosError;
+    logger.error(`[MSTeamsService] Error searching Teams messages for Atom user ${atomUserId}:`, axiosError.message, axiosError.response?.data);
+    const errorData = axiosError.response?.data as any;
+    return {
+      ok: false,
+      error: {
+        code: errorData?.error?.code || 'MSGRAPH_SEARCH_API_ERROR',
+        message: errorData?.error?.message || axiosError.message || 'Failed to search Teams messages',
+        details: errorData?.error || errorData
+      }
+    };
+  }
+}
+
+
+/**
+ * Gets the content of a specific chat message (1:1 or group chat).
+ * @param atomUserId Atom's internal user ID.
+ * @param chatId The ID of the chat.
+ * @param messageId The ID of the message.
+ * @returns A promise resolving to an AgentMSTeamsMessage object or null.
+ */
+export async function getTeamsChatMessageContent(
+  atomUserId: string,
+  chatId: string,
+  messageId: string
+): Promise<GraphSkillResponse<AgentMSTeamsMessage | null>> {
+  logger.debug(`[MSTeamsService] getTeamsChatMessageContent for user ${atomUserId}, chatId: ${chatId}, messageId: ${messageId}`);
+  const tokenResponse = await getDelegatedMSGraphTokenForUser(atomUserId);
+  if (!tokenResponse.ok || !tokenResponse.data) return { ok: false, error: tokenResponse.error };
+  const token = tokenResponse.data;
+
+  // The fields selected here should match the AgentMSTeamsMessage interface
+  const selectFields = "id,replyToId,from,body,createdDateTime,lastModifiedDateTime,webUrl,attachments,mentions,chatId";
+  const requestUrl = `${MSGRAPH_API_BASE_URL}/me/chats/${chatId}/messages/${messageId}?$select=${selectFields}`;
+
+  try {
+    const response = await axios.get(requestUrl, { headers: { 'Authorization': `Bearer ${token}` } });
+    const rawMsg = response.data;
+    const message: AgentMSTeamsMessage = {
+      id: rawMsg.id,
+      chatId: rawMsg.chatId, // Will be populated by this endpoint
+      replyToId: rawMsg.replyToId,
+      userId: rawMsg.from?.user?.id,
+      userName: rawMsg.from?.user?.displayName,
+      content: rawMsg.body?.content,
+      contentType: rawMsg.body?.contentType,
+      createdDateTime: rawMsg.createdDateTime,
+      lastModifiedDateTime: rawMsg.lastModifiedDateTime,
+      webUrl: rawMsg.webUrl,
+      attachments: rawMsg.attachments?.map((att: any) => ({
+          id: att.id, name: att.name, contentType: att.contentType, contentUrl: att.contentUrl, size: att.size
+      })),
+      mentions: rawMsg.mentions?.map((men:any) => ({
+          id: men.id, mentionText: men.mentionText, mentioned: men.mentioned
+      })),
+      raw: rawMsg,
+    };
+    return { ok: true, data: message };
+  } catch (error: any) {
+    const axiosError = error as AxiosError;
+    logger.error(`[MSTeamsService] Error getting chat message content (chat ${chatId}, msg ${messageId}):`, axiosError.message, axiosError.response?.data);
+    const errorData = axiosError.response?.data as any;
+    if (axiosError.response?.status === 404) return { ok: false, error: { code: 'MSGRAPH_MESSAGE_NOT_FOUND', message: 'Chat message not found.'}};
+    return { ok: false, error: { code: errorData?.error?.code || 'MSGRAPH_API_ERROR', message: errorData?.error?.message || 'Failed to get chat message content'}};
+  }
+}
+
+/**
+ * Gets the content of a specific channel message.
+ * @param atomUserId Atom's internal user ID.
+ * @param teamId The ID of the team.
+ * @param channelId The ID of the channel.
+ * @param messageId The ID of the message.
+ * @returns A promise resolving to an AgentMSTeamsMessage object or null.
+ */
+export async function getTeamsChannelMessageContent(
+  atomUserId: string,
+  teamId: string,
+  channelId: string,
+  messageId: string
+): Promise<GraphSkillResponse<AgentMSTeamsMessage | null>> {
+  logger.debug(`[MSTeamsService] getTeamsChannelMessageContent for user ${atomUserId}, team ${teamId}, channel ${channelId}, msg ${messageId}`);
+  const tokenResponse = await getDelegatedMSGraphTokenForUser(atomUserId);
+  if (!tokenResponse.ok || !tokenResponse.data) return { ok: false, error: tokenResponse.error };
+  const token = tokenResponse.data;
+
+  const selectFields = "id,replyToId,from,body,createdDateTime,lastModifiedDateTime,webUrl,attachments,mentions,channelIdentity";
+  const requestUrl = `${MSGRAPH_API_BASE_URL}/teams/${teamId}/channels/${channelId}/messages/${messageId}?$select=${selectFields}`;
+
+  try {
+    const response = await axios.get(requestUrl, { headers: { 'Authorization': `Bearer ${token}` } });
+    const rawMsg = response.data;
+    const message: AgentMSTeamsMessage = {
+      id: rawMsg.id,
+      teamId: rawMsg.channelIdentity?.teamId,
+      channelId: rawMsg.channelIdentity?.channelId,
+      replyToId: rawMsg.replyToId,
+      userId: rawMsg.from?.user?.id,
+      userName: rawMsg.from?.user?.displayName,
+      content: rawMsg.body?.content,
+      contentType: rawMsg.body?.contentType,
+      createdDateTime: rawMsg.createdDateTime,
+      lastModifiedDateTime: rawMsg.lastModifiedDateTime,
+      webUrl: rawMsg.webUrl,
+      attachments: rawMsg.attachments?.map((att: any) => ({
+          id: att.id, name: att.name, contentType: att.contentType, contentUrl: att.contentUrl, size: att.size
+      })),
+      mentions: rawMsg.mentions?.map((men:any) => ({
+          id: men.id, mentionText: men.mentionText, mentioned: men.mentioned
+      })),
+      raw: rawMsg,
+    };
+    return { ok: true, data: message };
+  } catch (error: any) {
+    const axiosError = error as AxiosError;
+    logger.error(`[MSTeamsService] Error getting channel message content (team ${teamId}, channel ${channelId}, msg ${messageId}):`, axiosError.message, axiosError.response?.data);
+    const errorData = axiosError.response?.data as any;
+    if (axiosError.response?.status === 404) return { ok: false, error: { code: 'MSGRAPH_MESSAGE_NOT_FOUND', message: 'Channel message not found.'}};
+    return { ok: false, error: { code: errorData?.error?.code || 'MSGRAPH_API_ERROR', message: errorData?.error?.message || 'Failed to get channel message content'}};
+  }
+}
+
+// Note: getTeamsMessagePermalink is implicitly handled by the `webUrl` property
+// in the AgentMSTeamsMessage when messages are fetched. No separate function needed
+// unless a specific API call for permalink generation is preferred or required for some edge cases.

--- a/atomic-docker/project/metadata/actions.graphql
+++ b/atomic-docker/project/metadata/actions.graphql
@@ -327,4 +327,126 @@ extend type Mutation {
 
   """Gets a permalink for a specific Slack message."""
   getSlackMessagePermalink(input: SlackMessageIdentifierInput!): SlackPermalinkOutput
+
+  # MS Teams Actions
+  """(Placeholder) Action to generate the Microsoft OAuth URL for Teams integration (delegated)."""
+  generateMSTeamsAuthUrl: GenerateMSTeamsAuthUrlOutput
+
+  """(Placeholder) Action to handle the OAuth callback from Microsoft after user authorization for Teams."""
+  handleMSTeamsAuthCallback(input: HandleMSTeamsAuthCallbackInput!): HandleMSTeamsAuthCallbackOutput
+
+  """Searches messages in the user's Microsoft Teams environment."""
+  searchUserMSTeamsMessages(input: SearchMSTeamsMessagesInput!): SearchMSTeamsMessagesOutput
+
+  """Fetches the detailed content of a specific Microsoft Teams message."""
+  getMSTeamsMessageDetail(input: GetMSTeamsMessageDetailInput!): GetMSTeamsMessageDetailOutput
+
+  """Gets a webUrl (permalink) for a specific Microsoft Teams message."""
+  getMSTeamsMessageWebUrl(input: GetMSTeamsMessageWebUrlInput!): GetMSTeamsMessageWebUrlOutput
+}
+
+# --- Microsoft Teams Integration Types ---
+
+"""(Placeholder) Output for generating MS Teams authorization URL."""
+type GenerateMSTeamsAuthUrlOutput {
+  authorizationUrl: String
+}
+
+"""(Placeholder) Input for handling MS Teams OAuth callback."""
+input HandleMSTeamsAuthCallbackInput {
+  code: String! # Authorization code
+}
+
+"""(Placeholder) Output for handling MS Teams OAuth callback."""
+type HandleMSTeamsAuthCallbackOutput {
+  success: Boolean!
+  message: String
+}
+
+"""Input for searching Microsoft Teams messages."""
+input SearchMSTeamsMessagesInput {
+  """Keyword Query Language (KQL) string or natural language query for Graph Search API."""
+  query: String!
+  """Maximum number of results to return. Defaults to 20."""
+  maxResults: Int
+}
+
+"""Represents an attachment in an MS Teams message."""
+type MSTeamsMessageAttachmentObject {
+  id: String!
+  name: String
+  contentType: String
+  contentUrl: String
+  size: Int
+}
+
+"""Represents a user mentioned in an MS Teams message."""
+type MSTeamsMentionedUserObject {
+  id: String      # AAD User ID
+  displayName: String
+  userIdentityType: String # e.g., "aadUser"
+}
+
+"""Represents a mention in an MS Teams message."""
+type MSTeamsMentionObject {
+  id: Int! # Numeric ID of the mention within the message
+  mentionText: String
+  mentioned: MSTeamsMentionedUserObject # Simplified to user mention for now
+}
+
+"""Represents an MS Teams message for agent interactions."""
+type MSTeamsMessageObject {
+  id: String! # Message ID from Graph
+  chatId: String
+  teamId: String
+  channelId: String
+  replyToId: String
+  userId: String # Sender's AAD User ID
+  userName: String # Sender's display name
+  content: String!
+  contentType: String! # 'html' or 'text'
+  createdDateTime: String! # ISO 8601
+  lastModifiedDateTime: String
+  webUrl: String
+  attachments: [MSTeamsMessageAttachmentObject!]
+  mentions: [MSTeamsMentionObject!]
+  # raw: JSON # Consider if needed
+}
+
+"""Output for searching MS Teams messages."""
+type SearchMSTeamsMessagesOutput {
+  success: Boolean!
+  message: String
+  results: [MSTeamsMessageObject!]
+}
+
+"""Input for fetching details or webUrl of a specific MS Teams message."""
+input GetMSTeamsMessageDetailInput {
+  messageId: String!
+  chatId: String      # Required if it's a chat message
+  teamId: String      # Required with channelId if it's a channel message
+  channelId: String   # Required with teamId if it's a channel message
+}
+
+# Input for getMSTeamsMessageWebUrl (can reuse GetMSTeamsMessageDetailInput)
+input GetMSTeamsMessageWebUrlInput {
+  messageId: String!
+  chatId: String
+  teamId: String
+  channelId: String
+}
+
+
+"""Output for fetching MS Teams message details."""
+type GetMSTeamsMessageDetailOutput {
+  success: Boolean!
+  message: String
+  msTeamsMessage: MSTeamsMessageObject
+}
+
+"""Output for fetching MS Teams message webUrl."""
+type GetMSTeamsMessageWebUrlOutput {
+  success: Boolean!
+  message: String
+  webUrl: String
 }

--- a/atomic-docker/project/metadata/actions.yaml
+++ b/atomic-docker/project/metadata/actions.yaml
@@ -180,6 +180,20 @@ custom_types:
     - name: SlackSearchOutput
     - name: SlackMessageOutput
     - name: SlackPermalinkOutput
+    # MS Teams Types
+    - name: GenerateMSTeamsAuthUrlOutput
+    - name: HandleMSTeamsAuthCallbackInput
+    - name: HandleMSTeamsAuthCallbackOutput
+    - name: SearchMSTeamsMessagesInput
+    - name: MSTeamsMessageAttachmentObject
+    - name: MSTeamsMentionedUserObject
+    - name: MSTeamsMentionObject
+    - name: MSTeamsMessageObject
+    - name: SearchMSTeamsMessagesOutput
+    - name: GetMSTeamsMessageDetailInput
+    - name: GetMSTeamsMessageWebUrlInput
+    - name: GetMSTeamsMessageDetailOutput
+    - name: GetMSTeamsMessageWebUrlOutput
   scalars: []
 actions:
   - name: processAudioForNote
@@ -379,3 +393,84 @@ actions:
     permissions:
       - role: user
     comment: "Gets a permalink for a specific Slack message."
+
+  # Microsoft Teams Actions
+  - name: generateMSTeamsAuthUrl
+    definition:
+      kind: synchronous
+      handler: "{{FUNCTIONS_BASE_URL}}/generate-msteams-auth-url" # Placeholder
+      request_transform:
+        version: 2
+        template_engine: Kriti
+        body: |
+          {
+            "input": {{ $.args.input | default({}) }},
+            "session_variables": {{ $.session_variables }}
+          }
+    permissions:
+      - role: user
+    comment: "Generates the Microsoft OAuth URL for Teams integration (delegated)."
+
+  - name: handleMSTeamsAuthCallback
+    definition:
+      kind: synchronous
+      handler: "{{FUNCTIONS_BASE_URL}}/handle-msteams-auth-callback" # Placeholder
+      request_transform:
+        version: 2
+        template_engine: Kriti
+        body: |
+          {
+            "input": {{ $.args.input }},
+            "session_variables": {{ $.session_variables }}
+          }
+    permissions:
+      - role: user
+    comment: "Handles the OAuth callback from Microsoft after user authorization for Teams."
+
+  - name: searchUserMSTeamsMessages
+    definition:
+      kind: synchronous
+      handler: "{{FUNCTIONS_BASE_URL}}/search-user-msteams-messages" # Placeholder
+      request_transform:
+        version: 2
+        template_engine: Kriti
+        body: |
+          {
+            "input": {{ $.args.input }},
+            "session_variables": {{ $.session_variables }}
+          }
+    permissions:
+      - role: user
+    comment: "Searches messages in the user's Microsoft Teams environment."
+
+  - name: getMSTeamsMessageDetail
+    definition:
+      kind: synchronous
+      handler: "{{FUNCTIONS_BASE_URL}}/get-msteams-message-detail" # Placeholder
+      request_transform:
+        version: 2
+        template_engine: Kriti
+        body: |
+          {
+            "input": {{ $.args.input }},
+            "session_variables": {{ $.session_variables }}
+          }
+    permissions:
+      - role: user
+    comment: "Fetches the detailed content of a specific Microsoft Teams message."
+
+  - name: getMSTeamsMessageWebUrl
+    definition:
+      kind: synchronous
+      handler: "{{FUNCTIONS_BASE_URL}}/get-msteams-message-weburl" # Placeholder
+      request_transform:
+        version: 2
+        template_engine: Kriti
+        body: |
+          {
+            "input": {{ $.args.input }},
+            "session_variables": {{ $.session_variables }}
+          }
+    permissions:
+      - role: user
+    comment: "Gets a webUrl (permalink) for a specific Microsoft Teams message."

--- a/docs/msteams_integration_guide.md
+++ b/docs/msteams_integration_guide.md
@@ -1,0 +1,168 @@
+# Microsoft Teams Integration Guide for Atom Agent (Delegated Permissions)
+
+This document outlines the setup, architecture, and usage of the Microsoft Teams integration feature within the Atom Agent, focusing on delegated permissions for accessing chat messages. This allows the agent to act on behalf of the user to search their Teams messages, retrieve content, and extract information.
+
+## 1. Setup and Configuration (Delegated Permissions)
+
+Proper setup is crucial for the Microsoft Teams integration with delegated permissions. This involves configuring an Azure AD Application, setting environment variables, and preparing for per-user token management.
+
+### 1.1. Azure AD Application Registration
+
+To enable Microsoft Graph API access with delegated permissions:
+
+1.  **Register an Application:**
+    *   Go to the [Azure portal](https://portal.azure.com/) > "Azure Active Directory" > "App registrations".
+    *   Click "+ New registration".
+    *   **Name:** Provide a name (e.g., "Atom Agent Teams Integration").
+    *   **Supported account types:** Choose an appropriate option. For most scenarios allowing organizational accounts, "Accounts in this organizational directory only (Single tenant)" or "Accounts in any organizational directory (Any Azure AD directory - Multitenant)" would be suitable. "Accounts in any organizational directory ... and personal Microsoft accounts (e.g. Skype, Xbox)" could also be chosen if wider access is needed.
+    *   **Redirect URI (Critical):**
+        *   Select "Web" as the platform.
+        *   Enter the redirect URI where Microsoft will send the authorization code after user consent. This URI must be handled by your backend. Example: `YOUR_APP_SERVICE_BASE_URL/auth/msteams/callback` (e.g., `http://localhost:YOUR_BACKEND_PORT/auth/msteams/callback` for local development, or your deployed backend callback URL). This will be configured via an environment variable like `MSGRAPH_DELEGATED_REDIRECT_URL`.
+    *   Click "Register".
+
+2.  **API Permissions (Delegated Permissions):**
+    *   Navigate to "API permissions" for your newly registered app.
+    *   Click "+ Add a permission" > "Microsoft Graph".
+    *   Select "Delegated permissions".
+    *   Add the following permissions:
+        *   `Chat.Read`: Allows the app to read the signed-in user's 1:1 and group chat messages.
+        *   `ChannelMessage.Read.All`: Allows the app to read messages in all channels the user can access.
+        *   `User.Read`: Allows the app to sign in the user and read their basic profile (required for most delegated flows).
+        *   `offline_access`: Allows the app to receive refresh tokens, enabling long-term access on behalf of the user without them being actively present.
+        *   (Optional, consider if needed later) `Team.ReadBasic.All`: To read basic properties of teams the user is a member of (e.g., to list teams/channels).
+    *   After adding permissions, an administrator might need to grant admin consent for these permissions on behalf of users in the organization, depending on tenant policies, especially for `ChannelMessage.Read.All`.
+
+3.  **Certificates & Secrets:**
+    *   Navigate to "Certificates & secrets".
+    *   Click "+ New client secret".
+    *   Provide a description and choose an expiry duration.
+    *   **Important:** Copy the **Value** of the client secret immediately. It will not be visible again. This will be used as an environment variable.
+
+4.  **Overview Tab:**
+    *   Note down the "Application (client) ID" and "Directory (tenant) ID". These will be used in environment variables.
+
+### 1.2. Environment Variables
+
+The following environment variables must be set in your backend function's environment:
+
+*   `MSGRAPH_DELEGATED_CLIENT_ID`: The Application (client) ID from your Azure AD app registration.
+*   `MSGRAPH_DELEGATED_CLIENT_SECRET`: The client secret value you generated.
+*   `MSGRAPH_DELEGATED_TENANT_ID`: The Directory (tenant) ID.
+*   `MSGRAPH_DELEGATED_AUTHORITY`: The authority URL, typically `https://login.microsoftonline.com/{YOUR_TENANT_ID}`. Replace `{YOUR_TENANT_ID}` with your actual tenant ID or use `common` for multi-tenant apps (if configured that way).
+*   `MSGRAPH_DELEGATED_REDIRECT_URL`: The exact redirect URI configured in your Azure AD app registration (e.g., `https://your-agent-backend.com/auth/msteams/callback`).
+*   `MSGRAPH_DELEGATED_SCOPES`: A space-separated string of the delegated scopes you configured (e.g., `"Chat.Read ChannelMessage.Read.All User.Read offline_access"`).
+*   `MSTEAMS_TOKEN_ENCRYPTION_KEY`: A **32-byte (64 hexadecimal characters)** secret key for AES-256-GCM encryption of stored user-specific OAuth tokens (similar to the Gmail key). **Generate a new, unique key for this.**
+*   `ATOM_OPENAI_API_KEY`: Your OpenAI API key, required for LLM-powered query understanding and information extraction.
+*   `ATOM_NLU_MODEL_NAME`: The OpenAI model to be used (e.g., `gpt-3.5-turbo`).
+*   `HASURA_GRAPHQL_ENDPOINT`: The endpoint for your Hasura GraphQL API.
+*   `FUNCTIONS_BASE_URL`: The base URL for your deployed backend functions that Hasura will call.
+
+### 1.3. Database Setup
+
+A new table (e.g., `user_msteams_tokens`) will be required to store the encrypted OAuth tokens (access token, refresh token, and MSAL account information) for each authorizing user. This table should include:
+*   `user_id` (uuid, foreign key to your users table, primary key)
+*   `encrypted_access_token` (text)
+*   `encrypted_refresh_token` (text)
+*   `token_expiry_timestamp` (timestamptz)
+*   `account_json_blob` (jsonb, to store the MSAL `AccountInfo` object)
+*   `created_at`, `updated_at` (timestamptz)
+
+Migrations for this table need to be created and applied.
+
+### 1.4. Hasura Metadata
+
+1.  **Track Table:** Track the new `user_msteams_tokens` table in Hasura.
+2.  **Define Actions:** The new MS Teams actions and their types are defined in `atomic-docker/project/metadata/actions.graphql` and `atomic-docker/project/metadata/actions.yaml`.
+3.  **Apply Metadata:** Apply all metadata changes using the Hasura CLI: `hasura metadata apply`.
+
+### 1.5. Backend Function Deployment
+
+The new and modified backend TypeScript functions need to be deployed:
+*   The refactored service `atomic-docker/project/functions/msteams-service/service.ts`.
+*   New agent skills in `atom-agent/skills/llm_msteams_query_understander.ts` and `atom-agent/skills/nlu_msteams_helper.ts`.
+*   The new agent skills file `atom-agent/skills/msTeamsSkills.ts`.
+*   The new command handler `atom-agent/command_handlers/msteams_command_handler.ts`.
+*   New HTTP handlers (e.g., Express routes or serverless function endpoints) that expose functions from `msteams-service.ts` (like OAuth URL generation, callback handling, message search, detail retrieval) to be callable by Hasura actions. URLs must match `actions.yaml`.
+
+---
+
+## 2. Token Management and Core Service (`msteams-service.ts`)
+
+Located in `atomic-docker/project/functions/msteams-service/service.ts`. This service is responsible for all direct interactions with the Microsoft Graph API using delegated permissions.
+
+### 2.1. OAuth 2.0 Authorization Code Flow
+*   **`initializeConfidentialClientApp()`**: Initializes the MSAL `ConfidentialClientApplication` with delegated app credentials.
+*   **`generateTeamsAuthUrl(userIdForContext: string, state?: string)`**: Generates the Microsoft authorization URL where the user will be redirected to grant consent. Includes scopes like `Chat.Read`, `ChannelMessage.Read.All`, `User.Read`, `offline_access`.
+*   **`handleTeamsAuthCallback(userId: string, authorizationCode: string)`**:
+    *   Called by your backend's redirect URI handler.
+    *   Exchanges the `authorizationCode` for an access token and a refresh token using `clientApp.acquireTokenByCode()`.
+    *   **Crucially, this function (and helper `storeUserMSTeamsTokens`) needs to be fully implemented to securely encrypt and store the obtained tokens (access token, refresh token, and MSAL `AccountInfo` object) in the `user_msteams_tokens` database table, associated with the `userId`.** (Currently placeholders).
+*   **`getDelegatedMSGraphTokenForUser(userId: string)`**:
+    *   **This function needs to be fully implemented to retrieve the stored, encrypted refresh token and `AccountInfo` for the given `userId` from the database.** (Currently placeholders).
+    *   Decrypts the tokens.
+    *   Uses `clientApp.acquireTokenSilent()` with the user's `AccountInfo` to get a valid access token. MSAL handles using the refresh token if the access token is expired.
+    *   If tokens are refreshed, the new tokens (and potentially updated `AccountInfo`) must be re-encrypted and stored back in the database.
+    *   Returns the valid access token.
+
+### 2.2. Microsoft Graph API Interactions
+*   **Meeting Functions (Updated):**
+    *   `listMicrosoftTeamsMeetings(atomUserId: string, options)`: Fetches calendar events for the user using `/me/calendar/events`.
+    *   `getMicrosoftTeamsMeetingDetails(atomUserId: string, eventId: string)`: Fetches specific event details using `/me/events/{id}`.
+*   **New Chat Message Functions:**
+    *   `searchTeamsMessages(atomUserId: string, searchQuery: string, maxResults: number)`: Uses the `/search/query` Graph API endpoint with `entityTypes: ['chatMessage']` to search messages based on a KQL query.
+    *   `getTeamsChatMessageContent(atomUserId: string, chatId: string, messageId: string)`: Fetches a specific 1:1 or group chat message using `/me/chats/{chat-id}/messages/{message-id}`.
+    *   `getTeamsChannelMessageContent(atomUserId: string, teamId: string, channelId: string, messageId: string)`: Fetches a specific channel message using `/teams/{team-id}/channels/{channel-id}/messages/{message-id}`.
+    *   Note: Message permalinks (`webUrl`) are typically part of the message resource fetched by the content retrieval functions.
+
+---
+
+## 3. Agent Integration (`atom-agent/`)
+
+These components enable the agent to understand and process MS Teams related commands.
+
+### 3.1. MS Teams Skills (`skills/msTeamsSkills.ts` - New File)
+This file contains agent-facing functions that usually call Hasura actions (which then trigger the `msteams-service.ts` functions).
+
+*   **`searchMyMSTeamsMessages(userId: string, searchQuery: string, limit: number)`**: Calls the `searchUserMSTeamsMessages` Hasura action.
+*   **`readMSTeamsMessage(userId: string, identifier: GetMSTeamsMessageDetailInput)`**: Calls the `getMSTeamsMessageDetail` Hasura action.
+*   **`extractInformationFromMSTeamsMessage(messageContent: string, infoKeywords: string[])`**: Uses an LLM (OpenAI) with a specific prompt (`MSTEAMS_EXTRACTION_SYSTEM_PROMPT_TEMPLATE`) to extract information from message text.
+*   **`getMSTeamsMessageWebUrl(userId: string, identifier: GetMSTeamsMessageWebUrlInput)`**: Calls the `getMSTeamsMessageWebUrl` Hasura action (which likely just extracts the `webUrl` from the full message detail fetched by the service).
+
+### 3.2. NLU for Teams Search (`skills/llm_msteams_query_understander.ts` & `skills/nlu_msteams_helper.ts`)
+1.  **`llm_msteams_query_understander.ts`**:
+    *   Defines `StructuredMSTeamsQuery` interface.
+    *   **`understandMSTeamsSearchQueryLLM(rawUserQuery: string)`**: Uses an LLM with `MSTEAMS_QUERY_UNDERSTANDING_SYSTEM_PROMPT` to parse natural language into a `StructuredMSTeamsQuery` object.
+2.  **`nlu_msteams_helper.ts`**:
+    *   **`buildMSTeamsSearchQuery(params: StructuredMSTeamsQuery)`**: Converts the `StructuredMSTeamsQuery` into a KQL string for the Graph Search API.
+
+### 3.3. Agent Command Handler (`command_handlers/msteams_command_handler.ts`)
+*   **`handleMSTeamsInquiry(request: ParsedNluMSTeamsRequest)`**:
+    *   Orchestrates the flow: NLU parsing -> KQL query building -> calling `searchMyMSTeamsMessages` -> (optional) disambiguation -> calling `readMSTeamsMessage` -> performing actions like `extractInformationFromMSTeamsMessage` or `getMSTeamsMessageWebUrl`.
+    *   Formats user-facing responses.
+
+---
+
+## 4. Hasura Actions
+
+Defined in `actions.graphql` and `actions.yaml`. These actions expose the backend service functions to the agent skills layer.
+
+*   **OAuth Placeholders (to be implemented for user interaction):**
+    *   `generateMSTeamsAuthUrl`
+    *   `handleMSTeamsAuthCallback`
+*   **Message Interaction Actions:**
+    *   `searchUserMSTeamsMessages`
+    *   `getMSTeamsMessageDetail`
+    *   `getMSTeamsMessageWebUrl`
+
+Handler URLs in `actions.yaml` for these actions must point to the deployed backend HTTP endpoints that trigger the corresponding functions in `msteams-service.ts`.
+
+---
+
+## 5. Frontend Overview
+
+Interaction with these advanced MS Teams chat features is primarily via the agent's chat interface. Future frontend work could include:
+*   A settings page section for connecting/disconnecting the MS Teams integration (initiating the OAuth flow and displaying connection status).
+*   UI elements for displaying Teams message search results or details if desired outside the chat context.
+
+---
+This guide will be updated as the features evolve, particularly the token storage and frontend components.


### PR DESCRIPTION
…issions

This commit introduces advanced Microsoft Teams chat integration using delegated user permissions. The agent can now:
- Understand natural language queries to search the user's Teams messages.
- Fetch and read specific Teams messages (chats and channels).
- Extract targeted information from Teams message content using an LLM.
- Retrieve web URLs (permalinks) for Teams messages.

Key changes include:
- Refactored MSAL authentication in a new `msteams-service.ts` to support delegated OAuth2 flow (authorization code grant), including token acquisition, refresh, and placeholder logic for secure per-user token storage.
- New service functions for searching messages via Graph Search API and fetching specific message content.
- LLM-based query understanding (`llm_msteams_query_understander.ts`) and KQL construction helper (`nlu_msteams_helper.ts`).
- New agent skills (`msTeamsSkills.ts`) for interacting with these features via Hasura.
- New MS Teams command handler (`msteams_command_handler.ts`) to orchestrate the agent's logic.
- Updated Hasura metadata (`actions.graphql`, `actions.yaml`) with new actions and types for Teams OAuth and message operations.
- Unit tests for the KQL query builder.
- Comprehensive documentation updates in FEATURES.md and a new `docs/msteams_integration_guide.md` detailing the delegated auth setup and new features.

Note: Database schema for storing user MS Teams tokens and encryption utilities for these tokens are pending full implementation.