### PR TITLE
feat: Implement Automated Weekly Digest skill

### DIFF
--- a/atomic-docker/project/functions/atom-agent/types.ts
+++ b/atomic-docker/project/functions/atom-agent/types.ts
@@ -855,3 +855,26 @@ export interface PrepareForMeetingEntities {
   meeting_date_time?: string; // e.g., "tomorrow", "2024-07-15T14:00:00Z", "next Monday at 3pm"
   // Future: could include specific attendees to focus on, or types of info (e.g., "only show tasks")
 }
+
+// --- Automated Weekly Digest Types ---
+export interface WeeklyDigestData {
+  periodStart: string; // ISO Date string
+  periodEnd: string; // ISO Date string
+  completedTasks: NotionTask[]; // Using existing NotionTask type
+  attendedMeetings: CalendarEvent[]; // Using existing CalendarEvent type
+  // For attendedMeetings, consider adding a briefOutcome?: string if V2 summarization is done
+  upcomingCriticalTasks: NotionTask[];
+  upcomingCriticalMeetings: CalendarEvent[];
+  errorMessage?: string;
+}
+
+// Response for the GenerateWeeklyDigest skill
+export interface GenerateWeeklyDigestResponse extends SkillResponse<{
+  digest: WeeklyDigestData;
+  formattedSummary: string; // The user-facing text summary
+}> {}
+
+// NLU Entities expected for the GenerateWeeklyDigest intent
+export interface GenerateWeeklyDigestEntities {
+  time_period?: "this week" | "last week" | string; // Allow specific date ranges in future if NLU supports
+}


### PR DESCRIPTION
This commit introduces the 'Automated Weekly Digest' skill to the Atom Agent.

Features:
- New `GenerateWeeklyDigest` intent allowing users to request a summary of their weekly activities and upcoming items.
- The skill can be triggered on-demand (e.g., "what's my weekly digest?") or scheduled.
- It gathers information for a specified period ("this week" or "last week") including:
    - Completed Notion tasks (approximated by 'Done' status and recent edits).
    - Key calendar meetings attended (filtered for significance).
    - Upcoming critical Notion tasks for the next period.
    - Upcoming significant calendar meetings for the next period.
- Provides data for a structured digest, with detailed formatting handled by the agent handler.

Implementation Details:
- Added new data types (`WeeklyDigestData`, `GenerateWeeklyDigestResponse`, `GenerateWeeklyDigestEntities`) to `types.ts`.
- Implemented `determineDateRange` helper and `handleGenerateWeeklyDigest` skill function in `skills/productivitySkills.ts`.
- Integrated the new skill into `handler.ts` with a new case for `GenerateWeeklyDigest` and logic to format the digest data into a user-friendly string.
- Included NLU guidance (in plan/documentation) for the `GenerateWeeklyDigest` intent and `time_period` entity.
- Updated conceptual unit tests in `skills/tests/productivitySkills.test.ts` to cover the new digest functionality and date calculations.

Notes for V1:
- Filtering Notion tasks by actual completion date is approximated using 'Done' status and last edit times. Future versions could improve this with dedicated 'Completed At' fields.
- Criteria for 'significant' meetings/tasks are currently basic (e.g., duration, priority) and can be enhanced later.