### PR TITLE
refactor: Implement LLMServiceInterface and dependency injection

### DIFF
--- a/src/skills/contextualDocumentAssistantSkill.ts
+++ b/src/skills/contextualDocumentAssistantSkill.ts
@@ -1,10 +1,10 @@
 import {
-    invokeLLM, // This will be replaced by LLMServiceInterface instance
+    LLMServiceInterface, // Import the interface
     StructuredLLMPrompt,
     DocumentSnippetData,
     DocumentSummaryData,
     OverallSummaryData,
-    LLMServiceInterface // Import the interface
+    LLMTaskType // Assuming these types are exported from llmUtils
 } from '../lib/llmUtils';
 
 // Mock Documents Data Store
@@ -39,15 +39,11 @@ const MOCK_DOCUMENTS: DocumentContent[] = [
   }
 ];
 
-// Helper function to simulate fetching documents
 async function _fetchMockDocuments(documentIds?: string[]): Promise<DocumentContent[]> {
-  console.log(`[_fetchMockDocuments] Attempting to fetch documents. Specified IDs: ${documentIds?.join(', ')}`);
+  // console.log(`[_fetchMockDocuments] Attempting to fetch documents. Specified IDs: ${documentIds?.join(', ')}`);
   if (documentIds && documentIds.length > 0) {
-    const foundDocs = MOCK_DOCUMENTS.filter(doc => documentIds.includes(doc.id));
-    console.log(`[_fetchMockDocuments] Found ${foundDocs.length} documents matching specified IDs.`);
-    return foundDocs;
+    return MOCK_DOCUMENTS.filter(doc => documentIds.includes(doc.id));
   }
-  console.log(`[_fetchMockDocuments] No specific IDs provided, returning all ${MOCK_DOCUMENTS.length} mock documents.`);
   return MOCK_DOCUMENTS;
 }
 
@@ -113,7 +109,7 @@ export class ContextualDocumentAssistantSkill {
     let overallSummary: string | undefined = undefined;
 
     for (const doc of candidateDocuments.slice(0, maxResults)) {
-      console.log(`[ContextualDocumentAssistantSkill] Processing doc: ${doc.id} - ${doc.title}`);
+      // console.log(`[ContextualDocumentAssistantSkill] Processing doc: ${doc.id} - ${doc.title}`);
       const snippetData: DocumentSnippetData = {
         query: input.query,
         documentTitle: doc.title,
@@ -130,13 +126,13 @@ export class ContextualDocumentAssistantSkill {
           if (parsedResp && Array.isArray(parsedResp.snippets)) {
             extractedSnippets = parsedResp.snippets.filter((s: any): s is string => typeof s === 'string');
           } else {
-            console.warn(`[ContextualDocumentAssistantSkill] Snippets response invalid structure for doc ${doc.id}: ${llmResponse.content}`);
+            console.warn(`[ContextualDocumentAssistantSkill] Snippets resp invalid for ${doc.id}: ${llmResponse.content}`);
           }
         } else {
-          console.error(`[ContextualDocumentAssistantSkill] Snippet extraction LLM call failed for doc ${doc.id}: ${llmResponse.error}`);
+          console.error(`[ContextualDocumentAssistantSkill] Snippet LLM call failed for ${doc.id}: ${llmResponse.error}`);
         }
       } catch (e: any) {
-        console.error(`[ContextualDocumentAssistantSkill] Error parsing snippet LLM response for doc ${doc.id}: ${e.message}`);
+        console.error(`[ContextualDocumentAssistantSkill] Error parsing snippet LLM resp for ${doc.id}: ${e.message}`);
       }
 
       if (extractedSnippets.length > 0) {

--- a/src/skills/emailTriageSkill.ts
+++ b/src/skills/emailTriageSkill.ts
@@ -1,12 +1,11 @@
 import {
-    invokeLLM, // This will be replaced by LLMServiceInterface instance
+    LLMServiceInterface, // Import the interface
     StructuredLLMPrompt,
     EmailCategorizationData,
     EmailSummarizationData,
     EmailReplySuggestionData,
     EmailActionExtractionData,
-    LLMTaskType, // Assuming LLMTaskType is exported from llmUtils
-    LLMServiceInterface // Import the interface
+    LLMTaskType
 } from '../lib/llmUtils';
 
 /**
@@ -192,7 +191,7 @@ export class EmailTriageSkill {
       if (llmResponse.success && llmResponse.content && llmResponse.content.trim().toLowerCase() !== "no reply needed." && !llmResponse.content.toLowerCase().startsWith("llm fallback")) {
         suggestedReplyMessage = llmResponse.content.trim();
       } else {
-         console.log(`[EmailTriageSkill] LLM indicated no reply needed or fallback for reply. Error: ${llmResponse.error}`);
+         console.log(`[EmailTriageSkill] LLM indicated no reply needed or fallback for reply. Error: ${llmResponse.error || 'No content'}`);
       }
     } catch (error: any) {
       console.error('[EmailTriageSkill] Error in LLM reply suggestion:', error.message);
@@ -217,10 +216,67 @@ export class EmailTriageSkill {
 
 // Example Usage
 /*
+import { MockLLMService, OpenAIGroqService_Stub } from '../lib/llmUtils'; // Adjust path as needed
+
 async function testEmailTriageSkill() {
-  // const llmService = new MockLLMService(); // Or OpenAIGroqService_Stub
-  // const skill = new EmailTriageSkill(llmService);
-  // ... rest of the test code
+  // Option 1: Use the MockLLMService for predictable mock behavior
+  const mockLlmService = new MockLLMService();
+  const skillWithMock = new EmailTriageSkill(mockLlmService);
+
+  console.log("\\n--- Testing EmailTriageSkill with MockLLMService ---");
+
+  const testEmail1: EmailObject = {
+    id: "test-email-001",
+    sender: "Alice <alice@example.com>",
+    recipients: ["bob@example.com", "currentUser@example.com"],
+    subject: "Quick question about the Phoenix project",
+    body: "Hi team, I had a quick question regarding the latest update on the Phoenix project. Can someone point me to the documentation for the new auth module? Thanks! Please send the report too.",
+    receivedDate: new Date(),
+    headers: { "X-Priority": "3" }
+  };
+  try {
+    const result1 = await skillWithMock.execute(testEmail1);
+    console.log("Result for testEmail1:", JSON.stringify(result1, null, 2));
+  } catch (error) {
+    console.error("Error during skillWithMock execution (testEmail1):", error);
+  }
+
+  const urgentEmail: EmailObject = {
+    id: "urgent-email-002",
+    sender: "boss@example.com", // This sender is in IMPORTANT_SENDERS
+    recipients: ["currentUser@example.com"],
+    subject: "URGENT: Action Required - System Outage",
+    body: "Team, we have a critical system outage affecting all customers. All hands on deck. Please join the emergency bridge now: conf-link. This requires your immediate action.",
+    receivedDate: new Date(),
+    headers: { "Importance": "High" }
+  };
+  try {
+    const resultUrgent = await skillWithMock.execute(urgentEmail);
+    console.log("Result for urgentEmail:", JSON.stringify(resultUrgent, null, 2));
+  } catch (error) {
+    console.error("Error during skillWithMock execution (urgentEmail):", error);
+  }
+
+  // Option 2: Use the OpenAIGroqService_Stub (which internally might call MockLLMService or have its own simple stubs)
+  // Replace with your actual API key and desired Groq model when ready for real calls.
+  // const groqApiKey = process.env.GROQ_API_KEY || "YOUR_GROQ_API_KEY_PLACEHOLDER";
+  // const groqModel = "mixtral-8x7b-32768"; // Example Groq model
+  // const openAIGroqStubService = new OpenAIGroqService_Stub(groqApiKey, groqModel);
+  // const skillWithGroqStub = new EmailTriageSkill(openAIGroqStubService);
+
+  // console.log("\\n--- Testing EmailTriageSkill with OpenAIGroqService_Stub ---");
+  // try {
+  //   const resultStub = await skillWithGroqStub.execute(testEmail1);
+  //   console.log("Result for testEmail1 (Groq Stub):", JSON.stringify(resultStub, null, 2));
+  // } catch (error) {
+  //   console.error("Error during skillWithGroqStub execution (testEmail1):", error);
+  // }
 }
+
+// To run the test:
+// 1. Ensure `MockLLMService` and `OpenAIGroqService_Stub` are exported from `llmUtils.ts`.
+// 2. Uncomment the imports at the top of this example function.
+// 3. If testing `OpenAIGroqService_Stub` for real, provide API key and uncomment relevant lines.
+// 4. Call testEmailTriageSkill();
 // testEmailTriageSkill();
 */


### PR DESCRIPTION
This commit introduces a major architectural refactoring for LLM interactions:

- Defined `LLMServiceInterface`, `StructuredLLMPrompt`, and specific task data interfaces in `src/lib/llmUtils.ts`.
- Implemented `MockLLMService` in `llmUtils.ts`, which provides dynamic mock LLM responses based on structured tasks.
- Created `OpenAIGroqService_Stub` in `llmUtils.ts` with commented-out examples for actual OpenAI/Groq API calls using the `openai` package, serving as a blueprint for live integration. The stub's prompt construction and API call examples have been further refined.
- Refactored `EmailTriageSkill`, `ContextualDocumentAssistantSkill`, and `LearningAndGuidanceSkill` to accept `LLMServiceInterface` via dependency injection in their constructors.
- These skills now use `this.llmService.generate(...)` with `StructuredLLMPrompt` for all (mocked) LLM calls and handle the structured `LLMServiceResponse`.
- Example usage comments in skill files updated to reflect instantiation with an LLMService.

This decouples skills from specific LLM implementations, enhancing testability and readiness for production LLM integration. The global `invokeLLM` function has been removed.