### PR TITLE
feat: Implement Smart Meeting Preparation skill

### DIFF
--- a/atomic-docker/project/functions/atom-agent/skills/productivitySkills.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/productivitySkills.ts
@@ -1,0 +1,218 @@
+// In atomic-docker/project/functions/atom-agent/skills/productivitySkills.ts
+import {
+  CalendarEvent,
+  PrepareForMeetingResponse,
+  MeetingPreparationData,
+  NotionPageContext,
+  EmailContext,
+  TaskContext,
+  Email, // Assuming Email type is defined for results from emailSkills
+  NotionTask, // Assuming NotionTask type is defined for results from notionAndResearchSkills
+  NotionSearchResultData, // Assuming this is what searchNotionRaw might return items as
+  SkillResponse, // Generic skill response
+} from '../../types'; // Adjust path as needed
+import { listUpcomingEvents } from './calendarSkills';
+import { queryNotionTasks, searchNotionRaw } from './notionAndResearchSkills'; // Assuming searchNotionRaw or similar exists
+import { searchEmailsNLU } from './emailSkills'; // Assuming searchEmailsNLU for targeted search; or use listRecentEmails with manual filtering
+// import { getCurrentUserId } from '../handler'; // Not needed if userId is passed directly
+
+const MAX_RESULTS_PER_CONTEXT = 3; // Max Notion pages, emails, tasks to show
+const EMAIL_SEARCH_DAYS_PRIOR = 7; // How many days back to search for emails
+
+// Helper to find the target meeting
+async function findTargetMeeting(
+  userId: string,
+  meetingIdentifier?: string,
+  meetingDateTime?: string // This could be a specific ISO string or a relative term like "tomorrow" handled by NLU/calendarSkill
+): Promise<CalendarEvent | null> {
+  // For simplicity, listUpcomingEvents might need to be enhanced or NLU should resolve meetingDateTime to a specific range
+  // For now, we assume listUpcomingEvents can take a start/end range or the NLU provides one.
+  // If meetingDateTime is a relative term, it should ideally be resolved to specific dates before this function.
+  // If meetingIdentifier is "next meeting", we take the first one.
+  // A more robust solution would involve better NLU parsing for date ranges and meeting name matching.
+
+  const events = await listUpcomingEvents(userId, 20); // Fetch more events to allow better filtering
+  if (!events || events.length === 0) {
+    return null;
+  }
+
+  let filteredEvents = events;
+
+  // Basic date filtering (example, needs robust date parsing for terms like "tomorrow")
+  if (meetingDateTime) {
+    // This is a placeholder. Real date parsing is complex.
+    // NLU should ideally provide a date range for meetingDateTime.
+    // For example, if meetingDateTime is "tomorrow", it resolves to tomorrow's date.
+    // const targetDate = new Date(meetingDateTime); // This is too naive for "tomorrow"
+    // filteredEvents = filteredEvents.filter(e => new Date(e.startTime).toDateString() === targetDate.toDateString());
+    console.warn(`[findTargetMeeting] Date/time based filtering for "${meetingDateTime}" is not fully implemented here. Relies on NLU or specific date.`)
+  }
+
+  if (meetingIdentifier && meetingIdentifier.toLowerCase() !== 'next meeting' && meetingIdentifier.toLowerCase() !== 'my next meeting') {
+    filteredEvents = filteredEvents.filter(e =>
+      e.summary.toLowerCase().includes(meetingIdentifier.toLowerCase()) ||
+      (e.attendees && e.attendees.some(a => a.email?.toLowerCase().includes(meetingIdentifier.toLowerCase()) || a.displayName?.toLowerCase().includes(meetingIdentifier.toLowerCase())))
+    );
+  }
+
+  if (filteredEvents.length === 0) {
+    return null;
+  }
+
+  // Sort by start time to get the "next" one if multiple match or if "next meeting" was specified
+  return filteredEvents.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())[0];
+}
+
+
+export async function handlePrepareForMeeting(
+  userId: string,
+  meetingIdentifier?: string,
+  meetingDateTime?: string
+): Promise<PrepareForMeetingResponse> {
+  console.log(`[handlePrepareForMeeting] User: ${userId}, Meeting ID: "${meetingIdentifier}", DateTime: "${meetingDateTime}"`);
+  const targetMeeting = await findTargetMeeting(userId, meetingIdentifier, meetingDateTime);
+
+  if (!targetMeeting) {
+    console.log(`[handlePrepareForMeeting] No target meeting found.`);
+    return {
+      ok: false,
+      error: { code: "MEETING_NOT_FOUND", message: "Could not find the specified meeting." },
+    };
+  }
+  console.log(`[handlePrepareForMeeting] Target meeting found: "${targetMeeting.summary}" at ${targetMeeting.startTime}`);
+
+  const preparationData: MeetingPreparationData = { targetMeeting };
+  let accumulatedErrorMessages = "";
+
+  const meetingKeywordsArray = [targetMeeting.summary];
+  if (targetMeeting.description) {
+    meetingKeywordsArray.push(...targetMeeting.description.split(' ').slice(0, 10)); // Add some keywords from description
+  }
+  targetMeeting.attendees?.forEach(attendee => {
+    if (attendee.displayName) meetingKeywordsArray.push(attendee.displayName);
+    // if (attendee.email) meetingKeywordsArray.push(attendee.email.split('@')[0]); // Add username part of email
+  });
+  const meetingKeywords = meetingKeywordsArray.join(' '); // Create a keyword string for searches
+
+  // 1. Gather Notion Context
+  try {
+    // searchNotionRaw is expected to be a function that takes a user ID and a query string.
+    // The actual implementation of searchNotionRaw might involve calling a Python service.
+    const notionQuery = `content related to: ${targetMeeting.summary}`; // Simple query
+    console.log(`[handlePrepareForMeeting] Querying Notion with: "${notionQuery}"`);
+    const notionSearchResponse = await searchNotionRaw(userId, notionQuery, MAX_RESULTS_PER_CONTEXT);
+
+    // Assuming searchNotionRaw returns a structure like: PythonApiResponse<NotionSearchResultData[]>
+    if (notionSearchResponse && notionSearchResponse.ok && notionSearchResponse.data) {
+      preparationData.relatedNotionPages = notionSearchResponse.data.map((p: NotionSearchResultData) => ({
+        id: p.id,
+        title: p.title || p.properties?.title?.title?.[0]?.plain_text || 'Untitled Notion Page',
+        url: p.url || (p.properties?.URL?.url),
+        briefSnippet: p.content_preview || p.content?.substring(0, 150) || (p.properties?.Description?.rich_text?.[0]?.plain_text.substring(0,150)),
+      })).slice(0, MAX_RESULTS_PER_CONTEXT);
+      console.log(`[handlePrepareForMeeting] Found ${preparationData.relatedNotionPages?.length || 0} Notion pages.`);
+    } else if (notionSearchResponse && !notionSearchResponse.ok) {
+        console.warn(`[handlePrepareForMeeting] Notion search failed: ${notionSearchResponse.error?.message}`);
+        accumulatedErrorMessages += `Could not fetch Notion documents: ${notionSearchResponse.error?.message}. `;
+    } else {
+        console.log(`[handlePrepareForMeeting] No Notion pages found or unexpected response format from searchNotionRaw.`);
+    }
+  } catch (e: any) {
+    console.error('[handlePrepareForMeeting] Error fetching Notion context:', e.message, e.stack);
+    accumulatedErrorMessages += 'Error occurred while fetching Notion documents. ';
+  }
+
+  // 2. Gather Email Context
+  try {
+    const toDate = new Date();
+    const fromDate = new Date();
+    fromDate.setDate(toDate.getDate() - EMAIL_SEARCH_DAYS_PRIOR);
+
+    // Construct a query for searchEmailsNLU. This may need refinement based on NLU capabilities.
+    // For now, make it somewhat structured if searchEmailsNLU is a passthrough to an API.
+    let emailQueryParts = [`about "${targetMeeting.summary}"`];
+    if (targetMeeting.attendees && targetMeeting.attendees.length > 0) {
+      const attendeeEmails = targetMeeting.attendees.map(a => a.email).filter(Boolean).join(' OR ');
+      if (attendeeEmails) {
+        emailQueryParts.push(`with attendees (${attendeeEmails})`);
+      }
+    }
+    emailQueryParts.push(`between ${fromDate.toISOString().split('T')[0]} and ${toDate.toISOString().split('T')[0]}`);
+    const emailQuery = emailQueryParts.join(' ');
+
+    console.log(`[handlePrepareForMeeting] Querying Emails with: "${emailQuery}"`);
+    // searchEmailsNLU should ideally handle parsing this query or accept structured input.
+    const emailsResponse: SkillResponse<Email[]> = await searchEmailsNLU(userId, emailQuery, MAX_RESULTS_PER_CONTEXT);
+
+    if (emailsResponse && emailsResponse.ok && emailsResponse.data) {
+      preparationData.relatedEmails = emailsResponse.data.map((email: Email) => ({
+        id: email.id,
+        subject: email.subject,
+        sender: email.sender,
+        receivedDate: email.timestamp, // Assuming Email.timestamp is ISO string
+        // url: email.webLink, // If available on your Email type
+        briefSnippet: email.body?.substring(0, 150) + (email.body && email.body.length > 150 ? '...' : ''),
+      })).slice(0, MAX_RESULTS_PER_CONTEXT);
+      console.log(`[handlePrepareForMeeting] Found ${preparationData.relatedEmails?.length || 0} emails.`);
+    } else if (emailsResponse && !emailsResponse.ok) {
+        console.warn(`[handlePrepareForMeeting] Email search failed: ${emailsResponse.error?.message}`);
+        accumulatedErrorMessages += `Could not fetch relevant emails: ${emailsResponse.error?.message}. `;
+    } else {
+        console.log(`[handlePrepareForMeeting] No emails found or unexpected response format from email search.`);
+    }
+  } catch (e: any) {
+    console.error('[handlePrepareForMeeting] Error fetching Email context:', e.message, e.stack);
+    accumulatedErrorMessages += 'Error occurred while fetching relevant emails. ';
+  }
+
+  // 3. Gather Task Context
+  try {
+    const notionTasksDbId = process.env.ATOM_NOTION_TASKS_DATABASE_ID;
+    if (!notionTasksDbId) {
+        console.warn('[handlePrepareForMeeting] ATOM_NOTION_TASKS_DATABASE_ID is not set. Skipping task search.');
+        accumulatedErrorMessages += 'Notion tasks database ID not configured. ';
+    } else {
+        const taskQueryParams = {
+            descriptionContains: targetMeeting.summary, // Basic search
+            status_not_equals: 'Done' as any, // Assuming 'Done' is a status to exclude
+            limit: MAX_RESULTS_PER_CONTEXT,
+            notionTasksDbId: notionTasksDbId,
+        };
+        console.log(`[handlePrepareForMeeting] Querying Tasks with params:`, taskQueryParams);
+        const tasksResponse = await queryNotionTasks(userId, taskQueryParams); // queryNotionTasks from notionAndResearchSkills
+
+        if (tasksResponse.success && tasksResponse.tasks) {
+            preparationData.relatedTasks = tasksResponse.tasks.map((task: NotionTask) => ({
+                id: task.id,
+                description: task.description,
+                dueDate: task.dueDate,
+                status: task.status,
+                url: task.url,
+            })).slice(0, MAX_RESULTS_PER_CONTEXT);
+            console.log(`[handlePrepareForMeeting] Found ${preparationData.relatedTasks?.length || 0} tasks.`);
+        } else if (!tasksResponse.success) {
+            console.warn(`[handlePrepareForMeeting] Task query failed: ${tasksResponse.error}`);
+            accumulatedErrorMessages += `Could not fetch related tasks: ${tasksResponse.error}. `;
+        } else {
+             console.log(`[handlePrepareForMeeting] No tasks found or unexpected response from task query.`);
+        }
+    }
+  } catch (e: any) {
+    console.error('[handlePrepareForMeeting] Error fetching Task context:', e.message, e.stack);
+    accumulatedErrorMessages += 'Error occurred while fetching related tasks. ';
+  }
+
+  // 4. (Stretch Goal) Key points from last meeting - Placeholder for V1
+  // preparationData.keyPointsFromLastMeeting = "Example: Decision X was made, Action Item Y was assigned.";
+
+  if (accumulatedErrorMessages) {
+      preparationData.errorMessage = accumulatedErrorMessages.trim();
+  }
+
+  console.log(`[handlePrepareForMeeting] Preparation data compiled:`, JSON.stringify(preparationData).substring(0,500) + "...");
+
+  return {
+    ok: true,
+    data: preparationData,
+  };
+}

--- a/atomic-docker/project/functions/atom-agent/skills/tests/productivitySkills.test.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/tests/productivitySkills.test.ts
@@ -1,0 +1,206 @@
+// Test file for productivitySkills.ts
+
+import { handlePrepareForMeeting } from '../productivitySkills';
+// Import findTargetMeeting if it's exported and needs direct testing,
+// otherwise it's tested via handlePrepareForMeeting.
+// For this example, let's assume findTargetMeeting is not directly exported for testing.
+
+import * as calendarSkills from '../calendarSkills';
+import * as notionSkills from '../notionAndResearchSkills';
+import * as emailSkills from '../emailSkills';
+import {
+  CalendarEvent,
+  PrepareForMeetingResponse,
+  NotionPageContext,
+  EmailContext,
+  TaskContext,
+  MeetingPreparationData,
+  NotionTask,
+  Email,
+  NotionSearchResultData,
+  SkillResponse,
+  TaskQueryResponse,
+} from '../../../types';
+
+// Mocking the dependent skill modules
+jest.mock('../calendarSkills');
+jest.mock('../notionAndResearchSkills');
+jest.mock('../emailSkills');
+
+const mockListUpcomingEvents = calendarSkills.listUpcomingEvents as jest.MockedFunction<typeof calendarSkills.listUpcomingEvents>;
+const mockSearchNotionRaw = notionSkills.searchNotionRaw as jest.MockedFunction<typeof notionSkills.searchNotionRaw>;
+const mockQueryNotionTasks = notionSkills.queryNotionTasks as jest.MockedFunction<typeof notionSkills.queryNotionTasks>;
+const mockSearchEmailsNLU = emailSkills.searchEmailsNLU as jest.MockedFunction<typeof emailSkills.searchEmailsNLU>;
+
+describe('productivitySkills', () => {
+  const mockUserId = 'test-user-123';
+  const mockNotionTasksDbId = 'mock-notion-db-id';
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    mockListUpcomingEvents.mockReset();
+    mockSearchNotionRaw.mockReset();
+    mockQueryNotionTasks.mockReset();
+    mockSearchEmailsNLU.mockReset();
+
+    // Setup default successful responses for mocks (can be overridden in specific tests)
+    mockListUpcomingEvents.mockResolvedValue([]);
+    mockSearchNotionRaw.mockResolvedValue({ ok: true, data: [] });
+    mockQueryNotionTasks.mockResolvedValue({ success: true, tasks: [], message: 'Tasks fetched' });
+    mockSearchEmailsNLU.mockResolvedValue({ ok: true, data: [] });
+
+    // Mock process.env
+    process.env.ATOM_NOTION_TASKS_DATABASE_ID = mockNotionTasksDbId;
+  });
+
+  afterEach(() => {
+    delete process.env.ATOM_NOTION_TASKS_DATABASE_ID;
+  });
+
+  describe('handlePrepareForMeeting', () => {
+    const upcomingEvent1: CalendarEvent = {
+      id: 'event1',
+      summary: 'Team Sync Q3 Planning',
+      startTime: new Date(Date.now() + 1000 * 60 * 60).toISOString(), // In 1 hour
+      endTime: new Date(Date.now() + 1000 * 60 * 120).toISOString(), // In 2 hours
+      attendees: [{ email: 'user1@example.com', displayName: 'User One' }, { email: 'user2@example.com' }],
+      description: 'Discuss Q3 goals and roadmap',
+    };
+    const upcomingEvent2: CalendarEvent = {
+      id: 'event2',
+      summary: 'Client Call - Project Alpha',
+      startTime: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(), // Tomorrow
+      endTime: new Date(Date.now() + 1000 * 60 * 60 * 25).toISOString(),
+      attendees: [{ email: 'client@example.com', displayName: 'Client Contact' }],
+    };
+
+    it('should return MEETING_NOT_FOUND if no meeting matches the identifier', async () => {
+      mockListUpcomingEvents.mockResolvedValue([upcomingEvent1]);
+      const response = await handlePrepareForMeeting(mockUserId, 'NonExistent Meeting');
+      expect(response.ok).toBe(false);
+      expect(response.error?.code).toBe('MEETING_NOT_FOUND');
+      expect(response.error?.message).toContain('Could not find the specified meeting');
+    });
+
+    it('should return MEETING_NOT_FOUND if listUpcomingEvents returns no events', async () => {
+      mockListUpcomingEvents.mockResolvedValue([]);
+      const response = await handlePrepareForMeeting(mockUserId, 'Any Meeting');
+      expect(response.ok).toBe(false);
+      expect(response.error?.code).toBe('MEETING_NOT_FOUND');
+    });
+
+    it('should pick the next upcoming meeting if identifier is "next meeting"', async () => {
+      mockListUpcomingEvents.mockResolvedValue([upcomingEvent1, upcomingEvent2].sort((a,b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()));
+      const response = await handlePrepareForMeeting(mockUserId, 'next meeting');
+      expect(response.ok).toBe(true);
+      expect(response.data?.targetMeeting.id).toBe(upcomingEvent1.id);
+    });
+
+    it('should pick the next upcoming meeting if no identifier is provided', async () => {
+        mockListUpcomingEvents.mockResolvedValue([upcomingEvent1, upcomingEvent2].sort((a,b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()));
+        const response = await handlePrepareForMeeting(mockUserId); // No identifier
+        expect(response.ok).toBe(true);
+        expect(response.data?.targetMeeting.id).toBe(upcomingEvent1.id);
+      });
+
+    it('should successfully prepare for a meeting with data from all sources', async () => {
+      mockListUpcomingEvents.mockResolvedValue([upcomingEvent1]);
+
+      const mockNotionPages: NotionSearchResultData[] = [
+        { id: 'notion1', title: 'Q3 Planning Notes', url: 'http://notion.so/q3planning', content_preview: 'Key points from last sync...' },
+      ];
+      mockSearchNotionRaw.mockResolvedValue({ ok: true, data: mockNotionPages });
+
+      const mockEmails: Email[] = [
+        { id: 'email1', subject: 'Prep for Q3 Sync', sender: 'user1@example.com', recipient: '', body: 'See attached doc', timestamp: new Date().toISOString(), read: false },
+      ];
+      mockSearchEmailsNLU.mockResolvedValue({ ok: true, data: mockEmails });
+
+      const mockTasks: NotionTask[] = [
+        { id: 'task1', description: 'Draft Q3 roadmap', dueDate: '2024-08-01', status: 'In Progress', createdDate: '', url: 'http://notion.so/task1' },
+      ];
+      mockQueryNotionTasks.mockResolvedValue({ success: true, tasks: mockTasks });
+
+      const response = await handlePrepareForMeeting(mockUserId, 'Team Sync Q3 Planning');
+
+      expect(response.ok).toBe(true);
+      expect(response.data?.targetMeeting.id).toBe(upcomingEvent1.id);
+      expect(response.data?.relatedNotionPages).toHaveLength(1);
+      expect(response.data?.relatedNotionPages?.[0].title).toBe('Q3 Planning Notes');
+      expect(response.data?.relatedEmails).toHaveLength(1);
+      expect(response.data?.relatedEmails?.[0].subject).toBe('Prep for Q3 Sync');
+      expect(response.data?.relatedTasks).toHaveLength(1);
+      expect(response.data?.relatedTasks?.[0].description).toBe('Draft Q3 roadmap');
+      expect(response.data?.errorMessage).toBeFalsy();
+    });
+
+    it('should handle cases where some data sources return no results', async () => {
+      mockListUpcomingEvents.mockResolvedValue([upcomingEvent1]);
+      mockSearchNotionRaw.mockResolvedValue({ ok: true, data: [] }); // No Notion pages
+      mockSearchEmailsNLU.mockResolvedValue({ ok: true, data: [] });   // No Emails
+      // Tasks will be fetched by default mock (empty array)
+
+      const response = await handlePrepareForMeeting(mockUserId, 'Team Sync Q3 Planning');
+      expect(response.ok).toBe(true);
+      expect(response.data?.targetMeeting.id).toBe(upcomingEvent1.id);
+      expect(response.data?.relatedNotionPages).toHaveLength(0);
+      expect(response.data?.relatedEmails).toHaveLength(0);
+      expect(response.data?.relatedTasks).toHaveLength(0);
+      expect(response.data?.errorMessage).toBeFalsy(); // Not an error, just no data
+    });
+
+    it('should include error messages if a data source fetch fails, but still return overall OK with partial data', async () => {
+      mockListUpcomingEvents.mockResolvedValue([upcomingEvent1]);
+      mockSearchNotionRaw.mockResolvedValue({ ok: false, error: { code: 'NOTION_API_ERROR', message: 'Notion API timeout' } });
+
+      const mockEmails: Email[] = [
+        { id: 'email1', subject: 'Prep for Q3 Sync', sender: 'user1@example.com', recipient: '', body: 'See attached doc', timestamp: new Date().toISOString(), read: false },
+      ];
+      mockSearchEmailsNLU.mockResolvedValue({ ok: true, data: mockEmails });
+      // Tasks will be fetched by default mock (empty array)
+
+      const response = await handlePrepareForMeeting(mockUserId, 'Team Sync Q3 Planning');
+      expect(response.ok).toBe(true); // Overall skill is ok, but with partial data
+      expect(response.data?.targetMeeting.id).toBe(upcomingEvent1.id);
+      expect(response.data?.relatedNotionPages).toBeUndefined(); // Or empty array, depending on implementation
+      expect(response.data?.relatedEmails).toHaveLength(1);
+      expect(response.data?.errorMessage).toContain('Could not fetch Notion documents: Notion API timeout.');
+    });
+
+    it('should handle ATOM_NOTION_TASKS_DATABASE_ID not being set', async () => {
+        delete process.env.ATOM_NOTION_TASKS_DATABASE_ID; // Unset the env var
+        mockListUpcomingEvents.mockResolvedValue([upcomingEvent1]);
+        // Other mocks as default (empty results)
+
+        const response = await handlePrepareForMeeting(mockUserId, 'Team Sync Q3 Planning');
+        expect(response.ok).toBe(true);
+        expect(response.data?.targetMeeting.id).toBe(upcomingEvent1.id);
+        expect(response.data?.relatedTasks).toBeUndefined(); // Or empty array
+        expect(response.data?.errorMessage).toContain('Notion tasks database ID not configured.');
+
+        process.env.ATOM_NOTION_TASKS_DATABASE_ID = mockNotionTasksDbId; // Reset for other tests
+    });
+
+    it('should limit the number of results for each context type to MAX_RESULTS_PER_CONTEXT', async () => {
+        mockListUpcomingEvents.mockResolvedValue([upcomingEvent1]);
+
+        const manyNotionPages: NotionSearchResultData[] = Array(5).fill(null).map((_, i) => ({ id: `notion${i}`, title: `Page ${i}` }));
+        mockSearchNotionRaw.mockResolvedValue({ ok: true, data: manyNotionPages });
+
+        const manyEmails: Email[] = Array(5).fill(null).map((_, i) => ({ id: `email${i}`, subject: `Email ${i}`, sender: '', recipient: '', body: '', timestamp: '', read: false }));
+        mockSearchEmailsNLU.mockResolvedValue({ ok: true, data: manyEmails });
+
+        const manyTasks: NotionTask[] = Array(5).fill(null).map((_, i) => ({ id: `task${i}`, description: `Task ${i}`, status: 'To Do', createdDate: '', url: '' }));
+        mockQueryNotionTasks.mockResolvedValue({ success: true, tasks: manyTasks });
+
+
+        const response = await handlePrepareForMeeting(mockUserId, 'Team Sync Q3 Planning');
+        expect(response.ok).toBe(true);
+        // MAX_RESULTS_PER_CONTEXT is 3 in productivitySkills.ts
+        expect(response.data?.relatedNotionPages).toHaveLength(3);
+        expect(response.data?.relatedEmails).toHaveLength(3);
+        expect(response.data?.relatedTasks).toHaveLength(3);
+    });
+
+  });
+});

--- a/atomic-docker/project/functions/atom-agent/types.ts
+++ b/atomic-docker/project/functions/atom-agent/types.ts
@@ -811,3 +811,47 @@ export interface UserAvailability {
   workTimes: UserWorkTime[];
   calendarEvents: CalendarEvent[]; // Existing events in the queried window
 }
+
+// --- Smart Meeting Preparation Types ---
+export interface NotionPageContext {
+  id: string;
+  title: string;
+  url?: string; // Notion page URL
+  briefSnippet?: string; // A short relevant snippet from the page content
+}
+
+export interface EmailContext {
+  id: string; // Email message ID
+  subject: string;
+  sender?: string; // Sender's email or name
+  receivedDate?: string; // ISO 8601 string
+  url?: string; // URL to view the email if available (e.g., Gmail link)
+  briefSnippet?: string; // Short snippet from the email body
+}
+
+export interface TaskContext {
+  id: string; // Notion Task Page ID
+  description: string;
+  dueDate?: string | null; // ISO date string or null
+  status?: NotionTaskStatus;
+  url?: string; // URL to the Notion task page
+}
+
+export interface MeetingPreparationData {
+  targetMeeting: CalendarEvent; // The meeting being prepared for
+  relatedNotionPages?: NotionPageContext[];
+  relatedEmails?: EmailContext[];
+  relatedTasks?: TaskContext[];
+  keyPointsFromLastMeeting?: string; // Optional: summary from previous similar meeting
+  errorMessage?: string; // If preparation is partial or fails (e.g., "Could not fetch Notion documents.")
+}
+
+// Response for the PrepareForMeeting skill
+export interface PrepareForMeetingResponse extends SkillResponse<MeetingPreparationData> {}
+
+// NLU Entities expected for the PrepareForMeeting intent
+export interface PrepareForMeetingEntities {
+  meeting_identifier?: string; // e.g., "Project Alpha discussion", "next meeting", "call with John"
+  meeting_date_time?: string; // e.g., "tomorrow", "2024-07-15T14:00:00Z", "next Monday at 3pm"
+  // Future: could include specific attendees to focus on, or types of info (e.g., "only show tasks")
+}


### PR DESCRIPTION
This commit introduces the 'Smart Meeting Preparation' skill for the Atom Agent.

Features:
- New `PrepareForMeeting` intent that allows users to request a briefing for an upcoming meeting.
- The skill gathers context from:
    - Notion (related documents and notes)
    - Emails (recent relevant correspondence)
    - Notion Tasks (open related tasks)
- Provides a consolidated summary to the user, including snippets and links where available.
- Handles partial data retrieval gracefully if some sources are unavailable or return errors.

Implementation Details:
- Added new data types (`NotionPageContext`, `EmailContext`, `TaskContext`, `MeetingPreparationData`, etc.) to `types.ts`.
- Created `skills/productivitySkills.ts` containing the core logic for `handlePrepareForMeeting` and the `findTargetMeeting` helper.
- Integrated the new skill into `handler.ts` with a new case for the `PrepareForMeeting` intent and response formatting.
- Included NLU guidance (in plan/documentation) for recognizing the intent and extracting entities (`meeting_identifier`, `meeting_date_time`).
- Outlined conceptual unit tests in `skills/tests/productivitySkills.test.ts` covering various scenarios.

Assumptions for V1:
- Relies on existing or to-be-enhanced capabilities of `searchNotionRaw` and `searchEmailsNLU` for effective information retrieval.
- Basic meeting identification logic; advanced semantic matching or disambiguation is a future enhancement.
- Summarization of past meeting notes is a placeholder for future LLM integration.