### PR TITLE
feat: Implement In-Person Audio Notes (Agent-Activated)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -50,9 +50,18 @@ Atom now offers comprehensive voice-powered task management, using a dedicated N
 
 ### Integrated Note-Taking & Research
 Keep your knowledge organized and accessible with Atom's integrated capabilities:
-*   **Note-Taking (Notion & Audio):** Create text and audio notes directly. Audio notes are automatically transcribed (e.g., using Deepgram) and saved, typically within Notion. Your notes can be searched, updated, and linked to tasks or calendar events.
+*   **Note-Taking (Notion & Audio):** Create text notes directly. Audio notes can be generated from existing audio files (e.g., via URL) or by recording directly within Atom for in-person meetings (see below). All audio notes are automatically transcribed (e.g., using Deepgram), summarized (using OpenAI), and saved into Notion. Your notes can be searched, updated, and linked to tasks or calendar events.
+*   **In-Person Meeting Audio Notes (Agent-Activated):**
+    *   **Agent-Controlled Recording:** Users can ask the Atom agent (via voice or text commands like "Atom, start an audio note" or "Record my meeting discussion") to begin recording audio using their device's microphone. The agent can also be commanded to stop or cancel the recording.
+    *   **Direct Microphone Capture:** This feature is designed for capturing discussions in physical meetings, personal voice memos, or any scenario where direct microphone input is needed.
+    *   **Automated Processing:** Once the recording is stopped, the captured audio is automatically:
+        *   Transcribed using Deepgram.
+        *   Summarized by an AI model (e.g., OpenAI GPT) to extract key points, decisions, and action items.
+        *   Saved as a new note in the user's configured Notion database, including the transcript, summary, and optionally a link to the raw audio file.
+    *   **UI Feedback:** The client application provides UI feedback for recording status (e.g., "Recording...", "Processing...") when initiated or controlled by the agent.
+    *   **Manual UI Recording:** A dedicated UI (e.g., an `AudioRecorder` component) also allows users to manually initiate, stop, and save microphone recordings directly without agent interaction.
 *   **Multi-Agent Research System (Notion & LanceDB):** Initiate research projects based on simple queries. A lead AI agent decomposes your query into sub-tasks and assigns them to specialized sub-agents. These agents perform research (e.g., web searches, internal Notion searches using LanceDB for vector-based information retrieval) and log their findings in a dedicated Notion database. The lead agent then synthesizes this information into a comprehensive final report, also in Notion.
-*   **Python API for Notes & Research:** Backend handlers and APIs for managing notes and research processes programmatically.
+*   **Python API for Notes & Research:** Backend handlers and APIs for managing notes and research processes programmatically, including endpoints for handling direct audio uploads and processing.
 *   **Searchable Meeting Archive (Semantic Search):**
     *   Unlock the knowledge in your past meetings. Transcripts stored in Notion (e.g., from live meeting processing or other sources) can be automatically converted into vector embeddings using AI models (like OpenAI).
     *   These embeddings are stored in a LanceDB vector database, enabling powerful semantic search capabilities.

--- a/atomic-docker/app_build_docker/components/Audio/AudioRecorder.tsx
+++ b/atomic-docker/app_build_docker/components/Audio/AudioRecorder.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { useAgentAudioControl, AgentAudioCommand } from '../../contexts/AgentAudioControlContext'; // Adjusted path
 
 // Placeholder Icons (replace with your actual icon components)
 const MicIcon = () => <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 14c1.66 0 2.99-1.34 2.99-3L15 5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3zm5.3-3c0 3-2.54 5.1-5.3 5.1S6.7 14 6.7 11H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28c3.28-.48 6-3.3 6-6.72h-1.7z"/></svg>;
@@ -7,28 +8,29 @@ const CancelIcon = () => <svg xmlns="http://www.w3.org/2000/svg" height="24px" v
 
 interface AudioRecorderProps {
   userId: string;
-  linkedEventId?: string;
-  suggestedTitle?: string;
+  // linkedEventId is now primarily set via agent command payload or if component is used in a specific event context
+  initialLinkedEventId?: string;
+  initialSuggestedTitle?: string; // Renamed from suggestedTitle to initialSuggestedTitle for clarity
   onRecordingComplete: (notionPageUrl: string, title: string, summaryPreview?: string) => void;
   onRecordingError: (errorMessage: string) => void;
-  // Example: how an agent command might be passed (for Phase 2)
-  // agentCommand?: { type: 'INITIATE_RECORDING'; payload: { suggestedTitle?: string; linkedEventId?: string } };
-  // clearAgentCommand?: () => void;
+  // This component will now primarily be controlled by agent commands via context,
+  // but can also be used standalone (user clicks record button).
 }
 
 type RecordingStatus = 'idle' | 'permissionPending' | 'recording' | 'stopped' | 'uploading' | 'error';
 
-const PROCESS_AUDIO_NOTE_ENDPOINT = "/api/process-recorded-audio-note"; // Ensure this is correct
+const PROCESS_AUDIO_NOTE_ENDPOINT = "/api/process-recorded-audio-note";
 
 const AudioRecorder: React.FC<AudioRecorderProps> = ({
   userId,
-  linkedEventId,
-  suggestedTitle,
+  initialLinkedEventId,
+  initialSuggestedTitle,
   onRecordingComplete,
   onRecordingError,
 }) => {
   const [status, setStatus] = useState<RecordingStatus>('idle');
-  const [noteTitle, setNoteTitle] = useState<string>('');
+  const [noteTitle, setNoteTitle] = useState<string>(initialSuggestedTitle || '');
+  const [currentLinkedEventId, setCurrentLinkedEventId] = useState<string | undefined>(initialLinkedEventId);
   const [elapsedTime, setElapsedTime] = useState<number>(0);
   const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
   const [audioBlob, setAudioBlob] = useState<Blob | undefined>(undefined);
@@ -39,11 +41,14 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
   const timerIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const actualMimeTypeRef = useRef<string>('');
 
+  // Consume Agent Audio Control Context
+  const { latestCommand, clearLastCommand } = useAgentAudioControl();
+
   useEffect(() => {
-    if (suggestedTitle && status === 'idle') {
-      setNoteTitle(suggestedTitle);
+    if (initialSuggestedTitle && status === 'idle') {
+      setNoteTitle(initialSuggestedTitle);
     }
-  }, [suggestedTitle, status]);
+  }, [initialSuggestedTitle, status]);
 
   const formatTime = (timeInSeconds: number): string => {
     const minutes = Math.floor(timeInSeconds / 60).toString().padStart(2, '0');
@@ -51,7 +56,7 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
     return `${minutes}:${seconds}`;
   };
 
-  const cleanupRecordingResources = useCallback(() => {
+  const cleanupRecordingResources = useCallback((preserveTitleOnError = false) => {
     if (timerIntervalRef.current) {
       clearInterval(timerIntervalRef.current);
       timerIntervalRef.current = null;
@@ -60,32 +65,41 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
       streamRef.current.getTracks().forEach(track => track.stop());
       streamRef.current = null;
     }
-    if (mediaRecorderRef.current && (mediaRecorderRef.current.state === 'recording' || mediaRecorderRef.current.state === 'inactive')) {
-        // Detach event handlers before setting to null to prevent memory leaks
+    if (mediaRecorderRef.current) {
         mediaRecorderRef.current.ondataavailable = null;
         mediaRecorderRef.current.onstop = null;
         mediaRecorderRef.current.onerror = null;
-        if(mediaRecorderRef.current.state === 'recording') {
-            mediaRecorderRef.current.stop();
+        if (mediaRecorderRef.current.state === 'recording') {
+            try { mediaRecorderRef.current.stop(); } catch (e) { console.warn("Error stopping MediaRecorder during cleanup:", e); }
         }
     }
     mediaRecorderRef.current = null;
     audioChunksRef.current = [];
-  }, []);
+    if (!preserveTitleOnError) { // Only reset title if not preserving on error
+        setNoteTitle(initialSuggestedTitle || ''); // Reset to initial or empty
+    }
+  }, [initialSuggestedTitle]);
 
 
   useEffect(() => {
-    return () => { // Cleanup on component unmount
+    return () => {
       cleanupRecordingResources();
     };
   }, [cleanupRecordingResources]);
 
-
-  const handleStartRecord = async () => {
+  // Abstracted start recording logic to be callable by user action or agent command
+  const startRecordingSession = useCallback(async (titleFromCommand?: string, eventIdFromCommand?: string) => {
+    if (status !== 'idle' && status !== 'error') {
+        console.warn("Recording session cannot start, current status:", status);
+        return; // Don't start if already busy, unless it's an error state we want to override
+    }
     setStatus('permissionPending');
     setErrorMessage(undefined);
     setAudioBlob(undefined);
     audioChunksRef.current = [];
+    if (titleFromCommand) setNoteTitle(titleFromCommand);
+    if (eventIdFromCommand) setCurrentLinkedEventId(eventIdFromCommand);
+
 
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
       const errorMsg = "Microphone access is not supported by your browser.";
@@ -105,7 +119,7 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
       } else if (MediaRecorder.isTypeSupported('audio/wav')) {
         actualMimeTypeRef.current = 'audio/wav';
       } else {
-        actualMimeTypeRef.current = ''; // Browser default
+        actualMimeTypeRef.current = '';
       }
       console.log("Using MIME type:", actualMimeTypeRef.current);
 
@@ -121,18 +135,23 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
       recorder.onstop = () => {
         const completeBlob = new Blob(audioChunksRef.current, { type: actualMimeTypeRef.current || audioChunksRef.current[0]?.type || 'application/octet-stream' });
         setAudioBlob(completeBlob);
-        setStatus('stopped');
-        cleanupRecordingResources(); // Stop tracks and timer
+        setStatus('stopped'); // This will trigger the useEffect for upload
+        // Cleanup is now part of the onstop logic before setting status to 'stopped' or handled by it.
+        // No, cleanup should happen *after* blob is formed and set, or when explicitly cancelled.
+        // Let's ensure cleanup happens after blob is processed or on cancel.
+        // The timer and stream tracks are stopped here.
+        if (timerIntervalRef.current) clearInterval(timerIntervalRef.current);
+        if (streamRef.current) streamRef.current.getTracks().forEach(track => track.stop());
+
       };
 
       recorder.onerror = (event: Event) => {
         const errorEvent = event as any;
         const errorMsg = `MediaRecorder error: ${errorEvent.error?.name || 'Unknown error'}`;
-        console.error(errorMsg, errorEvent.error);
         setErrorMessage(errorMsg);
         setStatus('error');
         onRecordingError(errorMsg);
-        cleanupRecordingResources();
+        cleanupRecordingResources(true); // Preserve title on media recorder error
       };
 
       recorder.start();
@@ -152,29 +171,85 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
       } else {
         errorMsg = `Error accessing microphone: ${err.message || err.name}`;
       }
-      console.error(errorMsg, err);
       setErrorMessage(errorMsg);
       setStatus('error');
       onRecordingError(errorMsg);
     }
-  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, onRecordingError]); // Removed cleanupRecordingResources from deps as it's stable
 
-  const handleStopAndSave = () => {
+  // Abstracted stop recording logic
+  const stopRecordingSession = useCallback(() => {
     if (mediaRecorderRef.current && mediaRecorderRef.current.state === 'recording') {
-      mediaRecorderRef.current.stop(); // onstop will set status to 'stopped' and create blob
+      mediaRecorderRef.current.stop(); // onstop handler will create blob and set status to 'stopped'
+    } else {
+        console.warn("Stop called but not in recording state or no mediaRecorder.");
     }
-    // Note: Upload will be triggered by a separate button or effect when status is 'stopped'
-  };
+    // Timer is cleared in onstop or cancel
+  }, []);
 
-  const handleUploadAudio = async () => {
-    if (!audioBlob) {
+  // Abstracted cancel recording logic
+  const cancelRecordingSession = useCallback(() => {
+    cleanupRecordingResources();
+    setAudioBlob(undefined);
+    setElapsedTime(0);
+    setStatus('idle');
+    setNoteTitle(initialSuggestedTitle || '');
+    setErrorMessage(undefined);
+    setCurrentLinkedEventId(initialLinkedEventId);
+  }, [cleanupRecordingResources, initialSuggestedTitle, initialLinkedEventId]);
+
+
+  // Effect to handle commands from AgentAudioControlContext
+  useEffect(() => {
+    if (latestCommand) {
+      console.log("AudioRecorder reacting to agent command:", latestCommand);
+      const { action, payload } = latestCommand;
+      switch (action) {
+        case 'START_RECORDING_SESSION':
+          // Optionally, ask user for confirmation before starting via agent.
+          // For now, directly start.
+          if (status === 'idle' || status === 'error') { // Only start if not already doing something
+            setNoteTitle(payload?.suggestedTitle || initialSuggestedTitle || 'Agent Audio Note');
+            setCurrentLinkedEventId(payload?.linkedEventId || initialLinkedEventId);
+            startRecordingSession(payload?.suggestedTitle, payload?.linkedEventId);
+          } else {
+            console.warn(`Agent commanded START_RECORDING_SESSION but current status is ${status}. Ignoring.`);
+            // TODO: Optionally send a NACK or BUSY status back to agent
+          }
+          break;
+        case 'STOP_RECORDING_SESSION':
+          if (status === 'recording') {
+            stopRecordingSession();
+          } else {
+             console.warn(`Agent commanded STOP_RECORDING_SESSION but current status is ${status}. Ignoring.`);
+          }
+          break;
+        case 'CANCEL_RECORDING_SESSION':
+          if (status === 'recording' || status === 'permissionPending' || status === 'stopped') { // Can cancel even if stopped but not yet uploaded
+            cancelRecordingSession();
+          } else {
+            console.warn(`Agent commanded CANCEL_RECORDING_SESSION but current status is ${status}. Ignoring.`);
+          }
+          break;
+        default:
+          console.warn("Received unknown agent audio command action:", action);
+      }
+      clearLastCommand(); // Consume the command
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [latestCommand, clearLastCommand, startRecordingSession, stopRecordingSession, cancelRecordingSession, status, initialSuggestedTitle, initialLinkedEventId]);
+
+
+  const handleUploadAudio = useCallback(async () => {
+    if (!audioBlob) { /* ... (rest of the upload logic remains largely the same) ... */
       const errorMsg = "No audio data available to upload.";
       setErrorMessage(errorMsg);
       setStatus('error');
       onRecordingError(errorMsg);
       return;
     }
-    if (!userId) {
+    if (!userId) { /* ... */
       const errorMsg = "User ID is missing.";
       setErrorMessage(errorMsg);
       setStatus('error');
@@ -190,8 +265,8 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
     formData.append('audio_file', audioBlob, fileName);
     formData.append('title', noteTitle || 'Audio Note - ' + new Date().toLocaleString());
     formData.append('user_id', userId);
-    if (linkedEventId) {
-      formData.append('linked_event_id', linkedEventId);
+    if (currentLinkedEventId) { // Use currentLinkedEventId from state
+      formData.append('linked_event_id', currentLinkedEventId);
     }
 
     try {
@@ -203,11 +278,11 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
 
       if (response.ok && responseData.ok && responseData.data) {
         onRecordingComplete(responseData.data.notion_page_url, responseData.data.title, responseData.data.summary_preview);
-        // Reset for next recording
         setStatus('idle');
-        setNoteTitle(suggestedTitle || '');
+        setNoteTitle(initialSuggestedTitle || '');
         setAudioBlob(undefined);
         setElapsedTime(0);
+        setCurrentLinkedEventId(initialLinkedEventId);
       } else {
         const errorMsg = responseData.error?.message || responseData.message || `Failed to process audio note (HTTP ${response.status}).`;
         setErrorMessage(errorMsg);
@@ -220,27 +295,32 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
       setStatus('error');
       onRecordingError(errorMsg);
     }
-  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [audioBlob, noteTitle, userId, currentLinkedEventId, onRecordingComplete, onRecordingError, initialSuggestedTitle, initialLinkedEventId]);
 
-
-  const handleCancel = () => {
-    cleanupRecordingResources();
-    setAudioBlob(undefined);
-    setElapsedTime(0);
-    setStatus('idle');
-    setNoteTitle(suggestedTitle || ''); // Reset title
-    setErrorMessage(undefined);
-  };
-
-  // Effect to trigger upload when status is 'stopped' and blob is available
   useEffect(() => {
     if (status === 'stopped' && audioBlob) {
       handleUploadAudio();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status, audioBlob]); // Dependencies: status and audioBlob. handleUploadAudio should be stable or wrapped in useCallback if it had dependencies.
+  }, [status, audioBlob, handleUploadAudio]);
+
+  // --- UI Event Handlers (for manual button clicks) ---
+  const handleManualStart = () => {
+    // When user clicks the UI button, start with current title and eventId from props/state
+    startRecordingSession(noteTitle || initialSuggestedTitle, currentLinkedEventId || initialLinkedEventId);
+  };
+
+  const handleManualStopAndSave = () => {
+    stopRecordingSession();
+  };
+
+  const handleManualCancel = () => {
+    cancelRecordingSession();
+  };
+
 
   // Basic styling (inline for simplicity, should be moved to CSS/SCSS modules or styled-components)
+  // ... (styles object remains the same) ...
   const styles = {
     container: { border: '1px solid #ccc', padding: '20px', borderRadius: '8px', maxWidth: '500px', margin: '20px auto', fontFamily: 'Arial, sans-serif' },
     titleInput: { width: 'calc(100% - 22px)', padding: '10px', marginBottom: '10px', border: '1px solid #ddd', borderRadius: '4px' },
@@ -257,16 +337,10 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
     cancelButton: { backgroundColor: '#e0e0e0', color: 'black' },
   };
 
-  // CSS for pulsing animation (would typically be in a global CSS or component-specific CSS file)
-  // <style>
-  // @keyframes pulse { 0% { opacity: 1; } 50% { opacity: 0.4; } 100% { opacity: 1; } }
-  // </style>
-  // For React, this needs to be handled via CSS files or CSS-in-JS. The animation property can be added to recordingDot style.
-
   return (
     <div style={styles.container}>
       <h3>In-Person Audio Note</h3>
-      {(status === 'idle' || status === 'recording' || status === 'error') && ( // Show title input unless uploading/pending
+      {(status === 'idle' || status === 'recording' || status === 'error') && (
         <input
           type="text"
           style={styles.titleInput}
@@ -290,22 +364,22 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
       )}
 
       <div style={styles.buttonsContainer}>
-        {status === 'idle' || status === 'error' ? (
-          <button style={{...styles.button, ...styles.recordButton}} onClick={handleStartRecord} disabled={status === 'permissionPending'}>
+        {(status === 'idle' || status === 'error') && ( // User can manually start if idle or after an error
+          <button style={{...styles.button, ...styles.recordButton}} onClick={handleManualStart} disabled={status === 'permissionPending'}>
             <MicIcon /> Record
           </button>
-        ) : null}
+        )}
 
-        {status === 'recording' ? (
+        {status === 'recording' && ( // User can manually stop/cancel if they started it or if agent started it
           <>
-            <button style={{...styles.button, ...styles.stopButton}} onClick={handleStopAndSave}>
+            <button style={{...styles.button, ...styles.stopButton}} onClick={handleManualStopAndSave}>
               <StopIcon /> Stop & Save
             </button>
-            <button style={{...styles.button, ...styles.cancelButton}} onClick={handleCancel}>
+            <button style={{...styles.button, ...styles.cancelButton}} onClick={handleManualCancel}>
               <CancelIcon /> Cancel
             </button>
           </>
-        ) : null}
+        )}
       </div>
     </div>
   );

--- a/atomic-docker/app_build_docker/contexts/AgentAudioControlContext.tsx
+++ b/atomic-docker/app_build_docker/contexts/AgentAudioControlContext.tsx
@@ -1,0 +1,78 @@
+import React, { createContext, useState, useContext, ReactNode, useCallback } from 'react';
+
+// Define the structure of commands received from the agent
+// This should align with the `AgentClientCommand` defined in the agent skill
+export interface AgentAudioCommand {
+  command_id: string;
+  action: 'START_RECORDING_SESSION' | 'STOP_RECORDING_SESSION' | 'CANCEL_RECORDING_SESSION';
+  payload?: {
+    suggestedTitle?: string;
+    linkedEventId?: string;
+  };
+}
+
+interface AgentAudioControlContextType {
+  latestCommand: AgentAudioCommand | null;
+  dispatchAgentCommand: (command: AgentAudioCommand) => void; // Called by WebSocket listener
+  clearLastCommand: () => void; // Called by components after consuming the command
+}
+
+const AgentAudioControlContext = createContext<AgentAudioControlContextType | undefined>(undefined);
+
+export const AgentAudioControlProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [latestCommand, setLatestCommand] = useState<AgentAudioCommand | null>(null);
+
+  const dispatchAgentCommand = useCallback((command: AgentAudioCommand) => {
+    console.log('AgentAudioControlContext: Dispatching command:', command);
+    setLatestCommand(command);
+  }, []);
+
+  const clearLastCommand = useCallback(() => {
+    console.log('AgentAudioControlContext: Clearing last command.');
+    setLatestCommand(null);
+  }, []);
+
+  return (
+    <AgentAudioControlContext.Provider value={{ latestCommand, dispatchAgentCommand, clearLastCommand }}>
+      {children}
+    </AgentAudioControlContext.Provider>
+  );
+};
+
+export const useAgentAudioControl = (): AgentAudioControlContextType => {
+  const context = useContext(AgentAudioControlContext);
+  if (context === undefined) {
+    throw new Error('useAgentAudioControl must be used within an AgentAudioControlProvider');
+  }
+  return context;
+};
+
+// Example of how a WebSocket listener might use this context:
+// (This part would NOT be in this file, but in your WebSocket handling logic)
+/*
+function webSocketMessageHandler(message: any, dispatchAgentCommand: (command: AgentAudioCommand) => void) {
+  try {
+    const parsedMessage = JSON.parse(message.data); // Or however messages are structured
+
+    // Check if it's an audio control command
+    if (parsedMessage && parsedMessage.type === 'AGENT_AUDIO_CONTROL_COMMAND' && parsedMessage.commandDetails) {
+      const commandDetails = parsedMessage.commandDetails as AgentAudioCommand;
+      // Validate commandDetails structure if necessary
+      if (commandDetails.action && commandDetails.command_id) {
+         dispatchAgentCommand(commandDetails);
+      } else {
+        console.warn("Received invalid agent audio command structure:", commandDetails);
+      }
+    } else {
+      // Handle other types of WebSocket messages
+    }
+  } catch (error) {
+    console.error("Error processing WebSocket message:", error);
+  }
+}
+
+// Somewhere in your app where WebSocket is initialized:
+// const { dispatchAgentCommand } = useAgentAudioControl(); // If context is available globally
+// or pass dispatchAgentCommand to your WebSocket service.
+// webSocket.onmessage = (event) => webSocketMessageHandler(event, dispatchAgentCommand);
+*/


### PR DESCRIPTION
Implements the 'In-Person Meeting Audio Notes' feature, allowing users to initiate and control microphone recordings via agent commands (text/voice) or manually through a new UI component.

Key components and changes:

1.  **Backend (`python_api_service/note_handler.py`):
    *   New endpoint `/api/process-recorded-audio-note` for direct audio uploads, transcription (Deepgram), summarization (OpenAI), and Notion note creation.
    *   Ensures server-side API key management.

2.  **Frontend (`app_build_docker/`):
    *   New `components/Audio/AudioRecorder.tsx`: React component for microphone access, recording, state management, and audio upload.
    *   New `contexts/AgentAudioControlContext.tsx`: React context to bridge agent commands to the `AudioRecorder`.
    *   Modified `pages/Calendar/Chat/UserViewChat.tsx`: WebSocket listener updated to parse agent audio commands and dispatch them via the new context.

3.  **Agent & Communication Backend (`functions_build_docker/server.ts`, `_chat/chat_brain/handler.ts`, `atom-agent/skills/inPersonAudioNoteSkills.ts`):
    *   `server.ts`: Enhanced WebSocket server to manage client connections by `userId` and added `sendCommandToUser` function to send commands to specific clients.
    *   `_chat/chat_brain/handler.ts`: Modified to accept and pass `sendCommandToUserFunc` to skill processing logic. New cases added to invoke audio note skills.
    *   `inPersonAudioNoteSkills.ts`: New agent skill file with logic for handling intents (START/STOP/CANCEL_IN_PERSON_AUDIO_NOTE) and sending commands to the client for direct recording control.

4.  **Documentation (`FEATURES.md`):
    *   Updated to describe the new feature, its agent-activated nature, and manual UI recording capabilities.

This commit lays the foundation for the feature. Comprehensive testing and further refinements (e.g., more nuanced agent-client acknowledgments, S3 storage for raw audio) are pending.