### PR TITLE
feat: Scaffold 5 core AI assistant use cases

### DIFF
--- a/src/lib/llmUtils.ts
+++ b/src/lib/llmUtils.ts
@@ -1,0 +1,173 @@
+// Mock LLM function - to be used by multiple skills
+
+/**
+ * Simulates a call to a Large Language Model.
+ * Behavior is based on keywords in the prompt to mimic different LLM tasks.
+ * @param prompt The prompt string for the LLM.
+ * @param model The model identifier (e.g., 'cheapest', 'balanced', 'powerful').
+ * @returns A Promise resolving to the LLM's string response.
+ */
+export async function invokeLLM(prompt: string, model: string): Promise<string> {
+  console.log(`[Mock LLM Utility] Received prompt for model "${model}":\n"${prompt.substring(0, 200)}..."`); // Log snippet
+
+  // Simulate LLM behavior for email categorization
+  if (prompt.includes("Categorize this email")) {
+    const promptLower = prompt.toLowerCase();
+    if (promptLower.includes("urgent") || promptLower.includes("critical system outage")) {
+      return JSON.stringify({ category: "Urgent", confidence: 0.92 });
+    } else if (promptLower.includes("action required") || promptLower.includes("please review") || promptLower.includes("task for you")) {
+      return JSON.stringify({ category: "ActionRequired", confidence: 0.85 });
+    } else if (promptLower.includes("meeting invite") || promptLower.includes("calendar invite") || promptLower.includes(".ics")) {
+      return JSON.stringify({ category: "MeetingInvite", confidence: 0.95 });
+    } else if (promptLower.includes("fyi") || promptLower.includes("update on") || promptLower.includes("heads up")) {
+      return JSON.stringify({ category: "FYI", confidence: 0.78 });
+    } else if (promptLower.includes("win a free") || promptLower.includes("limited time offer")) {
+        return JSON.stringify({ category: "Spam", confidence: 0.99 });
+    }
+    return JSON.stringify({ category: "Other", confidence: 0.45 });
+  }
+
+  // Simulate LLM behavior for email summarization
+  if (prompt.startsWith("Summarize this email")) {
+    const subjectMatch = prompt.match(/Subject: "([^"]*)"/);
+    const mockSubject = subjectMatch ? subjectMatch[1] : "this email";
+    return `LLM Summary: Key information from "${mockSubject}" suggests it's about [topic] and requires [action/attention].`;
+  }
+
+  // Simulate LLM behavior for suggested email replies
+  if (prompt.includes("Suggest a brief, polite, and professional reply")) {
+    const promptLower = prompt.toLowerCase();
+    if (promptLower.includes('category: "urgent"')) {
+      return "Acknowledged. We are looking into this with high priority and will update you shortly.";
+    } else if (promptLower.includes('category: "actionrequired"')) {
+      if (promptLower.includes("identified action items:")) {
+        const actionItemMatch = prompt.match(/Identified Action Items: "([^;"]*)/);
+        const firstAction = actionItemMatch ? actionItemMatch[1] : "the main request";
+        return `Understood. I will address the action items, starting with: "${firstAction}".`;
+      }
+      return "Received. I'll take care of the necessary actions.";
+    } else if (promptLower.includes('category: "meetinginvite"')) {
+      return "Thanks for the invite! I'll check my availability and respond through the calendar system.";
+    } else if (promptLower.includes('category: "fyi"')) {
+      return "No reply needed.";
+    } else if (promptLower.includes('category: "spam"')) {
+      return "No reply needed.";
+    } else if (promptLower.includes('category: "other"')) {
+      return "Thank you for your email. I will review it and get back to you if a response is needed.";
+    }
+    return "Thanks for your email.";
+  }
+
+  // Simulate LLM behavior for email action item extraction
+  if (prompt.includes("Extract action items")) {
+    const promptBodyLower = prompt.substring(prompt.indexOf("Email Body:")).toLowerCase();
+    const extractedActions: string[] = [];
+    if (promptBodyLower.includes("please send the report") || promptBodyLower.includes("can you prepare the document")) {
+      extractedActions.push("Send the report", "Prepare the document");
+    }
+    if (promptBodyLower.includes("schedule a meeting") && promptBodyLower.includes("discuss the proposal")) {
+      extractedActions.push("Schedule a meeting to discuss the proposal");
+    }
+    if (promptBodyLower.includes("confirm your availability")) {
+      extractedActions.push("Confirm availability");
+    }
+    if (promptBodyLower.includes("let me know what you think")) {
+      extractedActions.push("Provide feedback or thoughts.");
+    }
+    if (extractedActions.length > 0) {
+      return JSON.stringify({ actionItems: extractedActions.slice(0,2) });
+    }
+    return JSON.stringify({ actionItems: [] });
+  }
+
+  // Simulate LLM behavior for document snippet extraction
+  if (prompt.includes("extract up to") && prompt.includes("relevant snippets")) {
+    const queryMatch = prompt.match(/query '([^']*)'/);
+    const query = queryMatch ? queryMatch[1] : "the topic";
+    // Basic simulation: if document text (also in prompt) contains query words.
+    // This is a very rough check.
+    if (prompt.toLowerCase().includes(query.split(" ")[0].toLowerCase())) { // check first word of query
+        return JSON.stringify({ snippets: [`Mock snippet about "${query}".`, `Further details on "${query}" from the document.`] });
+    }
+    return JSON.stringify({ snippets: [] });
+  }
+
+  // Simulate LLM behavior for document summarization (based on query & snippets/title)
+  if (prompt.includes("provide a") && prompt.includes("summary") && (prompt.includes("these snippets") || prompt.includes("Document Title"))) {
+    const queryMatch = prompt.match(/query '([^']*)'/);
+    const query = queryMatch ? queryMatch[1] : "the main subject";
+    const lengthMatch = prompt.match(/provide a '([^']*)' summary/);
+    const length = lengthMatch ? lengthMatch[1] : "medium";
+    return `This is a mock ${length} summary regarding "${query}", based on the provided text.`;
+  }
+
+  // Simulate LLM for overall summarization of summaries
+  if (prompt.startsWith("Summarize these individual summaries")) {
+    const queryMatch = prompt.match(/answer to '([^']*)'/);
+    const query = queryMatch ? queryMatch[1] : "the user's query";
+    return `This is an overall synthesized mock summary for the query "${query}", based on multiple pieces of information.`;
+  }
+
+  // --- Additions for LearningAndGuidanceSkill ---
+
+  // Query Classification for GuidanceType
+  if (prompt.includes("Classify this query into GuidanceType")) {
+    const queryMatch = prompt.match(/query: "([^"]*)"/i);
+    const userQuery = queryMatch ? queryMatch[1].toLowerCase() : "";
+    if (userQuery.includes("how to") || userQuery.includes("steps for") || userQuery.includes("tutorial for")) {
+      return JSON.stringify({ guidanceType: "find_tutorial" });
+    } else if (userQuery.includes("what is") || userQuery.includes("explain") || userQuery.includes("tell me about")) {
+      return JSON.stringify({ guidanceType: "general_explanation" });
+    } else if (userQuery.includes("guide me through") || userQuery.includes("workflow for")) {
+      return JSON.stringify({ guidanceType: "guide_workflow" });
+    }
+    return JSON.stringify({ guidanceType: "answer_question" });
+  }
+
+  // Answering Questions from Text
+  if (prompt.includes("Using ONLY the provided text, answer the question:")) {
+    const queryMatch = prompt.match(/question: '([^']*)'/i);
+    const userQuery = queryMatch ? queryMatch[1] : "the question";
+    const textMatch = prompt.match(/Provided text: '([^']*)'/i);
+    const articleTextSnippet = textMatch ? textMatch[1] : "";
+
+    // Simple check if any word from query (split, lowercase) is in text snippet
+    const queryWords = userQuery.toLowerCase().split(/\s+/).filter(w => w.length > 2);
+    if (queryWords.some(qw => articleTextSnippet.toLowerCase().includes(qw))) {
+      return `Based on the text, the answer to '${userQuery}' is [mocked detail: ${articleTextSnippet.substring(0, 70)}...].`;
+    }
+    return `The provided text does not appear to contain a direct answer to your question about '${userQuery}'.`;
+  }
+
+  // Extracting Steps (JSON) from Instructional Text
+  if (prompt.includes("Extract the key steps for") && prompt.includes("Return as a JSON object")) {
+    const textMatch = prompt.match(/tutorial text: '([^']*)'/i);
+    const articleTextSnippet = textMatch ? textMatch[1].toLowerCase() : "";
+    if (articleTextSnippet.includes("step 1") || articleTextSnippet.includes("firstly") || articleTextSnippet.includes("1.")) {
+      return JSON.stringify({ steps: [{title: "Mock Step 1: Initialize", description: "First, initialize the system components based on the provided text."}, {title: "Mock Step 2: Configure", description: "Next, configure the main parameters as detailed in the article."}] });
+    }
+    return JSON.stringify({ steps: [] });
+  }
+
+  // Summarizing Text for Explanation
+  if (prompt.includes("Provide a concise explanation regarding") && prompt.includes("based on the following text")) {
+    const queryMatch = prompt.match(/regarding '([^']*)'/i);
+    const userQuery = queryMatch ? queryMatch[1] : "the topic";
+    const textMatch = prompt.match(/following text: '([^']*)'/i);
+    const articleTextSnippet = textMatch ? textMatch[1] : "the provided content";
+    return `This is a mock explanation regarding '${userQuery}'. The provided text mentions '${articleTextSnippet.substring(0,50)}...' and covers aspects like X, Y, and Z.`;
+  }
+
+  // Generating Follow-up Learning Suggestions
+  if (prompt.includes("suggest two distinct, related topics")) {
+    const articleTitleMatch = prompt.match(/guidance on '([^']*)'/i);
+    const articleTitle = articleTitleMatch ? articleTitleMatch[1] : "this topic";
+    const queryMatch = prompt.match(/query '([^']*)'/i);
+    const userQuery = queryMatch ? queryMatch[1] : "your initial question";
+
+    return JSON.stringify({ suggestions: [`Explore advanced "widgets" for ${articleTitle.split(" ").pop()}`, `Find tutorials on integrating ${userQuery.split(" ").pop()} with other tools.`] });
+  }
+
+  console.warn(`[Mock LLM Utility] Unhandled prompt type. Prompt (start): ${prompt.substring(0,150)}...`);
+  return "LLM fallback response: Unable to process this specific type of request.";
+}

--- a/src/skills/calendarSkills.ts
+++ b/src/skills/calendarSkills.ts
@@ -1,0 +1,424 @@
+/**
+ * Represents a summary of a calendar event.
+ * This structure will need to be defined based on the actual data available
+ * from the calendar API and the needs of the Proactive Meeting Prep Assistant.
+ */
+export interface CalendarEventSummary {
+  id: string;
+  title: string;
+  startTime: Date;
+  endTime: Date;
+  description?: string;
+  attendees?: string[]; // e.g., list of email addresses or names
+  location?: string;
+  organizer?: string;
+  // Potentially other relevant fields like meeting link, etc.
+}
+
+const STOP_WORDS: string[] = [
+  "a", "an", "and", "are", "as", "at", "be", "but", "by",
+  "for", "if", "in", "into", "is", "it", "its", "my",
+  "no", "not", "of", "on", "or", "such",
+  "that", "the", "their", "then", "there", "these",
+  "they", "this", "to", "was", "will", "with", "i", "me",
+  "you", "he", "she", "we", "us", "am", "pm" // also time indicators if not handled by date parser
+];
+
+/**
+ * Generates n-grams (specifically bigrams) from a string.
+ * @param str The input string.
+ * @param n The size of the n-grams (default is 2 for bigrams).
+ * @returns An array of n-grams.
+ */
+function _getNgrams(str: string, n: number = 2): string[] {
+  const cleanedStr = str.toLowerCase().replace(/[^a-z0-9]/g, ''); // Keep only alphanumeric for n-grams
+  if (cleanedStr.length < n) {
+    return [];
+  }
+  const ngrams: string[] = [];
+  for (let i = 0; i <= cleanedStr.length - n; i++) {
+    ngrams.push(cleanedStr.substring(i, i + n));
+  }
+  return ngrams;
+}
+
+/**
+ * Calculates string similarity based on n-gram comparison (Sørensen-Dice coefficient).
+ * @param str1 First string.
+ * @param str2 Second string.
+ * @param n N-gram size (default 2 for bigrams).
+ * @returns Similarity score between 0 and 1.
+ */
+function getStringSimilarity(str1: string, str2: string, n: number = 2): number {
+  if (!str1 || !str2) {
+    return 0;
+  }
+  // Normalize strings for comparison beyond just n-gram generation (e.g. full string if short)
+  const s1 = str1.toLowerCase().replace(/\s+/g, '');
+  const s2 = str2.toLowerCase().replace(/\s+/g, '');
+
+  if (s1 === s2) { // Exact match after normalization
+    return 1.0;
+  }
+
+  const ngrams1 = _getNgrams(s1, n);
+  const ngrams2 = _getNgrams(s2, n);
+
+  if (ngrams1.length === 0 || ngrams2.length === 0) {
+    return 0;
+  }
+
+  const set1 = new Set(ngrams1);
+  const set2 = new Set(ngrams2);
+  let commonCount = 0;
+
+  for (const ngram of set1) {
+    if (set2.has(ngram)) {
+      // For actual Dice, you'd count occurrences in lists, not just presence in sets,
+      // if strings can have repeated n-grams. For simplicity with sets:
+      commonCount++;
+    }
+  }
+  // Simplified Dice for sets: (2 * |Intersection|) / (|Set1| + |Set2|)
+  // More accurate Dice for bags (multisets) of ngrams: (2 * commonNgramsCount) / (ngrams1.length + ngrams2.length)
+  // Let's do the more accurate one by iterating through one list and removing from a copy of the other.
+
+  commonCount = 0;
+  const ngrams2Copy = [...ngrams2];
+  for (const ngram of ngrams1) {
+      const indexInCopy = ngrams2Copy.indexOf(ngram);
+      if (indexInCopy !== -1) {
+          commonCount++;
+          ngrams2Copy.splice(indexInCopy, 1); // Remove to handle duplicates correctly
+      }
+  }
+
+  return (2 * commonCount) / (ngrams1.length + ngrams2.length);
+}
+
+/**
+ * Extracts a display name from a typical calendar attendee string.
+ * @param attendeeString The raw attendee string (e.g., "John Doe <john.doe@example.com>", "jane@example.com").
+ * @returns A lowercase, cleaned name part or an empty string.
+ */
+function _extractNameFromAttendeeString(attendeeString: string): string {
+  if (!attendeeString) return "";
+
+  attendeeString = attendeeString.toLowerCase();
+
+  // Case 1: "FullName <email>" or "FirstName <email>"
+  const emailMatch = attendeeString.match(/^(.*?)<.*>$/);
+  if (emailMatch && emailMatch[1]) {
+    return emailMatch[1].trim();
+  }
+
+  // Case 2: "Name (Guest)" or "Name (External)"
+  const guestMatch = attendeeString.match(/^(.*?)\s*\((guest|external)\)/);
+  if (guestMatch && guestMatch[1]) {
+    return guestMatch[1].trim();
+  }
+
+  // Case 3: Just an email "user@example.com" -> "user"
+  if (attendeeString.includes('@')) {
+    const parts = attendeeString.split('@');
+    // Further clean username part if it contains dots or numbers that are not part of typical first/last names
+    // For simplicity here, just taking the part before @. More sophisticated cleaning could be added.
+    return parts[0].replace(/[^a-z\s'-]/gi, '').trim(); // Keep letters, spaces, hyphens, apostrophes
+  }
+
+  // Case 4: Just a name (no email, no guest marker)
+  // Clean it similarly to the email username part
+  return attendeeString.replace(/[^a-z\s'-]/gi, '').trim();
+}
+
+
+/**
+ * Optional date hints to narrow down the search for a calendar event.
+ * - specificDate: Looks for events on this particular day.
+ * - startDate/endDate: Defines a window to search for events.
+ * If multiple hints are provided, the narrowest possible range should be prioritized.
+ * For example, if specificDate is given, startDate and endDate might be ignored or used as validation.
+ */
+export interface DateHints {
+  specificDate?: Date; // e.g., "find my meeting on 2024-03-15"
+  startDate?: Date;    // e.g., "my meeting sometime after next Monday"
+  endDate?: Date;      // e.g., "my meeting before the end of next week"
+}
+
+/**
+ * Finds a calendar event based on a natural language reference and optional date hints.
+ *
+ * @param userId The ID of the user whose calendar is to be searched.
+ * @param meeting_reference A natural language string describing the meeting
+ *                          (e.g., "my sync up tomorrow", "budget review next week").
+ * @param date_hints Optional hints to narrow down the date range for the search.
+ * @returns A Promise that resolves to a CalendarEventSummary if a suitable event
+ *          is found, or undefined otherwise.
+ */
+export async function findCalendarEventByFuzzyReference(
+  userId: string,
+  meeting_reference: string,
+  date_hints?: DateHints
+): Promise<CalendarEventSummary | undefined> {
+  console.log(`[findCalendarEventByFuzzyReference] Inputs: userId=${userId}, reference="${meeting_reference}", hints=${JSON.stringify(date_hints)}`);
+
+  // 1. Determine search window based on date_hints or defaults.
+  let searchWindowStart: Date;
+  let searchWindowEnd: Date;
+  const now = new Date();
+
+  if (date_hints?.specificDate) {
+    searchWindowStart = new Date(date_hints.specificDate);
+    searchWindowStart.setHours(0, 0, 0, 0); // Start of the day
+    searchWindowEnd = new Date(date_hints.specificDate);
+    searchWindowEnd.setHours(23, 59, 59, 999); // End of the day
+  } else if (date_hints?.startDate && date_hints?.endDate) {
+    searchWindowStart = new Date(date_hints.startDate);
+    searchWindowEnd = new Date(date_hints.endDate);
+  } else if (date_hints?.startDate) {
+    searchWindowStart = new Date(date_hints.startDate);
+    searchWindowEnd = new Date(searchWindowStart);
+    searchWindowEnd.setDate(searchWindowStart.getDate() + 14); // Default 2 weeks window
+    searchWindowEnd.setHours(23, 59, 59, 999);
+  } else if (date_hints?.endDate) {
+    searchWindowEnd = new Date(date_hints.endDate);
+    searchWindowStart = new Date(searchWindowEnd);
+    searchWindowStart.setDate(searchWindowEnd.getDate() - 14); // Default 2 weeks window prior
+    searchWindowStart.setHours(0, 0, 0, 0);
+  } else {
+    // Default search window: from start of today to 14 days in the future
+    searchWindowStart = new Date(now);
+    searchWindowStart.setHours(0, 0, 0, 0);
+    searchWindowEnd = new Date(now);
+    searchWindowEnd.setDate(now.getDate() + 14);
+    searchWindowEnd.setHours(23, 59, 59, 999);
+  }
+
+  console.log(`[findCalendarEventByFuzzyReference] Determined search window: ${searchWindowStart.toISOString()} to ${searchWindowEnd.toISOString()}`);
+
+  // 2. Fetch calendar events for the user within that window (mocked for now).
+  const mockEvents = await mockFetchUserCalendarEvents(userId, searchWindowStart, searchWindowEnd);
+  console.log(`[findCalendarEventByFuzzyReference] Fetched ${mockEvents.length} mock events.`);
+
+  // 3. Apply matching logic (fuzzy, keyword, or LLM-based) against meeting_reference.
+  if (mockEvents.length === 0) {
+    console.log("[findCalendarEventByFuzzyReference] No mock events found in the search window. Returning undefined.");
+    return undefined;
+  }
+
+  const meetingReferenceLower = meeting_reference.toLowerCase();
+
+  // Enhanced keyword extraction:
+  // 1. Split by non-alphanumeric characters (handles punctuation better than just space)
+  // 2. Filter out stop words
+  // 3. Filter out very short words (e.g., < 3 chars)
+  const rawWords = meetingReferenceLower.split(/[^a-z0-9]+/).filter(Boolean); // Split and remove empty strings
+  const keywords = rawWords.filter(word =>
+    !STOP_WORDS.includes(word) && word.length >= 3
+  );
+
+  if (keywords.length === 0 && rawWords.length > 0) {
+    // If all words were stop words or too short, fall back to using all short words from original reference
+    // to catch cases like "1:1" or if the meeting title itself is very short and like a stop word.
+    console.log("[findCalendarEventByFuzzyReference] No significant keywords after filtering, falling back to raw short words if any.");
+    keywords.push(...rawWords.filter(word => word.length > 0 && word.length < 3)); // Add back very short words
+    if (keywords.length === 0) { // If still nothing, use all raw words
+         keywords.push(...rawWords);
+    }
+     console.log(`[findCalendarEventByFuzzyReference] Fallback keywords: ${keywords.join(", ")}`);
+  }
+
+
+  console.log(`[findCalendarEventByFuzzyReference] Processed Keywords from reference: ${keywords.join(", ")}`);
+  const processedReference = keywords.join(" "); // Use this for overall similarity
+
+  let bestMatch: CalendarEventSummary | undefined = undefined;
+  let highestScore = 0.0; // Scores are now float (0.0 to 1.0+)
+
+  for (const event of mockEvents) {
+    const eventTitleLower = event.title.toLowerCase();
+    const eventDescriptionLower = event.description?.toLowerCase() || "";
+
+    // Primary score from fuzzy matching the processed reference against the event title
+    let currentScore = getStringSimilarity(processedReference, eventTitleLower);
+    // console.log(`[findCalendarEventByFuzzyReference] Event: "${event.title}", Initial Similarity Score: ${currentScore.toFixed(3)}`);
+
+    // Bonus for exact keyword matches in title
+    let titleBonus = 0;
+    for (const keyword of keywords) {
+      if (eventTitleLower.includes(keyword)) {
+        titleBonus += 0.05; // Small bonus for each keyword found in title
+      }
+    }
+    // Cap title bonus to avoid over-inflation by many small keywords
+    currentScore += Math.min(titleBonus, 0.25);
+
+
+    // Bonus for exact keyword matches in description (smaller bonus)
+    let descriptionBonus = 0;
+    for (const keyword of keywords) {
+      if (eventDescriptionLower.includes(keyword)) {
+        descriptionBonus += 0.025;
+      }
+    }
+    currentScore += Math.min(descriptionBonus, 0.1);
+
+    // Attendee matching bonus
+    let attendeeMatchBonus = 0;
+    const maxAttendeeBonus = 0.3; // Max possible bonus from attendees
+    if (event.attendees && event.attendees.length > 0) {
+      const matchedKeywordsInAttendees = new Set<string>(); // Track keywords that already gave a bonus for this event
+      for (const attendeeString of event.attendees) {
+        const eventAttendeeName = _extractNameFromAttendeeString(attendeeString);
+        if (eventAttendeeName) {
+          for (const keyword of keywords) {
+            // Avoid re-scoring the same keyword if it matched another attendee for this event already
+            if (matchedKeywordsInAttendees.has(keyword)) continue;
+
+            const nameSimilarity = getStringSimilarity(keyword, eventAttendeeName);
+            if (nameSimilarity > 0.7) { // High threshold for name match
+              attendeeMatchBonus += 0.15; // Significant bonus for a good name match
+              matchedKeywordsInAttendees.add(keyword); // Mark this keyword as used for attendee bonus for this event
+              // console.log(`[findCalendarEventByFuzzyReference] Attendee match: keyword "${keyword}" vs attendee "${eventAttendeeName}", similarity ${nameSimilarity.toFixed(3)}`);
+            }
+          }
+        }
+      }
+    }
+    currentScore += Math.min(attendeeMatchBonus, maxAttendeeBonus); // Cap attendee bonus
+
+    console.log(`[findCalendarEventByFuzzyReference] Event: "${event.title}", Similarity: ${getStringSimilarity(processedReference, eventTitleLower).toFixed(3)}, TitleBonus: ${titleBonus.toFixed(3)}, DescBonus: ${descriptionBonus.toFixed(3)}, AttendeeBonus: ${attendeeMatchBonus.toFixed(3)}, Final Score: ${currentScore.toFixed(3)}`);
+
+    if (currentScore > highestScore) {
+      highestScore = currentScore;
+      bestMatch = event;
+    } else if (currentScore === highestScore && currentScore > 0.01) { // Check currentScore > 0.01 to avoid tie-breaking on zero scores
+      // If scores are tied, prefer the one that starts sooner
+      if (bestMatch && event.startTime < bestMatch.startTime) {
+        console.log(`[findCalendarEventByFuzzyReference] Tied score, preferring earlier event: "${event.title}" over "${bestMatch.title}"`);
+        bestMatch = event;
+      }
+    }
+  }
+
+  // Adjust minimum score threshold for similarity scores (0.0 to 1.0 range)
+  const minimumScoreThreshold = 0.3;
+  if (bestMatch && highestScore >= minimumScoreThreshold) {
+    console.log(`[findCalendarEventByFuzzyReference] Best match found: "${bestMatch.title}" with score ${highestScore.toFixed(3)} (Threshold: ${minimumScoreThreshold})`);
+    return bestMatch;
+  } else {
+    if (bestMatch) { // A best match was found, but it didn't meet the threshold
+        console.log(`[findCalendarEventByFuzzyReference] A potential match "${bestMatch.title}" was found with score ${highestScore.toFixed(3)}, but it's below the threshold of ${minimumScoreThreshold}.`);
+    } else { // No events scored > 0 or no events at all after filtering
+        console.log(`[findCalendarEventByFuzzyReference] No event scored above 0 or no events to score.`);
+    }
+    console.log(`[findCalendarEventByFuzzyReference] No event met the minimum score threshold (${minimumScoreThreshold}).`);
+    return undefined;
+  }
+}
+
+// Helper function to mock fetching calendar events
+async function mockFetchUserCalendarEvents(
+  userId: string,
+  startDate: Date,
+  endDate: Date
+): Promise<CalendarEventSummary[]> {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()); // Midnight today
+
+  const sampleEvents: CalendarEventSummary[] = [
+    {
+      id: "evt1",
+      title: "Project Phoenix Sync-Up",
+      startTime: new Date(new Date(today).setDate(today.getDate() + 1)),
+      endTime: new Date(new Date(today).setDate(today.getDate() + 1)),
+      description: "Weekly sync for Project Phoenix.",
+      attendees: ["currentUser@example.com", "Mark Johnson <mark.j@example.com>", "team.member.jane@example.com"],
+      organizer: "mark.j@example.com",
+    },
+    {
+      id: "evt2",
+      title: "Marketing Strategy Meeting",
+      startTime: new Date(new Date(today).setDate(today.getDate() + 2)),
+      endTime: new Date(new Date(today).setDate(today.getDate() + 2)),
+      description: "Discuss Q3 marketing strategy with Alice and the team.",
+      attendees: ["currentUser@example.com", "Alice Wonderland <alice.w@example.com>", "marketing_lead@example.com", "Bob (Guest)"],
+      location: "Conference Room B",
+      organizer: "marketing_lead@example.com",
+    },
+    {
+      id: "evt3",
+      title: "1:1 with Sarah Miller", // More specific title
+      startTime: new Date(new Date(today).setDate(today.getDate() + 3)),
+      endTime: new Date(new Date(today).setDate(today.getDate() + 3)),
+      attendees: ["currentUser@example.com", "Sarah Miller <sarahm@corp.com>"], // Specific manager name
+      organizer: "sarahm@corp.com",
+    },
+    {
+      id: "evt4",
+      title: "Team Lunch",
+      startTime: new Date(new Date(today).setDate(today.getDate() + 7)),
+      endTime: new Date(new Date(today).setDate(today.getDate() + 7)),
+      description: "Casual team lunch at The Eatery.",
+      attendees: ["currentUser@example.com", "Mark Johnson <mark.j@example.com>", "team.member.jane@example.com", "Alice Wonderland <alice.w@example.com>"],
+      location: "The Eatery",
+      organizer: "currentUser@example.com",
+    },
+    {
+      id: "evt5",
+      title: "Budget Review Q2",
+      startTime: new Date(new Date(today).setDate(today.getDate() - 7)),
+      endTime: new Date(new Date(today).setDate(today.getDate() - 7)),
+      description: "Final review of Q2 budget.",
+      attendees: ["currentUser@example.com", "finance_dept@example.com", "Sarah Miller <sarahm@corp.com>"],
+      organizer: "finance_dept@example.com",
+    },
+    {
+      id: "evt6",
+      title: "Project Phoenix - Critical Path Discussion",
+      startTime: new Date(new Date(today).setDate(today.getDate() + 1)),
+      endTime: new Date(new Date(today).setDate(today.getDate() + 1)),
+      description: "Urgent discussion on Project Phoenix blockers with Mark.",
+      attendees: ["currentUser@example.com", "Mark Johnson <mark.j@example.com>", "cto@example.com"],
+      organizer: "cto@example.com",
+    },
+    { // New event for attendee matching
+      id: "evt7",
+      title: "Planning Session",
+      startTime: new Date(new Date(today).setDate(today.getDate() + 4)), // 4 days from now 10 AM
+      endTime: new Date(new Date(today).setDate(today.getDate() + 4)),   // 4 days from now 12 PM
+      description: "General planning meeting.",
+      attendees: ["currentUser@example.com", "Alice Wonderland <alice.w@example.com>", "Bob The Builder <bob@build.it>", "Charlie <charlie.doe@email.com>"],
+      organizer: "currentUser@example.com",
+    }
+  ];
+
+  // Adjust fixed times for sample events to be relative to 'today' for consistent testing
+  sampleEvents.forEach(event => {
+      if (event.id === "evt1") {
+          event.startTime.setHours(9,0,0,0); event.endTime.setHours(10,0,0,0); // Tomorrow 9 AM
+      } else if (event.id === "evt2") {
+          event.startTime.setHours(14,0,0,0); event.endTime.setHours(15,0,0,0); // Day after tomorrow 2 PM
+      } else if (event.id === "evt3") {
+          event.startTime.setHours(11,0,0,0); event.endTime.setHours(11,30,0,0); // 3 days from now 11 AM
+      } else if (event.id === "evt4") {
+          event.startTime.setHours(12,0,0,0); event.endTime.setHours(13,0,0,0); // Next week 12 PM
+      } else if (event.id === "evt5") {
+          event.startTime.setHours(15,0,0,0); event.endTime.setHours(16,0,0,0); // Last week 3 PM
+      } else if (event.id === "evt6") {
+          event.startTime.setHours(14,0,0,0); event.endTime.setHours(15,0,0,0); // Tomorrow 2 PM
+      } else if (event.id === "evt7") {
+          event.startTime.setHours(10,0,0,0); event.endTime.setHours(12,0,0,0); // 4 days from now 10 AM
+      }
+  });
+
+
+  console.log(`[mockFetchUserCalendarEvents] Mock UserID: ${userId}. Filtering events between ${startDate.toISOString()} and ${endDate.toISOString()}`);
+
+  const filteredEvents = sampleEvents.filter(event => {
+    return event.startTime >= startDate && event.startTime <= endDate;
+  });
+
+  console.log(`[mockFetchUserCalendarEvents] Returning ${filteredEvents.length} mock events after filtering.`);
+  return Promise.resolve(filteredEvents);
+}

--- a/src/skills/contextualDocumentAssistantSkill.ts
+++ b/src/skills/contextualDocumentAssistantSkill.ts
@@ -1,0 +1,295 @@
+// Assuming invokeLLM might be moved to a shared utility later.
+// For now, if it's needed here, it would be re-defined or imported.
+// Let's assume for now that invokeLLM is a global-like utility function.
+// If not, we'd need to pass it or instantiate it.
+import { invokeLLM } from '../lib/llmUtils'; // Assuming invokeLLM is now in this path
+
+// Mock Documents Data Store
+const MOCK_DOCUMENTS: DocumentContent[] = [
+  {
+    id: "doc_001",
+    title: "Q3 Budget Planning Report",
+    textContent: "The Q3 budget planning meeting concluded with several key decisions. Firstly, the marketing budget was increased by 15% to support the new product launch. Secondly, R&D funding for Project Alpha will be maintained at current levels, while Project Beta will see a 10% reduction. Travel expenses are to be cut by 20% across all departments. A new hiring freeze for non-essential roles was also approved. Detailed minutes will be circulated by EOD tomorrow. The next budget review is scheduled for October 5th.",
+    tags: ["budget", "finance", "planning", "Q3"],
+    createdAt: new Date("2023-07-15T10:00:00Z"),
+  },
+  {
+    id: "doc_002",
+    title: "Project Phoenix - Technical Overview",
+    textContent: "Project Phoenix aims to refactor our legacy authentication module using modern microservices architecture. Key technologies include OAuth2, OpenID Connect, and a new identity provider service built with Go. The first phase focuses on core authentication and authorization. Phase two will introduce multi-factor authentication and biometric support. Current team members are Alice (Lead), Bob (Backend), Charlie (Frontend). Estimated completion for Phase 1 is Q4. This project is critical for enhancing security and scalability. All teams are expected to integrate with the new auth module by end of year.",
+    tags: ["project phoenix", "technical", "authentication", "security", "architecture"],
+    createdAt: new Date("2023-06-01T14:30:00Z"),
+  },
+  {
+    id: "doc_003",
+    title: "Marketing Strategy 2024",
+    textContent: "Our 2024 marketing strategy will focus on three core pillars: digital engagement, content leadership, and community building. Digital engagement involves a revamped social media presence and targeted ad campaigns. Content leadership will be driven by weekly blog posts, monthly webinars, and a new podcast series. Community building efforts will center around our annual user conference and regional meetups. Key performance indicators (KPIs) include website traffic, conversion rates, social media engagement, and lead generation. The marketing budget for these initiatives is outlined in the Q3 budget report.",
+    tags: ["marketing", "strategy", "2024", "digital", "content", "community"],
+    createdAt: new Date("2023-08-01T09:00:00Z"),
+  },
+  {
+    id: "doc_004",
+    title: "Employee Handbook - Remote Work Policy",
+    textContent: "This document outlines the company's remote work policy. Eligible employees may work remotely up to three days per week, subject to manager approval. Core working hours are 10 AM to 4 PM local time. Employees must ensure they have a secure and productive home office environment. All company equipment used remotely must adhere to security guidelines. For assistance, contact IT support. Regular team check-ins are mandatory. Exceptions to this policy require VP approval.",
+    tags: ["hr", "policy", "remote work", "employee handbook"],
+    createdAt: new Date("2023-05-10T11:00:00Z"),
+  }
+];
+
+// Helper function to simulate fetching documents
+async function _fetchMockDocuments(documentIds?: string[]): Promise<DocumentContent[]> {
+  console.log(`[_fetchMockDocuments] Attempting to fetch documents. Specified IDs: ${documentIds?.join(', ')}`);
+  if (documentIds && documentIds.length > 0) {
+    const foundDocs = MOCK_DOCUMENTS.filter(doc => documentIds.includes(doc.id));
+    console.log(`[_fetchMockDocuments] Found ${foundDocs.length} documents matching specified IDs.`);
+    return foundDocs;
+  }
+  console.log(`[_fetchMockDocuments] No specific IDs provided, returning all ${MOCK_DOCUMENTS.length} mock documents.`);
+  return MOCK_DOCUMENTS; // Return all if no specific IDs are requested
+}
+
+
+/**
+ * Represents the content and metadata of a document.
+ */
+export interface DocumentContent {
+  id: string;
+  title: string;
+  textContent: string; // The full plain text content of the document
+  tags?: string[];
+  createdAt?: Date;
+  // other metadata like author, source, etc. could be added
+}
+
+/**
+ * Input for the ContextualDocumentAssistantSkill.
+ */
+export interface DocumentAssistantInput {
+  query: string; // Natural language question from the user
+  documentIds?: string[]; // Optional: Specific document IDs to search within
+  userId: string; // For access control and personalization (not used in mock)
+  options?: {
+    summarize?: boolean; // Whether to generate summaries for found snippets/documents
+    targetSummaryLength?: 'short' | 'medium' | 'long'; // Desired length of summaries
+    maxResults?: number; // Maximum number of documents/answers to return
+    snippetLength?: number; // Approximate desired length of extracted snippets in characters
+  };
+}
+
+/**
+ * Represents a single answer found within a document.
+ */
+export interface AnswerObject {
+  documentId: string;
+  documentTitle?: string;
+  relevantSnippets: string[]; // Array of text snippets directly relevant to the query
+  summary?: string; // Optional summary of the relevant information in this document
+  relevanceScore?: number; // How relevant this document/answer is to the query (0.0 to 1.0)
+  pageNumbers?: number[]; // Optional: Page numbers where snippets were found (if applicable)
+}
+
+/**
+ * Output result from the ContextualDocumentAssistantSkill.
+ */
+export interface DocumentAssistantResult {
+  originalQuery: string;
+  answers: AnswerObject[];
+  overallSummary?: string; // Optional: A global summary if requested and multiple answers found
+  searchPerformedOn?: 'all_accessible' | 'specified_ids'; // Indicates the scope of the search
+  // errors?: string[]; // To report any issues during processing
+}
+
+/**
+ * Skill to find information within documents using natural language queries.
+ */
+export class ContextualDocumentAssistantSkill {
+  constructor() {
+    console.log("ContextualDocumentAssistantSkill initialized.");
+    // In a real scenario, this might load document indexes, connect to a vector DB, etc.
+  }
+
+  /**
+   * Executes the document query and assistance process.
+   * @param input The DocumentAssistantInput containing the user's query and options.
+   * @returns A Promise resolving to the DocumentAssistantResult.
+   */
+  public async execute(input: DocumentAssistantInput): Promise<DocumentAssistantResult> {
+    console.log(`[ContextualDocumentAssistantSkill] Received query: "${input.query}" for user: ${input.userId}, options: ${JSON.stringify(input.options)}`);
+
+    // 1. Validate input (query, userId)
+    if (!input.query || !input.userId) {
+      throw new Error("Query and userId are required for ContextualDocumentAssistantSkill.");
+    }
+    const snippetLength = input.options?.snippetLength || 150;
+    const targetSummaryLength = input.options?.targetSummaryLength || 'medium';
+    const maxResults = input.options?.maxResults || 5;
+
+
+    // 2. Fetch candidate documents using _fetchMockDocuments(input.documentIds)
+    const candidateDocuments = await _fetchMockDocuments(input.documentIds);
+    const searchScope = input.documentIds && input.documentIds.length > 0 ? 'specified_ids' : 'all_accessible';
+    console.log(`[ContextualDocumentAssistantSkill] Fetched ${candidateDocuments.length} candidate documents to process for scope: ${searchScope}.`);
+
+    // 3. Initialize results array: answers: AnswerObject[] = []
+    const answers: AnswerObject[] = [];
+    let overallSummary: string | undefined = undefined;
+
+    // 4. For each fetched document:
+    //    (Loop will be limited by maxResults if many documents are returned by _fetchMockDocuments without specific IDs)
+    for (const doc of candidateDocuments.slice(0, maxResults)) {
+      console.log(`[ContextualDocumentAssistantSkill] Processing document: ${doc.id} - ${doc.title}`);
+      //    a. Create snippetPrompt: "Given the query '${input.query}', extract up to 3 relevant snippets (each ~${snippetLength} chars) from the following document text. Return as JSON: {snippets: string[]}. Document Text: ${doc.textContent.substring(0, 2000)}..."
+      const docTextSnippetForLLM = doc.textContent.substring(0, 2000); // Limit text sent to LLM
+      const snippetPrompt = `
+        Given the query "${input.query}", extract up to 3 most relevant snippets from the following document text.
+        Each snippet should be approximately ${snippetLength} characters long.
+        Return the result as a JSON object with a single key "snippets" containing an array of strings: {"snippets": ["snippet1", "snippet2", ...]}.
+        If no relevant snippets are found, return {"snippets": []}.
+
+        Document Title: "${doc.title}"
+        Document Text:
+        "${docTextSnippetForLLM}..."
+      `;
+
+      let extractedSnippets: string[] = [];
+      try {
+        const llmSnippetsResponse = await invokeLLM(snippetPrompt, 'cheapest');
+        console.log(`[ContextualDocumentAssistantSkill] LLM snippets response for doc ${doc.id}: ${llmSnippetsResponse}`);
+        const parsedSnippetsResponse = JSON.parse(llmSnippetsResponse);
+        if (parsedSnippetsResponse && Array.isArray(parsedSnippetsResponse.snippets)) {
+          extractedSnippets = parsedSnippetsResponse.snippets.filter((s: any): s is string => typeof s === 'string');
+        } else {
+          console.warn(`[ContextualDocumentAssistantSkill] LLM snippets response for doc ${doc.id} had invalid structure.`);
+        }
+      } catch (error) {
+        console.error(`[ContextualDocumentAssistantSkill] Error processing LLM snippets for doc ${doc.id}:`, error);
+      }
+
+      if (extractedSnippets.length > 0) {
+        const answerObject: AnswerObject = {
+          documentId: doc.id,
+          documentTitle: doc.title,
+          relevantSnippets: extractedSnippets,
+          relevanceScore: 0.75 + Math.min(0.2, extractedSnippets.length * 0.05), // Placeholder score
+        };
+        answers.push(answerObject); // Add to answers first, then try to summarize
+      }
+    } // End of document loop
+
+    // Post-process answers for summarization if requested
+    if (input.options?.summarize) {
+      for (const answer of answers) {
+        if (answer.relevantSnippets.length > 0) {
+          const summaryPrompt = `
+            Based on the query "${input.query}" and the following relevant snippets from the document titled "${answer.documentTitle}",
+            provide a ${targetSummaryLength} summary.
+            Return only the summary text.
+
+            Snippets:
+            ${answer.relevantSnippets.map(s => `- ${s}`).join('\n')}
+          `;
+          try {
+            const llmSummary = await invokeLLM(summaryPrompt, 'cheapest');
+            console.log(`[ContextualDocumentAssistantSkill] LLM summary for doc ${answer.documentId}: ${llmSummary}`);
+            if (llmSummary && !llmSummary.toLowerCase().startsWith("llm fallback response")) {
+              answer.summary = llmSummary;
+            } else {
+              answer.summary = "Summary could not be generated by LLM.";
+              console.warn(`[ContextualDocumentAssistantSkill] LLM summary failed or returned fallback for doc ${answer.documentId}.`);
+            }
+          } catch (error) {
+            console.error(`[ContextualDocumentAssistantSkill] Error during LLM summarization for doc ${answer.documentId}:`, error);
+            answer.summary = "Error generating summary.";
+          }
+        }
+      }
+    }
+
+    // 5. (Optional) If input.options?.summarize and multiple answers with summaries exist, generate overallSummary:
+    if (input.options?.summarize && answers.some(a => a.summary)) { // Check if any answer has a summary
+      const summariesToCombine = answers.filter(a => a.summary).map(a => `Summary from "${a.documentTitle}": ${a.summary}`).join('\n\n---\n\n');
+      if (summariesToCombine.length > 0) { // Ensure there's something to summarize
+        const overallSummaryPrompt = `
+          The user's query was: "${input.query}".
+          Combine the following individual summaries from different documents into one concise overall answer.
+          Return only the combined summary text. Make sure it flows well and directly answers the query.
+
+          Individual Summaries:
+          ${summariesToCombine}
+        `;
+        try {
+          const llmOverallSummary = await invokeLLM(overallSummaryPrompt, 'cheapest');
+          console.log(`[ContextualDocumentAssistantSkill] LLM overall summary: ${llmOverallSummary}`);
+          if (llmOverallSummary && !llmOverallSummary.toLowerCase().startsWith("llm fallback response")) {
+            overallSummary = llmOverallSummary;
+          } else {
+            console.warn(`[ContextualDocumentAssistantSkill] LLM overall summary failed or returned fallback.`);
+            // overallSummary remains undefined or could be set to a message.
+          }
+        } catch (error) {
+          console.error(`[ContextualDocumentAssistantSkill] Error during LLM overall summarization:`, error);
+          // overallSummary remains undefined
+        }
+      }
+    }
+
+
+    // 6. Construct and return DocumentAssistantResult
+    const result: DocumentAssistantResult = {
+      originalQuery: input.query,
+      answers: answers,
+      searchPerformedOn: searchScope,
+      overallSummary: overallSummary,
+    };
+
+    console.log(`[ContextualDocumentAssistantSkill] Returning processed result for query: "${input.query}" with ${answers.length} answers.`);
+    return result;
+  }
+}
+
+// Example Usage (for testing or demonstration)
+/*
+async function testContextualDocSkill() {
+  // Assume invokeLLM is globally available or imported for the skill to use internally
+  // For testing here, we don't need to call it directly unless we're testing the skill's usage of it.
+
+  const skill = new ContextualDocumentAssistantSkill();
+
+  const testInput1: DocumentAssistantInput = {
+    userId: "user-test-123",
+    query: "What were the key decisions from the Q3 budget meeting?",
+    options: {
+      summarize: true,
+      targetSummaryLength: 'medium',
+      maxResults: 3,
+      snippetLength: 200
+    }
+  };
+
+  try {
+    console.log("\\n--- Test Case 1: General query with summarization ---");
+    const result1 = await skill.execute(testInput1);
+    console.log(JSON.stringify(result1, null, 2));
+  } catch (error) {
+    console.error("Error during skill execution (Test Case 1):", error);
+  }
+
+  const testInput2: DocumentAssistantInput = {
+    userId: "user-test-456",
+    query: "Tell me about Project Phoenix in document 'proj-phoenix-brief.pdf'",
+    documentIds: ["proj-phoenix-brief.pdf"], // Assuming this ID maps to a mock document
+    options: {
+      summarize: false, // Just snippets
+    }
+  };
+  try {
+    console.log("\\n--- Test Case 2: Query on specific document, no summary ---");
+    const result2 = await skill.execute(testInput2);
+    console.log(JSON.stringify(result2, null, 2));
+  } catch (error) {
+    console.error("Error during skill execution (Test Case 2):", error);
+  }
+}
+
+// testContextualDocSkill();
+*/

--- a/src/skills/emailTriageSkill.ts
+++ b/src/skills/emailTriageSkill.ts
@@ -1,0 +1,321 @@
+import { invokeLLM } from '../lib/llmUtils';
+
+/**
+ * Represents an incoming email message.
+ */
+export interface EmailObject {
+  id: string;
+  sender: string; // e.g., "John Doe <john.doe@example.com>" or "internal-alerts@example.com"
+  recipients: string[]; // List of recipient addresses/names
+  subject: string;
+  body: string; // Can be plain text or HTML content
+  receivedDate: Date;
+  headers?: Record<string, string>; // Optional: For specific mail headers like 'Importance', 'X-Priority'
+}
+
+/**
+ * Defines the possible categories for a triaged email.
+ */
+export type EmailCategory = 'Urgent' | 'ActionRequired' | 'FYI' | 'Spam' | 'MeetingInvite' | 'Other';
+
+/**
+ * Represents the result of triaging an email.
+ */
+export interface TriageResult {
+  emailId: string;
+  category: EmailCategory;
+  confidence?: number; // Confidence score (0.0 to 1.0) for the assigned category
+  summary?: string; // A brief summary of the email content
+  suggestedReply?: string; // A short suggested reply, if applicable
+  priorityScore?: number; // A numerical priority (e.g., 1-10, higher is more important)
+  extractedActionItems?: string[]; // Any specific action items identified in the email
+  // Could also include entities like mentioned people, dates, organizations etc.
+}
+
+// Define keyword sets for categorization (No longer primarily used for categorization, but might be useful for other heuristics or priority)
+const URGENT_KEYWORDS = ["urgent", "critical", "immediate", "action now", "down", "outage"];
+const ACTION_KEYWORDS = ["action required", "please review", "task for you", "can you look into", "needs your attention", "respond by", "deadline"];
+const MEETING_KEYWORDS = ["meeting invite", "calendar invite", "invitation:", "scheduled:", "zoom link", "teams meeting", ".ics"];
+const FYI_KEYWORDS = ["fyi", "heads up", "update", "information only", "newsletter", "announcement"];
+const SPAM_KEYWORDS = ["win a free", "limited time offer", "cialis", "viagra", "unsubscribe here", "claim your prize", "$$$"];
+
+// Define a list of important senders (lowercase for easier matching)
+const IMPORTANT_SENDERS = ["boss@example.com", "ceo@example.com", "directreport@example.com", "importantclient@example.com"];
+
+// Define phrases for action item extraction (Commented out as LLM now handles this)
+// const ACTION_PHRASES = ['please', 'can you', 'could you', 'action:', 'task:', 'needed:', 'required:', 'to do:', 'ensure that', 'confirm if'];
+// const QUESTION_ACTION_VERBS = ['send', 'provide', 'do', 'create', 'organize', 'schedule', 'confirm', 'clarify', 'find', 'update', 'check', 'get'];
+
+// Helper function to strip basic HTML
+function _stripHtml(htmlString: string): string {
+  let text = htmlString;
+  // Replace block-level tags that usually imply newlines
+  text = text.replace(/<\/(p|div|h[1-6]|li|dt|dd|pre|blockquote|address|header|footer|section|article)>/gi, '\n');
+  text = text.replace(/<br\s*\/?>/gi, '\n');
+  // Replace li and dd with a bullet point for better readability
+  text = text.replace(/<li[^>]*>/gi, '\n* ');
+  text = text.replace(/<dd[^>]*>/gi, '\n  '); // Indent definition descriptions
+
+  // Remove all other HTML tags
+  text = text.replace(/<[^>]+>/g, '');
+
+  // Decode common HTML entities
+  text = text.replace(/&nbsp;/g, ' ')
+             .replace(/&amp;/g, '&')
+             .replace(/&lt;/g, '<')
+             .replace(/&gt;/g, '>')
+             .replace(/&quot;/g, '"')
+             .replace(/&#39;/g, "'");
+             // Add more entities as needed: &apos; &cent; &pound; &yen; &euro; &copy; &reg;
+
+  // Normalize multiple newlines and spaces
+  text = text.replace(/\n{3,}/g, '\n\n'); // Max two consecutive newlines
+  text = text.replace(/ {2,}/g, ' ');    // Max one space
+
+  return text.trim();
+}
+
+
+/**
+ * Skill to triage and prioritize incoming emails.
+ */
+export class EmailTriageSkill {
+  constructor() {
+    // Initialization for the skill, e.g., loading models, configuration, etc.
+    console.log("EmailTriageSkill initialized.");
+  }
+
+  /**
+   * Executes the email triage process.
+   * @param email The EmailObject to process.
+   * @returns A Promise resolving to the TriageResult.
+   */
+  public async execute(email: EmailObject): Promise<TriageResult> {
+    console.log(`[EmailTriageSkill] Processing email ID: ${email.id} from: ${email.sender} with subject: "${email.subject}"`);
+
+    // 1. Validate email input (Basic check for now)
+    if (!email || !email.id || !email.subject || !email.body) {
+      throw new Error("Invalid email object provided. Essential fields (id, subject, body) are missing.");
+    }
+    console.log(`[EmailTriageSkill] Email validated: ${email.id}`);
+
+    // Pre-process body: Strip HTML if necessary
+    let processedBody = email.body;
+    const isHtml = /<([a-z][a-z0-9]*)\b[^>]*>/i.test(email.body);
+    if (isHtml) {
+      processedBody = _stripHtml(email.body);
+      console.log("[EmailTriageSkill] HTML detected in email body; stripped to plain text for processing.");
+    } else {
+      console.log("[EmailTriageSkill] Email body appears to be plain text.");
+    }
+
+    // 2. Determine Category (LLM-based)
+    let determinedCategory: EmailCategory = 'Other';
+    let categoryConfidence = 0.2;
+
+    const bodySnippetForCategorization = processedBody.substring(0, 250);
+    const categorizationPrompt = `
+      Given the following email details:
+      Subject: "${email.subject}"
+      Body (first ${bodySnippetForCategorization.length} chars): "${bodySnippetForCategorization}..."
+
+      Categorize this email into one of the following categories:
+      'Urgent', 'ActionRequired', 'FYI', 'Spam', 'MeetingInvite', 'Other'.
+      Return ONLY the category and a confidence score (0.0-1.0) in a valid JSON format, like:
+      {"category": "CATEGORY_NAME", "confidence": 0.X}
+    `;
+
+    try {
+      const llmCategoryResponse = await invokeLLM(categorizationPrompt, 'cheapest');
+      console.log(`[EmailTriageSkill] LLM category response string: ${llmCategoryResponse}`);
+      const parsedResponse = JSON.parse(llmCategoryResponse);
+
+      if (parsedResponse && parsedResponse.category && typeof parsedResponse.confidence === 'number') {
+        const potentialCategory = parsedResponse.category as EmailCategory;
+        const validCategories: EmailCategory[] = ['Urgent', 'ActionRequired', 'FYI', 'Spam', 'MeetingInvite', 'Other'];
+        if (validCategories.includes(potentialCategory)) {
+          determinedCategory = potentialCategory;
+          categoryConfidence = parsedResponse.confidence;
+        } else {
+          console.warn(`[EmailTriageSkill] LLM returned an invalid category: ${parsedResponse.category}. Defaulting to 'Other'.`);
+          determinedCategory = 'Other';
+          categoryConfidence = 0.25;
+        }
+      } else {
+        console.error('[EmailTriageSkill] LLM category response parsing error or invalid structure. Response:', llmCategoryResponse);
+      }
+    } catch (error) {
+      console.error('[EmailTriageSkill] Error calling or parsing LLM category response:', error);
+    }
+    console.log(`[EmailTriageSkill] LLM-determined category: ${determinedCategory} with confidence ${categoryConfidence.toFixed(2)}`);
+
+    // 3. Calculate Priority Score (Rule-based, using LLM category)
+    let calculatedPriorityScore = 0;
+    switch (determinedCategory) {
+      case 'Urgent': calculatedPriorityScore = 9; break;
+      case 'ActionRequired': calculatedPriorityScore = 7; break;
+      case 'MeetingInvite': calculatedPriorityScore = 6; break;
+      case 'FYI': calculatedPriorityScore = 3; break;
+      case 'Other': calculatedPriorityScore = 2; break;
+      case 'Spam': calculatedPriorityScore = 0; break;
+      default: calculatedPriorityScore = 1;
+    }
+
+    const senderLower = email.sender.toLowerCase();
+    const emailMatch = senderLower.match(/<([^>]+)>/);
+    const actualSenderEmail = emailMatch ? emailMatch[1] : senderLower;
+
+    if (IMPORTANT_SENDERS.includes(actualSenderEmail)) {
+      calculatedPriorityScore = Math.min(10, calculatedPriorityScore + 2);
+      console.log(`[EmailTriageSkill] Priority boosted due to important sender: ${email.sender}`);
+    }
+    if (email.headers?.Importance?.toLowerCase() === 'high' || email.headers?.['X-Priority']?.startsWith('1')) {
+      calculatedPriorityScore = Math.min(10, calculatedPriorityScore + 1);
+      console.log(`[EmailTriageSkill] Priority boosted due to high importance header.`);
+    }
+    console.log(`[EmailTriageSkill] Calculated priority score: ${calculatedPriorityScore}`);
+
+    // 4. Generate Summary (LLM-based)
+    let generatedSummary = "";
+    const bodySnippetForSummary = processedBody.substring(0, 500);
+    const summaryPrompt = `Summarize this email in 1-2 sentences: Subject: "${email.subject}" Body: "${bodySnippetForSummary}..." Return only the summary text.`;
+    try {
+        const llmSummaryResponse = await invokeLLM(summaryPrompt, 'cheapest');
+        console.log(`[EmailTriageSkill] LLM summary response: ${llmSummaryResponse}`);
+        if (llmSummaryResponse && !llmSummaryResponse.toLowerCase().startsWith("llm fallback response")) {
+            generatedSummary = llmSummaryResponse;
+        } else {
+            console.warn("[EmailTriageSkill] LLM summary failed or returned fallback, using basic snippet.");
+            const normalizedBodyForFallback = processedBody.replace(/\s+/g, " ").trim();
+            generatedSummary = `Subject: "${email.subject}". Body excerpt: "${normalizedBodyForFallback.substring(0, 150)}..."`;
+        }
+    } catch (error) {
+        console.error('[EmailTriageSkill] Error calling LLM for summary:', error);
+        const normalizedBodyForFallback = processedBody.replace(/\s+/g, " ").trim();
+        generatedSummary = `Subject: "${email.subject}". Body excerpt: "${normalizedBodyForFallback.substring(0, 150)}..."`;
+    }
+    console.log(`[EmailTriageSkill] Final generated summary: ${generatedSummary}`);
+
+    // 6. Extract Action Items (LLM-based) - Done *before* reply suggestion to inform it
+    let foundActionItems: string[] = [];
+    const bodyForActionExtraction = processedBody.substring(0, 1000);
+    const actionItemPrompt = `
+      Review the following email body and extract any distinct action items or tasks requested of the recipient.
+      Return these as a JSON array of strings, like: {"actionItems": ["Action 1", "Action 2"]}.
+      If no specific action items are found, return {"actionItems": []}.
+
+      Email Body:
+      "${bodyForActionExtraction}..."
+    `;
+    try {
+      const llmActionItemsResponse = await invokeLLM(actionItemPrompt, 'cheapest');
+      console.log(`[EmailTriageSkill] LLM action items response: ${llmActionItemsResponse}`);
+      const parsedResponse = JSON.parse(llmActionItemsResponse);
+      if (parsedResponse && Array.isArray(parsedResponse.actionItems)) {
+        foundActionItems = parsedResponse.actionItems.filter((item: any): item is string => typeof item === 'string');
+         if (foundActionItems.length > 0) {
+            console.log(`[EmailTriageSkill] LLM extracted action items:`, foundActionItems);
+        } else {
+            console.log(`[EmailTriageSkill] LLM found no specific action items.`);
+        }
+      } else {
+        if (typeof llmActionItemsResponse === 'string' && llmActionItemsResponse.length > 0 && !llmActionItemsResponse.toLowerCase().startsWith("llm fallback") && !llmActionItemsResponse.startsWith("{")) {
+            console.warn('[EmailTriageSkill] LLM action items response was not JSON array, treating as single string action item.');
+            foundActionItems = [llmActionItemsResponse];
+            console.log(`[EmailTriageSkill] LLM extracted single action item (from string):`, foundActionItems);
+        } else {
+            console.warn('[EmailTriageSkill] LLM action items response parsing error or invalid structure. Response:', llmActionItemsResponse);
+        }
+      }
+    } catch (error) {
+      console.error('[EmailTriageSkill] Error calling or parsing LLM for action items:', error);
+    }
+
+    // 5. Suggest Reply (LLM-based, now informed by extracted action items)
+    let suggestedReplyMessage: string | undefined = undefined;
+    const actionItemsText = foundActionItems.length > 0 ? `Identified Action Items: "${foundActionItems.join('; ')}"` : "";
+    const replyPrompt = `
+      Given an email with the following details:
+      Category: "${determinedCategory}"
+      Subject: "${email.subject}"
+      Summary: "${generatedSummary}"
+      ${actionItemsText}
+
+      Suggest a brief, polite, and professional reply for this email.
+      If no reply is typically needed for this category or content (e.g., for Spam or some FYI), return the exact phrase "No reply needed.".
+      Otherwise, provide only the suggested reply text.
+    `;
+    try {
+      const llmReply = await invokeLLM(replyPrompt, 'cheapest');
+      console.log(`[EmailTriageSkill] LLM raw reply: "${llmReply}"`);
+      if (llmReply && llmReply.trim().toLowerCase() !== "no reply needed." && !llmReply.toLowerCase().startsWith("llm fallback response")) {
+        suggestedReplyMessage = llmReply.trim();
+        console.log(`[EmailTriageSkill] LLM suggested reply: "${suggestedReplyMessage}"`);
+      } else {
+        console.log(`[EmailTriageSkill] LLM indicated no reply needed or fallback response for reply generation.`);
+        suggestedReplyMessage = undefined;
+      }
+    } catch (error) {
+      console.error('[EmailTriageSkill] Error calling LLM for suggested reply:', error);
+      suggestedReplyMessage = undefined;
+    }
+
+    // 7. Construct and return TriageResult
+    const result: TriageResult = {
+      emailId: email.id,
+      category: determinedCategory,
+      confidence: parseFloat(categoryConfidence.toFixed(2)),
+      priorityScore: calculatedPriorityScore,
+      summary: generatedSummary,
+      suggestedReply: suggestedReplyMessage,
+      extractedActionItems: foundActionItems.length > 0 ? foundActionItems : undefined,
+    };
+
+    console.log(`[EmailTriageSkill] Triage complete for email ID: ${email.id}. Category: ${result.category}, Priority: ${result.priorityScore}, Confidence: ${result.confidence}, Actions: ${foundActionItems.length}`);
+    return result;
+  }
+}
+
+// Example Usage (for testing or demonstration, typically called by an orchestrator)
+/*
+async function testEmailTriageSkill() {
+  const skill = new EmailTriageSkill();
+  const testEmail: EmailObject = {
+    id: "test-email-001",
+    sender: "Alice <alice@example.com>",
+    recipients: ["bob@example.com", "currentUser@example.com"],
+    subject: "Quick question about the Phoenix project",
+    body: "Hi team, I had a quick question regarding the latest update on the Phoenix project. Can someone point me to the documentation for the new auth module? Thanks!",
+    receivedDate: new Date(),
+    headers: { "X-Priority": "3" }
+  };
+
+  try {
+    const result = await skill.execute(testEmail);
+    console.log("\\n--- Email Triage Result ---");
+    console.log(JSON.stringify(result, null, 2));
+  } catch (error) {
+    console.error("Error during EmailTriageSkill execution:", error);
+  }
+
+  const urgentEmail: EmailObject = {
+    id: "urgent-email-002",
+    sender: "boss@example.com",
+    recipients: ["currentUser@example.com"],
+    subject: "URGENT: Action Required - System Outage",
+    body: "Team, we have a critical system outage affecting all customers. All hands on deck. Please join the emergency bridge now: conf-link. This requires your immediate action.",
+    receivedDate: new Date(),
+    headers: { "Importance": "High" }
+  };
+
+  try {
+    const resultUrgent = await skill.execute(urgentEmail);
+    console.log("\\n--- Urgent Email Triage Result ---");
+    console.log(JSON.stringify(resultUrgent, null, 2));
+  } catch (error) {
+    console.error("Error during Urgent EmailTriageSkill execution:", error);
+  }
+}
+
+// testEmailTriageSkill();
+*/

--- a/src/skills/learningAndGuidanceSkill.ts
+++ b/src/skills/learningAndGuidanceSkill.ts
@@ -1,0 +1,402 @@
+import { invokeLLM } from '../lib/llmUtils';
+
+// Mock Knowledge Base Data
+const MOCK_KB_ARTICLES: KnowledgeBaseArticle[] = [
+  {
+    id: "kb_001",
+    title: "How to Create Pivot Tables in SpreadsheetApp",
+    contentType: 'how-to',
+    application: "SpreadsheetApp",
+    keywords: ["pivot table", "spreadsheet", "data analysis", "report"],
+    content: "Pivot tables are a powerful tool for summarizing and analyzing large datasets. This guide explains how to create them in SpreadsheetApp.",
+    steps: [
+      { title: "Select Your Data", description: "Click on any cell within the data range you want to analyze." },
+      { title: "Insert Pivot Table", description: "Go to the 'Insert' menu and choose 'PivotTable'." },
+      { title: "Configure Fields", description: "In the PivotTable editor pane, drag fields into Rows, Columns, Values, and Filters areas." },
+      { title: "Customize", description: "Use options to sort, filter, and format your pivot table." }
+    ],
+    difficulty: 'intermediate',
+  },
+  {
+    id: "kb_002",
+    title: "Tutorial: Email Merge with Attachments",
+    contentType: 'tutorial',
+    application: "EmailClient",
+    keywords: ["email merge", "mail merge", "attachments", "bulk email", "tutorial"],
+    content: "This tutorial walks you through performing an email merge operation with personalized attachments using EmailClient and SpreadsheetApp for data.",
+    steps: [
+      { title: "Prepare Data Source", description: "Create a spreadsheet with recipient emails, names, and attachment file paths." },
+      { title: "Open EmailClient Merge Tool", description: "In EmailClient, find the 'Mail Merge Wizard' under 'Tools'." },
+      { title: "Connect Data Source", description: "Link your spreadsheet to the wizard." },
+      { title: "Compose Template", description: "Write your email template using placeholders for personalized fields (e.g., {{FirstName}})." },
+      { title: "Configure Attachments", description: "Specify the column in your spreadsheet that contains the path to each recipient's attachment." },
+      { title: "Preview and Send", description: "Review a few merged emails then start the send process." }
+    ],
+    difficulty: 'intermediate',
+  },
+  {
+    id: "kb_003",
+    title: "FAQ: Common Login Issues",
+    contentType: 'faq',
+    application: "General", // Applicable to multiple apps or system-wide
+    keywords: ["login", "password", "access denied", "troubleshooting", "faq"],
+    content: "Q: I forgot my password. How do I reset it?\nA: Click the 'Forgot Password' link on the login page and follow the instructions sent to your email.\n\nQ: Why am I seeing 'Access Denied' errors?\nA: This could be due to incorrect credentials, insufficient permissions, or network issues. Please verify your username/password and contact support if the problem persists.\n\nQ: What are the password complexity requirements?\nA: Passwords must be at least 12 characters, include uppercase, lowercase, numbers, and symbols.",
+    difficulty: 'beginner',
+  },
+  {
+    id: "kb_004",
+    title: "Understanding Conditional Formatting",
+    contentType: 'explanation',
+    application: "SpreadsheetApp",
+    keywords: ["conditional formatting", "spreadsheet", "data visualization", "rules"],
+    content: "Conditional formatting allows you to automatically apply formatting (like colors, icons, and data bars) to cells that meet certain criteria. This helps in visualizing data, highlighting important information, and identifying trends. You can set up rules based on cell values, formulas, or dates. Common uses include highlighting cells greater than a certain number, color-coding sales performance, or identifying duplicate values.",
+    difficulty: 'beginner',
+  },
+  {
+    id: "kb_005",
+    title: "Workflow Guide: New Client Onboarding",
+    contentType: 'workflow_guide',
+    application: "CRM_Platform",
+    keywords: ["client onboarding", "crm", "workflow", "new customer", "process"],
+    content: "This guide outlines the standard procedure for onboarding new clients in the CRM_Platform.",
+    steps: [
+        {title: "Receive Lead", description: "New lead is captured from web form or manual entry."},
+        {title: "Initial Contact & Qualification", description: "Sales rep makes initial contact within 24 hours to qualify the lead."},
+        {title: "Needs Assessment Meeting", description: "Schedule and conduct a meeting to understand client requirements."},
+        {title: "Proposal Creation", description: "Generate a tailored proposal in the CRM using approved templates."},
+        {title: "Contract & Signature", description: "Send contract for e-signature via integrated tool."},
+        {title: "Project Kickoff", description: "Once signed, schedule internal and client kickoff meetings."},
+        {title: "CRM Record Update", description: "Update client status to 'Active' and populate all relevant fields."}
+    ],
+    difficulty: 'intermediate',
+  }
+];
+
+// Helper function to simulate fetching/searching knowledge base articles
+async function _fetchMockKnowledgeBaseArticles(
+  query: string,
+  contentTypeHint?: KnowledgeBaseArticle['contentType'],
+  applicationContext?: string,
+  maxResults: number = 3
+): Promise<KnowledgeBaseArticle[]> {
+  console.log(`[_fetchMockKnowledgeBaseArticles] Query: "${query}", ContentType: ${contentTypeHint}, AppCtx: ${applicationContext}, MaxResults: ${maxResults}`);
+
+  const queryLower = query.toLowerCase();
+  const queryKeywords = queryLower.split(/\s+/).filter(kw => kw.length > 2);
+
+  let filteredArticles = MOCK_KB_ARTICLES;
+
+  if (applicationContext) {
+    filteredArticles = filteredArticles.filter(article =>
+      !article.application || article.application.toLowerCase() === applicationContext.toLowerCase() || article.application === "General"
+    );
+  }
+  if (contentTypeHint) {
+    filteredArticles = filteredArticles.filter(article => article.contentType === contentTypeHint);
+  }
+
+  // Simple keyword scoring (very basic)
+  const scoredArticles = filteredArticles.map(article => {
+    let score = 0;
+    const titleLower = article.title.toLowerCase();
+    const contentSnippetLower = article.content.substring(0, 300).toLowerCase(); // Search in snippet
+
+    queryKeywords.forEach(kw => {
+      if (titleLower.includes(kw)) score += 3;
+      if (article.keywords?.some(k => k.toLowerCase().includes(kw))) score += 2;
+      if (contentSnippetLower.includes(kw)) score += 1;
+    });
+    // Boost if content type matches common query terms
+    if (queryLower.includes(article.contentType)) score +=2;
+
+
+    return { article, score };
+  }).filter(item => item.score > 0) // Only include articles with some match
+    .sort((a, b) => b.score - a.score); // Sort by score descending
+
+  console.log(`[_fetchMockKnowledgeBaseArticles] Found ${scoredArticles.length} potentially relevant articles after filtering and scoring.`);
+  return scoredArticles.slice(0, maxResults).map(item => item.article);
+}
+
+
+/**
+ * Represents an article or entry in the knowledge base.
+ */
+export interface KnowledgeBaseArticle {
+  id: string;
+  title: string;
+  contentType: 'tutorial' | 'how-to' | 'faq' | 'workflow_guide' | 'explanation';
+  application?: string; // e.g., "SpreadsheetApp", "CRM_Platform", "General"
+  keywords?: string[];
+  content: string; // Can be Markdown, plain text, or structured content
+  steps?: { title: string; description: string; }[]; // For tutorials or workflows
+  difficulty?: 'beginner' | 'intermediate' | 'advanced';
+  // lastUpdatedAt?: Date;
+}
+
+/**
+ * Type of guidance the user is seeking or the skill determines is needed.
+ */
+export type GuidanceType = 'answer_question' | 'find_tutorial' | 'guide_workflow' | 'general_explanation';
+
+/**
+ * Input for the LearningAndGuidanceSkill.
+ */
+export interface LearningAndGuidanceInput {
+  userId: string;
+  query: string; // e.g., "how do I create a pivot table in SpreadsheetApp?"
+  guidanceTypeHint?: GuidanceType; // Optional hint from NLU or previous interaction
+  applicationContext?: string; // Optional: current application user is in, e.g., "SpreadsheetApp"
+  options?: {
+    preferContentType?: KnowledgeBaseArticle['contentType'];
+    maxResults?: number; // Max number of guidance items to return
+  };
+}
+
+/**
+ * Represents a piece of guidance provided to the user, derived from a KB article.
+ */
+export interface ProvidedGuidance {
+  title: string; // Usually from the source KB article
+  contentSnippet?: string; // A direct answer or a key snippet for explanations
+  fullContent?: string; // Optional: The full content if concise or specifically requested
+  steps?: { title: string; description: string; }[]; // For tutorials/workflows
+  sourceArticleId: string;
+  relevanceScore?: number; // How relevant this piece of guidance is to the query
+}
+
+/**
+ * Output result from the LearningAndGuidanceSkill.
+ */
+export interface LearningAndGuidanceResult {
+  originalQuery: string;
+  guidanceProvided: ProvidedGuidance[];
+  followUpSuggestions?: string[]; // e.g., "Learn about advanced pivot table features."
+  searchPerformedOn?: string; // e.g., "KB Articles for SpreadsheetApp", "All KB Articles"
+  // errors?: string[];
+}
+
+/**
+ * Skill to provide tutorials, answer how-to questions, and guide users.
+ */
+export class LearningAndGuidanceSkill {
+  constructor() {
+    console.log("LearningAndGuidanceSkill initialized.");
+    // In a real system, this might load/connect to a knowledge base, vector index, etc.
+  }
+
+  /**
+   * Executes the learning and guidance process.
+   * @param input The LearningAndGuidanceInput from the user/system.
+   * @returns A Promise resolving to the LearningAndGuidanceResult.
+   */
+  public async execute(input: LearningAndGuidanceInput): Promise<LearningAndGuidanceResult> {
+    console.log(`[LearningAndGuidanceSkill] Received query: "${input.query}" for user: ${input.userId}`);
+
+    // Placeholder mock result
+    const mockGuidance: ProvidedGuidance = {
+      title: "Mock Article: How to do something",
+      contentSnippet: `This is a mock answer to your query: "${input.query}". Detailed steps would be listed if this were a real tutorial.`,
+      sourceArticleId: "kb-mock-001",
+      relevanceScore: 0.75,
+      steps: input.query.toLowerCase().includes("steps") || input.query.toLowerCase().includes("tutorial")
+        ? [{title: "Step 1 Mock", description: "Do the first thing."}, {title: "Step 2 Mock", description: "Then do the second thing."}]
+        : undefined,
+    };
+
+    const result: LearningAndGuidanceResult = {
+      originalQuery: input.query,
+      guidanceProvided: [mockGuidance],
+      followUpSuggestions: ["Ask about advanced features.", "Search for another topic."],
+      searchPerformedOn: input.applicationContext
+        ? `Mock KB for ${input.applicationContext}`
+        : "General Mock KB",
+    };
+
+    // Detailed LLM-centric logic will be outlined as comments in the next step.
+
+    // 1. Validate input. (Basic check done, more specific validation could be added)
+    const maxResults = input.options?.maxResults || 3;
+    let effectiveGuidanceType: GuidanceType = input.guidanceTypeHint || 'answer_question'; // Default if no hint
+
+    if (!input.guidanceTypeHint) {
+        console.log(`[LearningAndGuidanceSkill] No guidanceTypeHint provided, attempting to classify query: "${input.query}"`);
+        const classificationPrompt = `
+          Classify this user query: "${input.query}"
+          Into one of the following GuidanceType categories:
+          'answer_question', 'find_tutorial', 'guide_workflow', 'general_explanation'.
+          Return ONLY the GuidanceType in a valid JSON format, like:
+          {"guidanceType": "TYPE_NAME"}
+        `;
+        try {
+            const llmClassificationResponse = await invokeLLM(classificationPrompt, 'cheapest');
+            console.log(`[LearningAndGuidanceSkill] LLM classification response: ${llmClassificationResponse}`);
+            const parsedResponse = JSON.parse(llmClassificationResponse);
+            const validTypes: GuidanceType[] = ['answer_question', 'find_tutorial', 'guide_workflow', 'general_explanation'];
+            if (parsedResponse && parsedResponse.guidanceType && validTypes.includes(parsedResponse.guidanceType as GuidanceType)) {
+                effectiveGuidanceType = parsedResponse.guidanceType as GuidanceType;
+            } else {
+                console.warn(`[LearningAndGuidanceSkill] LLM returned invalid or no guidanceType. Defaulting to '${effectiveGuidanceType}'. Response: ${llmClassificationResponse}`);
+            }
+        } catch (error) {
+            console.error(`[LearningAndGuidanceSkill] Error during LLM query classification:`, error);
+            // Keep the default effectiveGuidanceType
+        }
+    }
+    console.log(`[LearningAndGuidanceSkill] Effective guidance type: ${effectiveGuidanceType}`);
+
+    // 3. Fetch relevant articles using _fetchMockKnowledgeBaseArticles, potentially refining search terms with LLM.
+    //    Example LLM call for search terms: let searchTermsForKB = await invokeLLM(\`Extract keywords for KB search from query: "${input.query}"\`, 'cheapest');
+    const searchTerms = input.query; // Using raw query for mock fetcher
+    const relevantArticles = await _fetchMockKnowledgeBaseArticles(
+        searchTerms,
+        input.options?.preferContentType,
+        input.applicationContext,
+        maxResults
+    );
+    console.log(`[LearningAndGuidanceSkill] Fetched ${relevantArticles.length} relevant articles.`);
+
+    // 4. Initialize guidanceProvided: ProvidedGuidance[] = []
+    const guidanceProvided: ProvidedGuidance[] = [];
+
+    // 5. For each relevantArticle:
+    for (const article of relevantArticles) {
+      //    a. Based on effectiveGuidanceType:
+      //        - If 'answer_question': prompt = "Answer '${input.query}' using this text: ${article.content}. Return just the answer." -> answerContent
+      //        - If 'find_tutorial'/'guide_workflow': prompt = "Extract key steps for '${input.query}' from this tutorial: ${article.content}. Return as JSON {steps: [{title:'', description:''}]}" -> extractedSteps
+      //        - If 'general_explanation': prompt = "Summarize this text regarding '${input.query}': ${article.content}. Return concise explanation." -> explanationContent
+      //    b. Call LLM: const llmResponse = await invokeLLM(prompt, 'cheapest') (Conceptual)
+      //    c. Parse llmResponse and populate a ProvidedGuidance object (title, contentSnippet/fullContent, steps, sourceArticleId, mock relevanceScore).
+      //    d. Add to guidanceProvided.
+
+      let guidance: ProvidedGuidance = {
+        title: article.title,
+        sourceArticleId: article.id,
+        relevanceScore: 0.6, // Base relevance for being fetched
+      };
+
+      let llmResponseForArticleProcessing: string;
+
+      switch (effectiveGuidanceType) {
+        case 'answer_question':
+        case 'general_explanation':
+          const answerPrompt = `Using ONLY the provided text from the article titled '${article.title}', please answer the question: '${input.query}'. Return only the direct answer. Text: '${article.content.substring(0, 1500)}...'`;
+          llmResponseForArticleProcessing = await invokeLLM(answerPrompt, 'cheapest');
+          if (llmResponseForArticleProcessing && !llmResponseForArticleProcessing.toLowerCase().startsWith("llm fallback") && !llmResponseForArticleProcessing.toLowerCase().includes("not appear to contain")) {
+            guidance.contentSnippet = llmResponseForArticleProcessing;
+            guidance.relevanceScore = 0.8; // Higher score if LLM found direct answer
+            console.log(`[LearningAndGuidanceSkill] LLM Answer/Explanation for "${article.title}": ${guidance.contentSnippet}`);
+          } else {
+            guidance.contentSnippet = `Article "${article.title}" was found, but a direct answer/explanation for "${input.query}" could not be extracted by the LLM. You may find relevant information within.`;
+             console.log(`[LearningAndGuidanceSkill] LLM could not provide direct answer/explanation for "${article.title}" or fallback.`);
+          }
+          break;
+
+        case 'find_tutorial':
+        case 'guide_workflow':
+        // Note: 'how-to' was used in mock _fetchKBArticles, ensure it's mapped or included in GuidanceType if distinct
+        // For now, we'll treat 'how-to' effectively as 'find_tutorial' or 'guide_workflow'
+          if (article.steps && article.steps.length > 0) {
+            guidance.steps = article.steps;
+            guidance.contentSnippet = `Found relevant steps in "${article.title}".`;
+            guidance.relevanceScore = 0.85; // Higher score for direct step match
+            console.log(`[LearningAndGuidanceSkill] Using predefined steps for "${article.title}".`);
+          } else {
+            const stepsPrompt = `Extract the key steps relevant to the query '${input.query}' from the content of '${article.title}'. Return as a JSON object: {"steps": [{"title":"Step 1 Title", "description":"Step 1 Description"}, ...]}. If no specific steps are found, return {"steps": []}. Content: '${article.content.substring(0, 2000)}...'`;
+            llmResponseForArticleProcessing = await invokeLLM(stepsPrompt, 'cheapest');
+            console.log(`[LearningAndGuidanceSkill] LLM steps response for "${article.title}": ${llmResponseForArticleProcessing}`);
+            try {
+              const parsedSteps = JSON.parse(llmResponseForArticleProcessing);
+              if (parsedSteps && Array.isArray(parsedSteps.steps) && parsedSteps.steps.length > 0) {
+                guidance.steps = parsedSteps.steps;
+                guidance.contentSnippet = "Extracted the following key steps from the article:";
+                guidance.relevanceScore = 0.8;
+              } else {
+                 guidance.contentSnippet = `While "${article.title}" is relevant, specific steps for "${input.query}" were not automatically extracted. You can review the article content.`;
+              }
+            } catch (e) {
+              console.error(`[LearningAndGuidanceSkill] Error parsing steps JSON from LLM for "${article.title}":`, e);
+              guidance.contentSnippet = `Could not extract steps for "${article.title}". The article might still be relevant.`;
+            }
+          }
+          break;
+
+        default: // Should not be reached if effectiveGuidanceType is always set
+            guidance.contentSnippet = `Found article: ${article.title}. Displaying general information. (First 200 chars): ${article.content.substring(0, 200)}...`;
+            console.warn(`[LearningAndGuidanceSkill] Unexpected guidance type: ${effectiveGuidanceType}`);
+      }
+
+      // Fallback if no specific content generated yet
+      if (!guidance.contentSnippet && (!guidance.steps || guidance.steps.length === 0)) {
+        guidance.contentSnippet = `Article "${article.title}" may contain information relevant to your query. (Excerpt: ${article.content.substring(0, 150)}...)`;
+      }
+      guidanceProvided.push(guidance);
+    }
+
+    // 6. (Optional) Generate followUpSuggestions with LLM
+    let followUpSuggestions: string[] | undefined = undefined;
+    if (guidanceProvided.length > 0 && guidanceProvided[0]) { // Ensure there's at least one piece of guidance
+        const firstGuidanceTitle = guidanceProvided[0].title;
+        const followUpPrompt = `
+          Given the user query "${input.query}" and that guidance on "${firstGuidanceTitle}" was provided,
+          suggest two distinct, related topics or advanced features the user might want to learn next.
+          Return as JSON: {"suggestions": ["Suggestion 1", "Suggestion 2"]}.
+          If no specific suggestions come to mind, return {"suggestions": []}.
+        `;
+        try {
+            const llmFollowUpResponse = await invokeLLM(followUpPrompt, 'cheapest');
+            console.log(`[LearningAndGuidanceSkill] LLM follow-up suggestions response: ${llmFollowUpResponse}`);
+            const parsedFollowUp = JSON.parse(llmFollowUpResponse);
+            if (parsedFollowUp && Array.isArray(parsedFollowUp.suggestions) && parsedFollowUp.suggestions.length > 0) {
+                followUpSuggestions = parsedFollowUp.suggestions.filter((s: any): s is string => typeof s === 'string');
+            }
+        } catch (e) {
+            console.error(`[LearningAndGuidanceSkill] Error processing LLM follow-up suggestions:`, e);
+        }
+    }
+
+    result.guidanceProvided = guidanceProvided;
+    result.followUpSuggestions = followUpSuggestions;
+    result.searchPerformedOn = `${relevantArticles.length} articles from ${input.applicationContext || 'General'} KB matching "${searchTerms.substring(0,50)}..."`;
+
+
+    console.log(`[LearningAndGuidanceSkill] Returning processed guidance for query: "${input.query}"`);
+    return result;
+  }
+}
+
+// Example Usage (for testing or demonstration)
+/*
+async function testLearningAndGuidanceSkill() {
+  const skill = new LearningAndGuidanceSkill();
+
+  const testInput1: LearningAndGuidanceInput = {
+    userId: "user-guidance-test-1",
+    query: "How do I create a filter in SpreadsheetApp?",
+    applicationContext: "SpreadsheetApp",
+    options: { preferContentType: 'how-to', maxResults: 1 }
+  };
+  try {
+    console.log("\\n--- Test Case 1: How-to question ---");
+    const result1 = await skill.execute(testInput1);
+    console.log(JSON.stringify(result1, null, 2));
+  } catch (error) {
+    console.error("Error (Test Case 1):", error);
+  }
+
+  const testInput2: LearningAndGuidanceInput = {
+    userId: "user-guidance-test-2",
+    query: "Give me a tutorial on email merge",
+    guidanceTypeHint: 'find_tutorial'
+  };
+  try {
+    console.log("\\n--- Test Case 2: Find tutorial ---");
+    const result2 = await skill.execute(testInput2);
+    console.log(JSON.stringify(result2, null, 2));
+  } catch (error) {
+    console.error("Error (Test Case 2):", error);
+  }
+}
+
+// testLearningAndGuidanceSkill();
+*/

--- a/src/skills/smartMeetingPrepSkill.ts
+++ b/src/skills/smartMeetingPrepSkill.ts
@@ -1,0 +1,315 @@
+import { findCalendarEventByFuzzyReference, CalendarEventSummary, DateHints } from './calendarSkills';
+
+// Define the expected structure of the skill's input
+export interface SmartMeetingPrepSkillInput {
+  userId: string;
+  meeting_reference: string; // e.g., "my meeting tomorrow morning", "the project sync-up"
+  // Potentially other context like preferred language for summaries, etc.
+}
+
+// Define the expected structure of the skill's output (for now, just the event or nothing)
+// This would expand to include prep notes, document links, etc.
+export interface SmartMeetingPrepSkillOutput {
+  resolvedEvent?: CalendarEventSummary;
+  preparationNotes?: string;
+  relatedDocuments?: any[]; // Using any for mock documents for now
+  // other output fields
+}
+
+export class SmartMeetingPrepSkill {
+  constructor() {
+    // Initialization logic for the skill, if any (e.g., API clients, settings)
+  }
+
+  /**
+   * Executes the smart meeting preparation skill.
+   *
+   * @param input - The input parameters for the skill.
+   * @returns A promise that resolves to the skill's output, including the resolved event
+   *          and any generated preparation materials (though initially just the event).
+   */
+  public async execute(input: SmartMeetingPrepSkillInput): Promise<SmartMeetingPrepSkillOutput> {
+    console.log(`SmartMeetingPrepSkill: Received request for userId: ${input.userId}, meeting_reference: "${input.meeting_reference}"`);
+
+    // Step 1: Resolve the calendar event
+    // For now, date_hints is undefined. This could be derived or passed in input in the future.
+    const date_hints: DateHints | undefined = undefined;
+
+    const resolvedEvent = await findCalendarEventByFuzzyReference(
+      input.userId,
+      input.meeting_reference,
+      date_hints
+    );
+
+    let preparationNotes: string | undefined = undefined;
+    let relatedDocuments: any[] = [];
+
+    if (resolvedEvent) {
+      console.log(`SmartMeetingPrepSkill: Resolved event - Title: ${resolvedEvent.title}, StartTime: ${resolvedEvent.startTime}`);
+
+      // Step 2: Find related documents (mocked)
+      relatedDocuments = await this._findRelatedDocuments(resolvedEvent);
+
+      // Step 3: Generate preparation notes (mocked)
+      preparationNotes = await this._generatePreparationNotes(resolvedEvent, relatedDocuments);
+
+      console.log(`SmartMeetingPrepSkill: Successfully generated preparation materials for "${resolvedEvent.title}".`);
+
+    } else {
+      console.log(`SmartMeetingPrepSkill: Could not resolve a specific calendar event for "${input.meeting_reference}". No preparation materials will be generated.`);
+      preparationNotes = `Could not resolve a specific calendar event for reference: "${input.meeting_reference}". Please try a more specific query or check your calendar.`;
+    }
+
+    const output: SmartMeetingPrepSkillOutput = {
+      resolvedEvent: resolvedEvent,
+      relatedDocuments: relatedDocuments,
+      preparationNotes: preparationNotes,
+    };
+
+    console.log("[SmartMeetingPrepSkill.execute] Final output:", JSON.stringify(output, null, 2));
+    return output;
+  }
+
+  private async _findRelatedDocuments(event: CalendarEventSummary): Promise<any[]> {
+    console.log(`[SmartMeetingPrepSkill._findRelatedDocuments] Dynamically finding mock documents for event: "${event.title}" (ID: ${event.id})`);
+    const mockDocs: any[] = [];
+    const titleLower = event.title.toLowerCase();
+    const descriptionLower = event.description?.toLowerCase() || "";
+
+    // Title-based document mocking
+    if (titleLower.includes("budget") || descriptionLower.includes("budget")) {
+      mockDocs.push({ name: `Budget Overview for ${event.title}.xlsx`, url: `internal://finance/budget-${event.id}.xlsx`, type: "spreadsheet" });
+    }
+    if (titleLower.includes("phoenix") || descriptionLower.includes("phoenix")) {
+      mockDocs.push({ name: `Project Phoenix Status - ${event.id}.pptx`, url: `internal://projects/phoenix/status-${event.id}.pptx`, type: "presentation" });
+    }
+    if (titleLower.includes("marketing") || titleLower.includes("strategy") || descriptionLower.includes("marketing") || descriptionLower.includes("strategy")) {
+      mockDocs.push({ name: `Marketing Strategy Brief - ${event.id}.pdf`, url: `internal://marketing/strategy-${event.id}.pdf`, type: "pdf" });
+    }
+
+    // Attendee-based document mocking
+    if (event.attendees) {
+      for (const attendeeString of event.attendees) {
+        // Using a simplified name extraction here, assuming _extractNameFromAttendeeString is in calendarSkills.ts
+        // For direct use here, we'd either import it or use a simpler inline version.
+        // Let's use a very simple inline version for this mock:
+        const namePart = attendeeString.split('<')[0].trim().toLowerCase();
+        const simpleName = namePart.split(' ')[0]; // first word of the name part
+
+        if (simpleName === "alice") {
+          mockDocs.push({ name: `Alice's Action Items from previous sessions.txt`, url: `internal://users/alice/actions-${event.id}.txt`, type: "text" });
+        }
+        if (simpleName === "mark") {
+          mockDocs.push({ name: `Mark's Proposal Draft for ${event.title}.docx`, url: `internal://users/mark/drafts/prop-${event.id}.docx`, type: "document" });
+        }
+         if (simpleName === "sarah" && titleLower.includes("1:1")) {
+          mockDocs.push({ name: `Performance Review Notes - Sarah Miller.pdf`, url: `internal://hr/reviews/sarahm-${event.id}.pdf`, type: "confidential" });
+        }
+      }
+    }
+
+    // Generic documents
+    mockDocs.push({ name: `Minutes from last general meeting on '${event.title}'.pdf`, url: `internal://meetings/minutes/prev-${event.id}.pdf`, type: "minutes" });
+
+    if (mockDocs.length === 0) {
+      mockDocs.push({ name: `Standard Agenda Template.docx`, url: "internal://templates/agenda.docx", type: "template" });
+    }
+
+    // Deduplicate (simple check based on name)
+    const uniqueDocs = Array.from(new Set(mockDocs.map(doc => doc.name)))
+        .map(name => mockDocs.find(doc => doc.name === name));
+
+    console.log(`[SmartMeetingPrepSkill._findRelatedDocuments] Found ${uniqueDocs.length} mock documents dynamically.`);
+    return uniqueDocs.slice(0, 4); // Cap at 4 documents for brevity
+  }
+
+  private async _generatePreparationNotes(event: CalendarEventSummary, documents: any[]): Promise<string> {
+    console.log(`[SmartMeetingPrepSkill._generatePreparationNotes] Dynamically generating notes for event: "${event.title}"`);
+    const titleLower = event.title.toLowerCase();
+    const descriptionLower = event.description?.toLowerCase() || "";
+
+    let notes = `## Meeting Preparation Notes: ${event.title}\n\n`;
+    notes += `**Scheduled:** ${event.startTime.toLocaleString()} - ${event.endTime.toLocaleString()}\n`;
+    notes += `**Location:** ${event.location || "Not specified"}\n`;
+    notes += `**Organizer:** ${event.organizer || "N/A"}\n`;
+
+    const attendeeList = event.attendees && event.attendees.length > 0
+      ? event.attendees.map(a => a.split('<')[0].trim()).join(", ") // Show cleaner names
+      : "No attendees listed";
+    notes += `**Attendees:** ${attendeeList}\n\n`;
+
+    if (event.description) {
+      notes += `**Description/Agenda:**\n${event.description}\n\n`;
+    }
+
+    notes += "**Key Discussion Points (Suggested):**\n";
+    const discussionPoints: string[] = [];
+    if (titleLower.includes("budget") || descriptionLower.includes("budget")) {
+      discussionPoints.push("Review budget figures and allocations.");
+      const budgetDoc = documents.find(doc => doc.name.toLowerCase().includes("budget"));
+      if (budgetDoc) {
+        discussionPoints.push(`Analyze data in "${budgetDoc.name}".`);
+      }
+    }
+    if (titleLower.includes("strategy") || titleLower.includes("planning") || descriptionLower.includes("strategy") || descriptionLower.includes("planning")) {
+      discussionPoints.push("Define/Review strategic goals and next actions.");
+    }
+    if (titleLower.includes("phoenix") || descriptionLower.includes("phoenix")) {
+      discussionPoints.push("Assess Project Phoenix progress and address blockers.");
+    }
+    if (titleLower.includes("1:1")) {
+        const attendeeName = event.title.replace("1:1 with", "").trim(); // Simple extraction
+        discussionPoints.push(`Discuss ${attendeeName}'s progress, goals, and any challenges.`);
+    }
+     if (discussionPoints.length === 0) {
+      discussionPoints.push("Clarify meeting objectives and desired outcomes.");
+      discussionPoints.push("Identify key topics based on participant roles.");
+    }
+    discussionPoints.forEach(point => notes += `- ${point}\n`);
+    notes += "\n";
+
+    notes += "**Relevant Materials & Context:**\n";
+    if (documents.length > 0) {
+      documents.forEach(doc => {
+        notes += `- **${doc.name}** (${doc.type}): Review this document for relevant background/data.\n`;
+      });
+    } else {
+      notes += "- No specific documents were automatically linked. Consider searching manually if needed.\n";
+    }
+    notes += "\n";
+
+    notes += "**Potential Action Items to Consider from This Meeting (TODO):**\n";
+    notes += "- [Assign owners and deadlines for new tasks]\n";
+    notes += "- [Schedule follow-up meetings if necessary]\n\n";
+
+
+    notes += "**Action Items from Previous Related Meetings (TODO):**\n";
+    const actionItemDoc = documents.find(doc => doc.name.toLowerCase().includes("action items"));
+    const minutesDoc = documents.find(doc => doc.name.toLowerCase().includes("minutes"));
+    if (actionItemDoc) {
+      notes += `- Review action items from "${actionItemDoc.name}".\n`;
+    } else if (minutesDoc) {
+      notes += `- Check for open action items in "${minutesDoc.name}".\n`;
+    } else {
+      notes += "- Check for any outstanding action items from prior relevant meetings.\n";
+    }
+    notes += "\n";
+
+    // Enhanced Attendee Section - check for specific people and tailor notes
+    if (event.attendees) {
+        const lowerAttendees = event.attendees.map(a => a.toLowerCase());
+        if (lowerAttendees.some(a => a.includes("alice"))) {
+            const aliceDoc = documents.find(d => d.name.toLowerCase().includes("alice's action items"));
+            if (aliceDoc) {
+                notes += `**For Alice:** Please come prepared to discuss items from "${aliceDoc.name}".\n`;
+            } else {
+                notes += `**For Alice:** Be ready to provide updates on your current tasks.\n`;
+            }
+        }
+         if (lowerAttendees.some(a => a.includes("mark"))) {
+            const markDoc = documents.find(d => d.name.toLowerCase().includes("mark's proposal draft"));
+            if (markDoc) {
+                notes += `**For Mark:** Key discussion point will be your proposal: "${markDoc.name}".\n`;
+            }
+        }
+        notes += "\n";
+    }
+
+
+    notes += "---\nGenerated by SmartMeetingPrepSkill";
+    console.log(`[SmartMeetingPrepSkill._generatePreparationNotes] Dynamically generated notes for "${event.title}". Length: ${notes.length}`);
+    return notes;
+  }
+}
+
+// Example of how this skill might be instantiated and used (for testing/demonstration)
+// This would typically be done by a skill orchestrator or a higher-level application logic.
+
+async function testSkill() {
+  const skill = new SmartMeetingPrepSkill();
+  const userId = "user123-test"; // Consistent user ID for tests
+
+  console.log("\\n--- Test Case 1: General reference 'sync up tomorrow' ---");
+  let testInput: SmartMeetingPrepSkillInput = {
+    userId: userId,
+    meeting_reference: "my sync up tomorrow"
+  };
+  try {
+    let result = await skill.execute(testInput);
+    console.log("Skill execution result (sync up tomorrow):", JSON.stringify(result.resolvedEvent?.title || "Not Found", null, 2));
+  } catch (error) {
+    console.error("Error executing skill (sync up tomorrow):", error);
+  }
+
+  console.log("\\n--- Test Case 2: Specific 'Marketing Strategy' ---");
+  testInput = {
+    userId: userId,
+    meeting_reference: "Marketing Strategy meeting"
+  };
+  try {
+    let result = await skill.execute(testInput);
+    console.log("Skill execution result (Marketing Strategy):", JSON.stringify(result.resolvedEvent?.title || "Not Found", null, 2));
+  } catch (error) {
+    console.error("Error executing skill (Marketing Strategy):", error);
+  }
+
+  console.log("\\n--- Test Case 3: Reference with specific project name 'Project Phoenix discussion' ---");
+  testInput = {
+    userId: userId,
+    meeting_reference: "Project Phoenix discussion"
+  };
+  try {
+    let result = await skill.execute(testInput);
+    console.log("Skill execution result (Phoenix discussion):", JSON.stringify(result.resolvedEvent?.title || "Not Found", null, 2));
+     // It should pick "Project Phoenix - Critical Path Discussion" if "discussion" is a keyword and it's sooner or scores higher.
+     // Or "Project Phoenix Sync-Up" if that scores higher due to "sync up" vs "discussion"
+  } catch (error) {
+    console.error("Error executing skill (Phoenix discussion):", error);
+  }
+
+  console.log("\\n--- Test Case 4: Vague reference 'my meeting' ---");
+  testInput = {
+    userId: userId,
+    meeting_reference: "my meeting"
+  };
+  try {
+    let result = await skill.execute(testInput);
+    console.log("Skill execution result (my meeting):", JSON.stringify(result.resolvedEvent?.title || "Not Found", null, 2));
+    // This should likely pick the soonest one if "meeting" is too generic or not a good keyword.
+    // Current logic might give low scores to all if "meeting" isn't in titles.
+  } catch (error) {
+    console.error("Error executing skill (my meeting):", error);
+  }
+
+  console.log("\\n--- Test Case 5: Non-existent meeting 'board game night' ---");
+  testInput = {
+    userId: userId,
+    meeting_reference: "board game night"
+  };
+  try {
+    let result = await skill.execute(testInput);
+    console.log("Skill execution result (board game night):", JSON.stringify(result.resolvedEvent?.title || "Not Found", null, 2));
+  } catch (error) {
+    console.error("Error executing skill (board game night):", error);
+  }
+
+  // To test date_hints, findCalendarEventByFuzzyReference would need to be called directly
+  // or SmartMeetingPrepSkillInput would need to support date_hints.
+  // For now, direct calls to findCalendarEventByFuzzyReference for date_hint testing:
+  console.log("\\n--- Test Case 6: Direct call with specific date hint (past event) ---");
+  try {
+    const pastDate = new Date();
+    pastDate.setDate(pastDate.getDate() - 7); // Targeting "Budget Review Q2"
+    pastDate.setHours(12,0,0,0); // Set a specific time on that day to ensure it's within the event's day
+    const event = await findCalendarEventByFuzzyReference(userId, "budget review", { specificDate: pastDate });
+    console.log("Direct call result (budget review last week):", JSON.stringify(event?.title || "Not Found", null, 2));
+  } catch (error) {
+    console.error("Error in direct call (budget review last week):", error);
+  }
+}
+
+// To run the test:
+// You would typically uncomment this in a local environment or run this through a test runner.
+// For agent-based execution, we usually don't invoke testSkill() directly here
+// unless specifically instructed for a one-off test run.
+// testSkill();

--- a/src/skills/workflowAutomationSuggesterSkill.ts
+++ b/src/skills/workflowAutomationSuggesterSkill.ts
@@ -1,0 +1,168 @@
+// import { invokeLLM } from '../lib/llmUtils'; // For future LLM-based enhancements
+
+/**
+ * Represents a single observed user action.
+ */
+export interface UserAction {
+  id: string; // Unique ID for the action event
+  timestamp: Date;
+  userId: string;
+  application: string; // e.g., "EmailClient", "SpreadsheetApp", "TextEditor", "Browser"
+  actionType: string;  // e.g., "COPY_CELL_RANGE", "PASTE_INTO_BODY", "CREATE_NEW_EMAIL", "NAVIGATE_URL"
+  details?: Record<string, any>; // Specifics of the action, e.g., { range: 'A1:B10', url: 'http://...' }
+}
+
+/**
+ * Represents a suggestion for automating a detected repetitive workflow.
+ */
+export interface AutomationSuggestion {
+  id: string; // Unique ID for the suggestion
+  title: string; // User-friendly title, e.g., "Automate sending weekly report data"
+  description: string; // Explanation of the repetitive pattern detected
+  basedOnActionIds: string[]; // IDs of the UserAction events that form the detected pattern
+  suggestedMacro?: string; // Pseudo-code or descriptive steps for the automation
+  userBenefit?: string; // e.g., "Saves approximately 2 minutes per task"
+  confidence?: number; // How confident the system is that this is a useful suggestion (0.0 to 1.0)
+  // We could also add: estimatedTimeSavedPerInstance: number (in seconds/minutes)
+  //                     frequencyOfPattern: number (how many times it was observed in a period)
+}
+
+/**
+ * Input for the WorkflowAutomationSuggesterSkill.
+ */
+export interface WorkflowAutomationSuggesterSkillInput {
+  userId: string;
+  recentActions: UserAction[]; // A list of recent actions to analyze
+  // Could also include: analysisTimeWindow: { startDate: Date, endDate: Date }
+  //                     minPatternFrequency: number (to filter suggestions)
+}
+
+/**
+ * Skill to observe repetitive user actions and suggest potential automations.
+ */
+export class WorkflowAutomationSuggesterSkill {
+  constructor() {
+    console.log("WorkflowAutomationSuggesterSkill initialized.");
+    // In a real system, this might connect to an action logging service or a pattern mining engine.
+  }
+
+  /**
+   * Analyzes recent user actions to find repetitive patterns and suggest automations.
+   * @param input The input containing the userId and a list of recent actions.
+   * @returns A Promise resolving to an array of AutomationSuggestion objects.
+   */
+  public async execute(input: WorkflowAutomationSuggesterSkillInput): Promise<AutomationSuggestion[]> {
+    console.log(`[WorkflowAutomationSuggesterSkill] Received ${input.recentActions.length} actions for user: ${input.userId}`);
+
+    const suggestions: AutomationSuggestion[] = [];
+
+    // 1. Validate input (userId, recentActions) - Basic check
+    if (!input.userId || !input.recentActions) {
+      console.warn("[WorkflowAutomationSuggesterSkill] Missing userId or recentActions.");
+      return [];
+    }
+    if (input.recentActions.length < 3) { // Need at least a few actions to find a pattern
+        console.log("[WorkflowAutomationSuggesterSkill] Not enough actions to detect patterns meaningfully.");
+        return [];
+    }
+    console.log(`[WorkflowAutomationSuggesterSkill] Analyzing ${input.recentActions.length} actions for user: ${input.userId}`);
+
+    // 2. Implement mock pattern detection:
+    //    Define a simple target pattern, e.g., sequence:
+    //      Action1: { application: 'SpreadsheetApp', actionType: 'COPY_CELL_RANGE' }
+    //      Action2: { application: 'EmailClient', actionType: 'CREATE_NEW_EMAIL' }
+    //      Action3: { application: 'EmailClient', actionType: 'PASTE_INTO_BODY' }
+    //      Action4: { application: 'EmailClient', actionType: 'SEND_EMAIL' }
+    //    (This is a very basic stand-in for complex pattern mining algorithms or LLM-based sequence analysis).
+
+    const actions = input.recentActions;
+    for (let i = 0; i < actions.length - 3; i++) { // Need at least 4 actions for this specific pattern
+        const potentialPatternActions = actions.slice(i, i + 4);
+
+        // Mock check for a specific hardcoded pattern: Copy from Spreadsheet, Create Email, Paste, Send.
+        if (
+            potentialPatternActions[0].application === 'SpreadsheetApp' && potentialPatternActions[0].actionType === 'COPY_CELL_RANGE' &&
+            potentialPatternActions[1].application === 'EmailClient' && potentialPatternActions[1].actionType === 'CREATE_NEW_EMAIL' &&
+            potentialPatternActions[2].application === 'EmailClient' && potentialPatternActions[2].actionType === 'PASTE_INTO_BODY' &&
+            potentialPatternActions[3].application === 'EmailClient' && potentialPatternActions[3].actionType === 'SEND_EMAIL'
+        ) {
+            console.log(`[WorkflowAutomationSuggesterSkill] Mock pattern "Copy-Paste-Send Report" detected starting at action ID ${potentialPatternActions[0].id}`);
+
+            // 4. If mock pattern is detected:
+            //    a. Create a corresponding AutomationSuggestion object
+            const suggestion: AutomationSuggestion = {
+                id: `sugg-${Date.now()}-${Math.random().toString(36).substring(2,7)}`,
+                title: "Automate Sending Copied Spreadsheet Data via Email",
+                description: "Detected a pattern where you copy data from a spreadsheet, create a new email, paste the data, and send it. This could potentially be automated.",
+                basedOnActionIds: potentialPatternActions.map(a => a.id),
+                suggestedMacro: `
+                  1. Get data from Spreadsheet (e.g., range specified in details: ${JSON.stringify(potentialPatternActions[0].details?.range || 'last copied range')}).
+                  2. Create new Email.
+                  3. (Optional) Set recipient (e.g., from details: ${JSON.stringify(potentialPatternActions[1].details?.to || 'common recipient')}).
+                  4. (Optional) Set subject (e.g., "Data Report").
+                  5. Paste/insert data into email body.
+                  6. Send Email.
+                `,
+                userBenefit: "Could save a few minutes each time this task is performed.",
+                confidence: 0.7, // Mock confidence
+            };
+            suggestions.push(suggestion);
+
+            // For this mock, let's only find the first instance of the pattern to keep it simple.
+            // In a real system, you'd find all occurrences or use more sophisticated frequency analysis.
+            break;
+        }
+    }
+
+    // 5. Return the suggestions array.
+    if (suggestions.length > 0) {
+        console.log(`[WorkflowAutomationSuggesterSkill] Generated ${suggestions.length} automation suggestion(s).`);
+    } else {
+        console.log("[WorkflowAutomationSuggesterSkill] No predefined mock patterns detected in the provided action sequence.");
+    }
+    return suggestions;
+  }
+}
+
+// Example Usage (for testing or demonstration)
+/*
+async function testWorkflowAutomationSuggesterSkill() {
+  const skill = new WorkflowAutomationSuggesterSkill();
+
+  // Sample actions that might form a pattern
+  const sampleActions: UserAction[] = [
+    { id: "act1", timestamp: new Date(), userId: "user123", application: "SpreadsheetApp", actionType: "COPY_CELL_RANGE", details: { sheet: "Sheet1", range: "A1:B10" } },
+    { id: "act2", timestamp: new Date(), userId: "user123", application: "EmailClient", actionType: "CREATE_NEW_EMAIL", details: { to: "report_distribution@example.com" } },
+    { id: "act3", timestamp: new Date(), userId: "user123", application: "EmailClient", actionType: "SET_SUBJECT", details: { subject: "Weekly Sales Data" } },
+    { id: "act4", timestamp: new Date(), userId: "user123", application: "EmailClient", actionType: "PASTE_INTO_BODY" },
+    { id: "act5", timestamp: new Date(), userId: "user123", application: "EmailClient", actionType: "SEND_EMAIL" },
+    // ... more actions, some repetitive, some not ...
+    { id: "act6", timestamp: new Date(), userId: "user123", application: "Browser", actionType: "NAVIGATE_URL", details: { url: "http://example.com/dashboard" } },
+    { id: "act7", timestamp: new Date(), userId: "user123", application: "SpreadsheetApp", actionType: "COPY_CELL_RANGE", details: { sheet: "Sheet1", range: "A1:B10" } },
+    { id: "act8", timestamp: new Date(), userId: "user123", application: "EmailClient", actionType: "CREATE_NEW_EMAIL", details: { to: "report_distribution@example.com" } },
+    { id: "act9", timestamp: new Date(), userId: "user123", application: "EmailClient", actionType: "SET_SUBJECT", details: { subject: "Weekly Sales Data" } },
+    { id: "act10", timestamp: new Date(), userId: "user123", application: "EmailClient", actionType: "PASTE_INTO_BODY" },
+    { id: "act11", timestamp: new Date(), userId: "user123", application: "EmailClient", actionType: "SEND_EMAIL" },
+  ];
+
+  const input: WorkflowAutomationSuggesterSkillInput = {
+    userId: "user123",
+    recentActions: sampleActions
+  };
+
+  try {
+    console.log("\\n--- Test Case: Workflow Automation Suggester ---");
+    const suggestions = await skill.execute(input);
+    if (suggestions.length > 0) {
+      console.log("Found suggestions:");
+      console.log(JSON.stringify(suggestions, null, 2));
+    } else {
+      console.log("No automation suggestions found for the given actions.");
+    }
+  } catch (error) {
+    console.error("Error during skill execution (Workflow Automation Suggester):", error);
+  }
+}
+
+// testWorkflowAutomationSuggesterSkill();
+*/


### PR DESCRIPTION
This commit introduces the initial scaffolding for five core AI assistant use cases:

1.  SmartMeetingPrepSkill: Prepares users for meetings by finding calendar events (rule-based fuzzy matching) and outlining document/notes generation (mocked).
2.  EmailTriageSkill: Triages emails using a (mocked) LLM-based approach for categorization, summarization, reply suggestion, and action item extraction. Includes HTML stripping.
3.  ContextualDocumentAssistantSkill: Finds information in documents using (mocked) LLM-based snippet extraction and summarization. Includes mock document store.
4.  WorkflowAutomationSuggesterSkill: Suggests automations by detecting a simple hardcoded pattern in a sequence of user actions (mocked).
5.  LearningAndGuidanceSkill: Provides learning materials by classifying user queries, fetching from a mock KB, and processing/presenting content using (mocked) LLM calls.

Includes a shared mock `invokeLLM` utility in `src/lib/llmUtils.ts` used by email, document, and learning skills.