### PR TITLE
docs: Integrate Dockerized Lambdas into local Docker Compose setup

### DIFF
--- a/atomic-docker/project/functions/ses-notification-lambda/Dockerfile
+++ b/atomic-docker/project/functions/ses-notification-lambda/Dockerfile
@@ -1,0 +1,41 @@
+# Use the official AWS Lambda Node.js 18 base image
+# This image includes the Lambda Runtime Interface Emulator (RIE) for local testing.
+FROM public.ecr.aws/lambda/nodejs:18
+
+# Set the working directory in the Lambda container.
+# ${LAMBDA_TASK_ROOT} is a standard environment variable in AWS Lambda.
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+# Copy the bundled application code.
+# It's assumed that a build step (e.g., using 'serverless-esbuild' or a custom script)
+# has already compiled TypeScript to JavaScript and placed the output (e.g., index.js and index.js.map)
+# at the root of the context that Docker uses for this COPY operation.
+# When Serverless Framework builds an image, it typically prepares a context with these files.
+COPY index.js ${LAMBDA_TASK_ROOT}/
+COPY index.js.map ${LAMBDA_TASK_ROOT}/
+
+# If your project has production node_modules that were NOT bundled by esbuild
+# (e.g., native modules marked as external, or if you explicitly chose not to bundle node_modules):
+# 1. Ensure your esbuild configuration (e.g., in serverless.yml via serverless-esbuild)
+#    marks these dependencies as external.
+# 2. Copy package.json and package-lock.json (or yarn.lock).
+# COPY package.json package-lock.json* ./
+# # COPY yarn.lock ./ # If using Yarn
+#
+# 3. Install *only* production dependencies using the appropriate lock file.
+# RUN npm ci --only=production
+# # RUN yarn install --production --frozen-lockfile # If using Yarn
+#
+# This will create a node_modules folder in your image.
+# For many common use cases with serverless-esbuild, dependencies are bundled,
+# and this explicit npm/yarn install step in the Dockerfile is not needed.
+
+# The CMD instruction in a Dockerfile for an AWS Lambda base image specifies the handler.
+# However, this is often overridden by the 'Handler' property in the Lambda function's
+# configuration (e.g., in serverless.yml or SAM template).
+# The AWS Lambda Runtime Interface Client (included in the base image) will use the
+# handler specified in the Lambda configuration.
+# If CMD is set, it might serve as a default if no handler is configured, or for local testing.
+# For example: CMD [ "index.handler" ]
+# For this setup, we'll rely on the handler being set in serverless.yml.
+# The base image's ENTRYPOINT will start the Lambda Runtime Interface Client.

--- a/atomic-docker/project/functions/ses-notification-lambda/serverless.yml
+++ b/atomic-docker/project/functions/ses-notification-lambda/serverless.yml
@@ -4,19 +4,19 @@ frameworkVersion: '3'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  # runtime: nodejs18.x # Removed: Runtime is defined by the Docker image
   stage: ${opt:stage, 'dev'}
   region: ${opt:region, 'us-east-1'}
 
-  environment:
+  environment: # Global environment variables, also available to the Docker container
     NODE_OPTIONS: --enable-source-maps
     AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
-    HASURA_GRAPHQL_ENDPOINT_URL: ${env:HASURA_GRAPHQL_ENDPOINT_URL, "http://host.docker.internal:8080/v1/graphql"} # Replace with your actual dev/prod Hasura URL via env vars
-    HASURA_ADMIN_SECRET_ARN: ${env:HASURA_ADMIN_SECRET_ARN} # e.g., arn:aws:secretsmanager:us-east-1:123456789012:secret:hasura/admin-secret-xxxxxx
-    SES_SENDER_EMAIL: ${env:SES_SENDER_EMAIL} # e.g., noreply@example.com
+    HASURA_GRAPHQL_ENDPOINT_URL: ${env:HASURA_GRAPHQL_ENDPOINT_URL, "http://host.docker.internal:8080/v1/graphql"}
+    HASURA_ADMIN_SECRET_ARN: ${env:HASURA_ADMIN_SECRET_ARN}
+    SES_SENDER_EMAIL: ${env:SES_SENDER_EMAIL}
     # LOG_LEVEL: ${env:LOG_LEVEL, "INFO"}
 
-  iam:
+  iam: # Global IAM role statements
     role:
       statements:
         - Effect: Allow
@@ -24,19 +24,34 @@ provider:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents
-          Resource: "arn:aws:logs:${aws:region}:${aws:accountId}:log-group:/aws/lambda/${self:service}-${self:provider.stage}-*:*"
+          Resource: "arn:aws:logs:${aws:region}:${aws:accountId}:log-group:/aws/lambda/${self:service}-${sls:stage}-*:*"
         - Effect: Allow
           Action:
             - ses:SendEmail
             - ses:SendRawEmail
-          Resource: "*" # For production, scope this down to specific SES identities (e.g., arn:aws:ses:us-east-1:123456789012:identity/example.com)
+          Resource: "*" # Scope down in production
         - Effect: Allow
           Action:
             - secretsmanager:GetSecretValue
-          Resource: ${env:HASURA_ADMIN_SECRET_ARN} # Ensures Lambda can fetch the Hasura admin secret
+          Resource: ${env:HASURA_ADMIN_SECRET_ARN}
+        # Permissions needed by Serverless Framework to manage ECR if it creates the repo
+        # These are for the *deploying IAM user/role*, not the Lambda execution role.
+        # However, sometimes people add ecr:GetAuthorizationToken to Lambda if it dynamically pulls images,
+        # but for this push-based model, it's mainly deploy-time permissions for the deployer.
+        # If Serverless Framework creates the ECR repo, the deployer needs:
+        # - ecr:CreateRepository
+        # - ecr:DescribeRepositories
+        # The Lambda execution role itself does not need ECR permissions to *run* from an image.
+
+  ecr: # ECR configuration for Docker image deployments
+    images:
+      sesnotificationlambdaimage: # Logical name for this image configuration
+        path: ./ # Path to the directory containing Dockerfile (root of this service)
+        # file: Dockerfile # Optional: if Dockerfile is named differently
+        # platform: linux/amd64 # Optional: specify platform if needed for cross-compilation builds
 
 custom:
-  esbuild:
+  esbuild: # serverless-esbuild will still build the JS code that goes INTO the Docker image
     bundle: true
     minify: true
     sourcemap: true # Recommended for dev, can be 'external' or false for prod to reduce package size
@@ -54,23 +69,27 @@ custom:
 
 plugins:
   - serverless-esbuild
-  - serverless-offline # Optional: for local HTTP server testing
-  # - serverless-iam-roles-per-function # Optional: for per-function IAM roles
+  - serverless-offline
+  # - serverless-iam-roles-per-function
 
 functions:
   sesNotificationHandler:
-    handler: src/index.handler # Path to file (src/index.ts -> .esbuild/.build/src/index.js) and exported function
-    name: ${self:service}-${sls:stage}-ses-notifier # Recommended: use ${sls:stage} for consistency
-    description: Sends scheduling result notifications via SES, triggered by Hasura.
-    # memorySize: 256 # Default: 1024 MB, uncomment to override
-    # timeout: 15 # Default: 6 seconds for AWS provider, uncomment to override
-    # iamRoleStatements: # Example for per-function IAM roles if plugin is used
-    #   - Effect: Allow
-    #     Action: [ ... ]
-    #     Resource: "..."
+    # handler: src/index.handler # Not needed when 'image' is specified
+                                 # The handler is specified by CMD in Dockerfile or Lambda config
+    name: ${self:service}-${sls:stage}-ses-notifier
+    description: Sends scheduling result notifications via SES (Docker image), triggered by Hasura.
+    # memorySize: 256
+    # timeout: 15
+    image:
+      name: sesnotificationlambdaimage # Refers to the logical image name in provider.ecr.images
+      # command: [ "src/index.handler" ] # Optional: Override CMD in Dockerfile. Format depends on base image.
+                                        # For AWS base images, this is often how you specify your handler.
+      # entryPoint: [ "/usr/bin/custom-entrypoint.sh" ] # Optional
+      # workingDirectory: "/var/task" # Optional
+
     events:
-      - httpApi: # AWS API Gateway HTTP API (v2) - simpler & cheaper
-          path: /hasura/event/ses-notification # This is the URL Hasura will call
+      - httpApi:
+          path: /hasura/event/ses-notification
           method: post
           # Example of securing HTTP API with a Lambda Authorizer (JWT or custom)
           # authorizer:


### PR DESCRIPTION
Provides the configuration and workflow for running and testing Dockerized AWS Lambda functions (created with Serverless Framework) within the local Docker Compose environment (`atomic-docker/project/docker-compose.yaml`).

Key additions and documentation:
- Defined a conceptual service block for adding a Lambda (e.g., `ses-notification-lambda-service`) to `docker-compose.yaml`. This includes:
  - Build context pointing to the Lambda's function directory.
  - Environment variables for local execution (Hasura internal URL, secrets, RIE handler).
  - Port mapping for direct RIE invocation from the host.
- Documented how to configure Hasura Event Trigger webhook URLs for local Docker network communication (e.g., `http://<lambda-service-name>:8080/2015-03-31/functions/function/invocations`), managed via environment variables.
- Outlined a local testing workflow, including `docker-compose up --build`, direct Lambda invocation via RIE with `curl`, and end-to-end testing through Hasura event triggers.