### PR TITLE
docs: Update documentation for new skills & refine core components

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -8,6 +8,9 @@ Atom is designed to enhance your productivity through a comprehensive suite of A
 *   **User Authentication:** Secure login system for protecting your data and configurations.
 *   **Configurable Agent Settings:** Customize various aspects of the Atom agent's behavior and its interaction with integrated services.
 *   **Wake Word Detection:** (If confirmed as fully functional) Initiate interaction with Atom using a spoken wake word for hands-free operation.
+*   **Smart Meeting Preparation:** Proactively gathers relevant notes, emails, and tasks for your upcoming meetings. Example command: *"Atom, prepare me for my meeting with 'Project X' tomorrow."*
+*   **Automated Weekly Digest:** Provides a summary of your past week's accomplishments (completed tasks, key meetings) and a preview of critical items for the upcoming week. Can be triggered on-demand or scheduled. Example command: *"Atom, what's my weekly digest?"*
+*   **Intelligent Follow-up Suggester:** Analyzes meeting notes, transcripts, or project documents to identify and suggest potential action items, key decisions, and unresolved questions. Example command: *"Atom, suggest follow-ups for the 'Q3 Strategy discussion'."*
 
 ### Smart Scheduling & Calendar Management
 Atom revolutionizes how you manage your time with a suite of AI-powered scheduling tools:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Tired of juggling multiple apps and struggling to stay organized? Atom is here t
 *   **Proactive Schedule Optimization:** With Autopilot, Atom can learn your work patterns and preferences. "My mornings are for deep work. Keep them as free of meetings as possible." Atom will then intelligently schedule new events accordingly.
 *   **Quickly Access Information:** "What was the outcome of the Project Phoenix meeting last month?" Atom can search your linked Notion notes and relevant event details to provide you with the context you need.
 *   **Stay on Top of Your Day:** "What's on my agenda for today?" or "Do I have any free time this afternoon for a quick call?"
+*   **Proactive Meeting Prep:** "Atom, get me ready for my meeting with 'Project X'." Atom gathers related notes, emails, and tasks.
+*   **Weekly Review & Preview:** "Atom, what's my weekly digest?" Atom summarizes completed tasks, key meetings, and highlights upcoming critical items.
+*   **Intelligent Follow-ups:** After a meeting, ask "Atom, what follow-ups for the 'Project X' meeting?" Atom analyzes notes/transcripts for actions, decisions, and questions.
 
 ## Documentation
 
@@ -57,6 +60,9 @@ Atom comes packed with a variety of features designed to enhance your productivi
 *   Comprehensive voice-driven task management using a Notion database backend.
 *   Semantic search capabilities across your meeting transcript archive.
 *   Automated extraction of action items and decisions from meeting transcripts.
+*   **Smart Meeting Preparation:** Gathers relevant documents, emails, and tasks before your meetings.
+*   **Automated Weekly Digest:** Summarizes your past week's accomplishments and previews upcoming critical items.
+*   **Intelligent Follow-up Suggester:** Analyzes meeting notes or project documents to suggest action items, decisions, and questions.
 
 For a detailed list and explanation of all features, please see our [Features Document](./FEATURES.md).
 
@@ -75,6 +81,9 @@ Atom provides a rich set of commands to manage your productivity. You can intera
 *   **Process payments:** Interact with Stripe to list payments.
 *   **Handle accounting:** Work with QuickBooks Online to manage invoices.
 *   **Take notes and conduct research:** Create notes in Notion, initiate multi-agent research projects, and process research queues.
+*   **Prepare for meetings:** "Atom, prep me for my meeting on [topic/date]."
+*   **Get weekly summaries:** "Atom, what's my weekly digest?"
+*   **Suggest follow-ups:** "Atom, what are the follow-ups for [meeting/project context]?"
 *   And much more, including general commands like `help`.
 
 For a more detailed list of commands and their specific syntax, please refer to the agent's `help` command or explore the agent's capabilities through interaction.

--- a/atomic-docker/project/functions/atom-agent/docs/NLU_INTENT_GUIDANCE.md
+++ b/atomic-docker/project/functions/atom-agent/docs/NLU_INTENT_GUIDANCE.md
@@ -1,0 +1,152 @@
+# NLU Intent Guidance for New Productivity Skills
+
+This document provides guidance for configuring the Natural Language Understanding (NLU) service (specifically the LLM used within `nluService.ts`) to recognize intents and extract entities for the new productivity skills: Smart Meeting Preparation, Automated Weekly Digest, and Intelligent Follow-up Suggester.
+
+The NLU service is expected to parse user messages and return a JSON object with an `intent` and an `entities` object. The following sections detail the required additions to the NLU's system prompt or training data.
+
+## 1. Smart Meeting Preparation
+
+*   **Intent Name:** `PrepareForMeeting`
+*   **Purpose:** Allows users to request a consolidated briefing for an upcoming meeting, including related documents, emails, and tasks.
+*   **Entities to Extract:**
+    *   `meeting_identifier` (Type: String, Optional): Captures the user's reference to a specific meeting (e.g., "Q3 Marketing Strategy," "call with Jane Doe," "my next meeting").
+    *   `meeting_date_time` (Type: String, Optional): Captures temporal information about the meeting's timing (e.g., "tomorrow," "next Monday at 3pm," "on July 26th"). If not provided, the skill defaults to the soonest relevant meeting.
+*   **Example User Utterances & Expected NLU JSON Output:**
+
+    *   User: "Prepare me for my meeting about 'Q3 Marketing Strategy'."
+        ```json
+        {
+          "intent": "PrepareForMeeting",
+          "entities": {
+            "meeting_identifier": "Q3 Marketing Strategy"
+          }
+        }
+        ```
+    *   User: "Get me ready for the call with Jane Doe tomorrow afternoon."
+        ```json
+        {
+          "intent": "PrepareForMeeting",
+          "entities": {
+            "meeting_identifier": "call with Jane Doe",
+            "meeting_date_time": "tomorrow afternoon"
+          }
+        }
+        ```
+    *   User: "What do I need to know for my next meeting?"
+        ```json
+        {
+          "intent": "PrepareForMeeting",
+          "entities": {
+            "meeting_identifier": "my next meeting"
+          }
+        }
+        ```
+    *   User: "Prep for the budget review meeting."
+        ```json
+        {
+          "intent": "PrepareForMeeting",
+          "entities": {
+            "meeting_identifier": "budget review"
+          }
+        }
+        ```
+
+## 2. Automated Weekly Digest
+
+*   **Intent Name:** `GenerateWeeklyDigest`
+*   **Purpose:** Provides users with a summary of their past week's accomplishments and a preview of critical items for the upcoming week.
+*   **Entities to Extract:**
+    *   `time_period` (Type: String, Optional): Specifies the period for the digest (e.g., "this week," "last week"). Defaults to "this week" if not provided.
+*   **Example User Utterances & Expected NLU JSON Output:**
+
+    *   User: "What's my weekly digest?"
+        ```json
+        {
+          "intent": "GenerateWeeklyDigest",
+          "entities": {}
+        }
+        ```
+    *   User: "Generate my summary for this week."
+        ```json
+        {
+          "intent": "GenerateWeeklyDigest",
+          "entities": {
+            "time_period": "this week"
+          }
+        }
+        ```
+    *   User: "Show me last week's digest."
+        ```json
+        {
+          "intent": "GenerateWeeklyDigest",
+          "entities": {
+            "time_period": "last week"
+          }
+        }
+        ```
+    *   User: "Atom, give me the weekly digest."
+        ```json
+        {
+          "intent": "GenerateWeeklyDigest",
+          "entities": {}
+        }
+        ```
+
+## 3. Intelligent Follow-up Suggester
+
+*   **Intent Name:** `SuggestFollowUps`
+*   **Purpose:** Analyzes meeting notes, transcripts, or project documents to identify and suggest potential action items, key decisions, and unresolved questions.
+*   **Entities to Extract:**
+    *   `context_identifier` (Type: String, Mandatory): The specific meeting, project, or document to analyze (e.g., "Project Phoenix Q1 review meeting," "the client onboarding project," "my last call with Sarah").
+    *   `context_type` (Type: String, Optional, Enum-like: "meeting," "project," "document"): Helps the skill narrow down how to search for the context. If absent, the skill may infer or perform a broader search.
+*   **Example User Utterances & Expected NLU JSON Output:**
+
+    *   User: "What follow-ups should I consider for the 'Project Phoenix Q1 review' meeting?"
+        ```json
+        {
+          "intent": "SuggestFollowUps",
+          "entities": {
+            "context_identifier": "Project Phoenix Q1 review",
+            "context_type": "meeting"
+          }
+        }
+        ```
+    *   User: "Suggest next steps for my 'Client Onboarding' project."
+        ```json
+        {
+          "intent": "SuggestFollowUps",
+          "entities": {
+            "context_identifier": "Client Onboarding",
+            "context_type": "project"
+          }
+        }
+        ```
+    *   User: "Any follow-ups needed after my last meeting?"
+        ```json
+        {
+          "intent": "SuggestFollowUps",
+          "entities": {
+            "context_identifier": "my last meeting",
+            "context_type": "meeting"
+          }
+        }
+        ```
+        *(Note: The skill will need to resolve "my last meeting" to a specific event).*
+    *   User: "Atom, analyze the 'Q1 Review transcript' for action items."
+        ```json
+        {
+          "intent": "SuggestFollowUps",
+          "entities": {
+            "context_identifier": "Q1 Review transcript"
+          }
+        }
+        ```
+
+## General NLU Prompting Considerations:
+
+*   The main `SYSTEM_PROMPT` in `nluService.ts` should be updated to include these new intents, their entity definitions, and a few illustrative examples for each, similar to how existing intents are defined.
+*   The LLM should be instructed to strictly adhere to providing only a single valid JSON object in its response.
+*   Emphasize that if an intent is not clearly matched, it should return `{"intent": null, "entities": {}}`.
+*   The existing `NeedsClarification` and `ComplexTask` intents can still be used by the NLU if appropriate for these new commands when input is ambiguous or multi-step.
+
+This guidance should be used to update the prompt for the LLM within `nluService.ts` to enable recognition of these new capabilities. Iterative testing and refinement of the main NLU prompt will be necessary to achieve high accuracy.

--- a/atomic-docker/project/functions/atom-agent/skills/llmUtilities.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/llmUtilities.ts
@@ -45,6 +45,13 @@ export async function analyzeTextForFollowUps(
   }
 
   // Construct the System and User Prompts for the LLM
+  // This prompt is crucial for the LLM's performance and will likely require
+  // iterative testing and refinement with real-world data to achieve optimal results.
+  // Key aspects:
+  // - Clear definition of the AI's role and goal.
+  // - Explicit instruction for JSON output with a defined schema.
+  // - Constraints like "based only on the information within the document" and "Do not invent".
+  // - Guidance on handling empty categories (return empty arrays).
   const systemPrompt = `You are an AI assistant specialized in identifying follow-up items from text.
 Your goal is to extract:
 1. Distinct actionable items or tasks. If an assignee is mentioned or clearly implied, note the assignee.

--- a/atomic-docker/project/functions/atom-agent/types.ts
+++ b/atomic-docker/project/functions/atom-agent/types.ts
@@ -709,6 +709,7 @@ export interface NotionTask {
   createdDate: string; // ISO date string (from Notion's created_time)
   url: string; // Notion page URL
   notes?: string | null; // Additional text content or a summary from the page body
+  last_edited_time?: string; // ISO 8601 string, from Notion's last_edited_time
 }
 
 export interface CreateNotionTaskParams {


### PR DESCRIPTION
This commit includes several updates to move the new productivity skills closer to a live-ready state, primarily focusing on documentation and essential code refinements.

Documentation Updates:
- Updated `README.md` and `FEATURES.md` to include descriptions, example commands, and benefits of the 'Smart Meeting Preparation', 'Automated Weekly Digest', and 'Intelligent Follow-up Suggester' skills.
- Updated `atomic-docker/docs/ATOM_AGENT_MANUAL_TESTING_PLAN.md` with new sections and detailed manual test cases for each of the three new skills.
- Created `atomic-docker/project/functions/atom-agent/docs/NLU_INTENT_GUIDANCE.md` to provide comprehensive guidance for the NLU team on implementing intents and entities for the new skills, including example utterances and expected JSON outputs.
- Added detailed comments to the LLM prompt in `llmUtilities.ts` for developer clarity.

Code Refinements:
- Modified `listUpcomingEvents` in `skills/calendarSkills.ts` to accept optional `timeMin` and `timeMax` parameters, enabling the querying of past calendar events. This supports the 'Automated Weekly Digest' skill.
- Updated `types.ts` to ensure the `NotionTask` type includes an optional `last_edited_time` field, aligning with its usage in `productivitySkills.ts`.
- Added extensive comments in `handleGenerateWeeklyDigest` (within `skills/productivitySkills.ts`) to clarify the V1 approximation used for filtering completed Notion tasks by date (`last_edited_time`) and to document its limitations and suggest future improvements (e.g., using a dedicated 'Completed At' field).