### PR TITLE
feat: Implement Notion Task Management agent skills

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -38,10 +38,10 @@ Atom revolutionizes how you manage your time with a suite of AI-powered scheduli
 *   **Task Scheduling (Future & Recurring)**: Atom can schedule tasks or actions for future execution. You can ask the agent to perform a task at a specific date and time, or set up recurring tasks (e.g., "remind me every Monday at 9 AM to check emails"). This uses a persistent, internal scheduling system (Agenda with MongoDB) to ensure tasks are reliably executed even if the system restarts.
 
 ### Task Management (Voice-Powered with Notion Backend)
-Atom now offers comprehensive voice-powered task management, using a dedicated Notion database that you configure.
-*   **Task Creation:** Easily create new tasks using natural language (e.g., "Atom, add 'Draft Q4 report' to my work list due next Friday"). Atom captures the description, due date/time, priority, and can assign it to a specific list.
-*   **Task Querying:** Ask Atom about your tasks with various filters. For example: "What are my tasks for today?", "Show me overdue items on my shopping list," or "List high priority work tasks."
-*   **Task Updates:** Modify existing tasks using voice commands, such as marking them as complete (e.g., "Atom, mark 'buy groceries' as done") or changing their properties.
+Atom offers comprehensive voice-powered task management using a dedicated Notion database (configure via `ATOM_NOTION_TASKS_DATABASE_ID`). The agent understands natural language commands to create, query, and update tasks.
+*   **Task Creation:** Create tasks by specifying descriptions, due dates (e.g., "tomorrow", "next Friday at 5pm"), priorities (e.g., "high", "low"), and list names (e.g., "work", "personal"). Example: "Atom, add 'Draft Q4 report' to my work list due next Friday, priority high." Atom parses these details and populates the corresponding fields in your Notion task database.
+*   **Task Querying:** Ask about your tasks using various filters like date conditions ("today", "overdue", "this week"), priority, list name, status, or keywords in the description. Example: "Atom, what are my high priority work tasks due today?"
+*   **Task Updates:** Modify existing tasks by referring to them (e.g., by name) and specifying the changes, such as marking them complete, changing due dates, or updating priorities. Example: "Atom, mark 'buy groceries' as done" or "Change the due date for 'Draft Q4 report' to next Monday."
 *   **Flexible Task Properties:** Tasks are stored in Notion with properties like:
     *   `Task Description` (Title type in Notion)
     *   `Due Date` (Date type)

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Atom requires various environment variables to be set for full functionality. Th
 
 **Core Service & API Keys:**
 *   `OPENAI_API_KEY`: For AI capabilities.
-*   `NOTION_API_KEY`: For Notion integration.
+*   `NOTION_API_KEY`: For Notion integration (used by various skills, including task management).
 *   `DEEPGRAM_API_KEY`: For transcription services.
-*   `ATOM_NOTION_TASKS_DATABASE_ID`: The ID of your Notion database for task management.
+*   `ATOM_NOTION_TASKS_DATABASE_ID`: The ID of your Notion database dedicated to task management. Refer to the "Notion Task Management" section in `FEATURES.md` for required database properties.
 *   `LANCEDB_URI`: URI for your LanceDB instance (e.g., `./lance_db` for local, or a remote URI). Required for semantic search of meeting transcripts.
 *   `PYTHON_API_SERVICE_BASE_URL`: (Optional) URL for the Python backend service if not `http://localhost:8080`.
 

--- a/atomic-docker/project/functions/atom-agent/command_handlers/createNotionTaskCommandHandler.ts
+++ b/atomic-docker/project/functions/atom-agent/command_handlers/createNotionTaskCommandHandler.ts
@@ -1,0 +1,63 @@
+import {
+  // Assuming NLU entities for general task creation will be similar or a new type.
+  // For now, using a generic Record<string, any> and will cast/validate inside.
+  // Ideally, a CreateTaskNluEntities type would be defined in types.ts
+  SkillResponse,
+  CreateTaskData,
+} from '../types';
+import { handleCreateNotionTask } from '../skills/notionTaskSkills'; // The actual skill implementation
+import { logger } from '../../_utils/logger';
+
+// NLU Entities expected by this handler (should align with what NLU provides for "CreateTask" intent)
+// This is based on the conceptual CreateTaskNluEntities from notionTaskSkills.ts
+interface CreateTaskHandlerNluEntities {
+  task_description: string;
+  due_date_text?: string;
+  priority_text?: string;
+  list_name_text?: string;
+  // any other entities NLU might provide for this intent
+}
+
+/**
+ * Handles the "CreateTask" intent.
+ * Calls the skill to create a Notion task and formats the result for the user.
+ *
+ * @param userId The ID of the user.
+ * @param entities The NLU entities extracted for the CreateTask intent.
+ * @returns A promise that resolves to a user-facing string response.
+ */
+export async function handleCreateTaskRequest(
+  userId: string,
+  entities: CreateTaskHandlerNluEntities, // Use the specific NLU entity type
+): Promise<string> {
+  logger.info(`[CreateNotionTaskCmdHandler] Handling request for user ${userId} to create task.`);
+  logger.debug(`[CreateNotionTaskCmdHandler] Received NLU entities: ${JSON.stringify(entities)}`);
+
+  if (!entities.task_description) {
+    logger.warn(`[CreateNotionTaskCmdHandler] Missing task_description.`);
+    return "Please provide a description for the task you want to create.";
+  }
+
+  try {
+    // The skill `handleCreateNotionTask` expects entities matching its internal CreateTaskNluEntities.
+    // Ensure the structure passed matches.
+    const skillResponse: SkillResponse<CreateTaskData & { userMessage: string }> = await handleCreateNotionTask(userId, {
+        task_description: entities.task_description,
+        due_date_text: entities.due_date_text,
+        priority_text: entities.priority_text,
+        list_name_text: entities.list_name_text,
+    });
+
+    if (skillResponse.ok && skillResponse.data?.userMessage) {
+      logger.info(`[CreateNotionTaskCmdHandler] Task creation successful: ${skillResponse.data.userMessage}`);
+      return skillResponse.data.userMessage;
+    } else {
+      const errorMsg = skillResponse.error?.message || skillResponse.data?.userMessage || 'Unknown error from skill';
+      logger.error(`[CreateNotionTaskCmdHandler] Skill execution failed or task creation unsuccessful: ${errorMsg}`, skillResponse.error);
+      return `I couldn't create the task. ${errorMsg}`;
+    }
+  } catch (error: any) {
+    logger.error(`[CreateNotionTaskCmdHandler] Critical error handling request: ${error.message}`, error);
+    return `I encountered an unexpected critical error while trying to create the task: ${error.message}.`;
+  }
+}

--- a/atomic-docker/project/functions/atom-agent/command_handlers/queryNotionTasksCommandHandler.ts
+++ b/atomic-docker/project/functions/atom-agent/command_handlers/queryNotionTasksCommandHandler.ts
@@ -1,0 +1,61 @@
+import {
+  SkillResponse,
+  NotionTask,
+  // Conceptual NLU entity types
+} from '../types';
+import { handleQueryNotionTasks } from '../skills/notionTaskSkills'; // The actual skill
+import { logger } from '../../_utils/logger';
+
+// NLU Entities expected by this handler for "QueryTasks" intent
+interface QueryTasksHandlerNluEntities {
+  date_condition_text?: string;
+  priority_text?: string;
+  list_name_text?: string;
+  status_text?: string;
+  description_contains_text?: string;
+  sort_by_text?: "dueDate" | "priority" | "createdDate";
+  sort_order_text?: "ascending" | "descending";
+  limit_number?: number;
+  // any other entities NLU might provide
+}
+
+/**
+ * Handles the "QueryTasks" intent.
+ * Calls the skill to query Notion tasks and formats the result for the user.
+ *
+ * @param userId The ID of the user.
+ * @param entities The NLU entities extracted for the QueryTasks intent.
+ * @returns A promise that resolves to a user-facing string response.
+ */
+export async function handleQueryTasksRequest(
+  userId: string,
+  entities: QueryTasksHandlerNluEntities,
+): Promise<string> {
+  logger.info(`[QueryNotionTasksCmdHandler] Handling request for user ${userId} to query tasks.`);
+  logger.debug(`[QueryNotionTasksCmdHandler] Received NLU entities: ${JSON.stringify(entities)}`);
+
+  try {
+    const skillResponse: SkillResponse<{ tasks: NotionTask[], userMessage: string }> = await handleQueryNotionTasks(userId, {
+        date_condition_text: entities.date_condition_text,
+        priority_text: entities.priority_text,
+        list_name_text: entities.list_name_text,
+        status_text: entities.status_text,
+        description_contains_text: entities.description_contains_text,
+        sort_by_text: entities.sort_by_text,
+        sort_order_text: entities.sort_order_text,
+        limit_number: entities.limit_number,
+    });
+
+    if (skillResponse.ok && skillResponse.data?.userMessage) {
+      logger.info(`[QueryNotionTasksCmdHandler] Task query successful.`);
+      return skillResponse.data.userMessage;
+    } else {
+      const errorMsg = skillResponse.error?.message || skillResponse.data?.userMessage || 'Unknown error from skill';
+      logger.error(`[QueryNotionTasksCmdHandler] Skill execution failed or task query unsuccessful: ${errorMsg}`, skillResponse.error);
+      return `I couldn't query tasks. ${errorMsg}`;
+    }
+  } catch (error: any) {
+    logger.error(`[QueryNotionTasksCmdHandler] Critical error handling request: ${error.message}`, error);
+    return `I encountered an unexpected critical error while trying to query tasks: ${error.message}.`;
+  }
+}

--- a/atomic-docker/project/functions/atom-agent/command_handlers/updateNotionTaskCommandHandler.ts
+++ b/atomic-docker/project/functions/atom-agent/command_handlers/updateNotionTaskCommandHandler.ts
@@ -1,0 +1,78 @@
+import {
+  SkillResponse,
+  UpdateTaskData,
+  // Conceptual NLU entity types
+} from '../types';
+import { handleUpdateNotionTask } from '../skills/notionTaskSkills'; // The actual skill
+import { logger } from '../../_utils/logger';
+
+// NLU Entities expected by this handler for "UpdateTask" intent
+interface UpdateTaskHandlerNluEntities {
+  task_identifier_text: string; // Text to help identify the task
+  new_status_text?: string;
+  new_due_date_text?: string;
+  new_priority_text?: string;
+  new_list_name_text?: string;
+  new_description_text?: string;
+  // This entity helps differentiate simple updates from specific actions like "mark as complete"
+  update_action?: 'complete' | 'set_due_date' | 'change_priority' | 'rename' | 'move_list' | 'add_notes';
+}
+
+
+/**
+ * Handles the "UpdateTask" intent.
+ * Calls the skill to update a Notion task and formats the result for the user.
+ *
+ * @param userId The ID of the user.
+ * @param entities The NLU entities extracted for the UpdateTask intent.
+ * @returns A promise that resolves to a user-facing string response.
+ */
+export async function handleUpdateTaskRequest(
+  userId: string,
+  entities: UpdateTaskHandlerNluEntities,
+): Promise<string> {
+  logger.info(`[UpdateNotionTaskCmdHandler] Handling request for user ${userId} to update task.`);
+  logger.debug(`[UpdateNotionTaskCmdHandler] Received NLU entities: ${JSON.stringify(entities)}`);
+
+  if (!entities.task_identifier_text) {
+    logger.warn(`[UpdateNotionTaskCmdHandler] Missing task_identifier_text.`);
+    return "Please specify which task you want to update (e.g., by its name or part of its description).";
+  }
+
+  // If a specific update_action is "complete", ensure new_status_text reflects "Done"
+  // NLU should ideally handle this mapping, but we can enforce it here.
+  let finalEntities = { ...entities };
+  if (entities.update_action === 'complete' && entities.new_status_text?.toLowerCase() !== 'done') {
+    logger.info(`[UpdateNotionTaskCmdHandler] 'complete' action detected, overriding status to 'Done'.`);
+    finalEntities.new_status_text = 'Done';
+  }
+
+
+  try {
+    const skillResponse: SkillResponse<UpdateTaskData & { userMessage: string }> = await handleUpdateNotionTask(userId, {
+        task_identifier_text: finalEntities.task_identifier_text,
+        new_status_text: finalEntities.new_status_text,
+        new_due_date_text: finalEntities.new_due_date_text,
+        new_priority_text: finalEntities.new_priority_text,
+        new_list_name_text: finalEntities.new_list_name_text,
+        new_description_text: finalEntities.new_description_text,
+    });
+
+    if (skillResponse.ok && skillResponse.data?.userMessage) {
+      logger.info(`[UpdateNotionTaskCmdHandler] Task update successful: ${skillResponse.data.userMessage}`);
+      return skillResponse.data.userMessage;
+    } else {
+      // If the error was about ambiguity, the skill itself returns a userMessage for clarification
+      if (skillResponse.error?.code === 'AMBIGUOUS_TASK' && skillResponse.data?.userMessage) {
+          logger.warn(`[UpdateNotionTaskCmdHandler] Task update ambiguous: ${skillResponse.data.userMessage}`);
+          return skillResponse.data.userMessage;
+      }
+      const errorMsg = skillResponse.error?.message || skillResponse.data?.userMessage || 'Unknown error from skill';
+      logger.error(`[UpdateNotionTaskCmdHandler] Skill execution failed or task update unsuccessful: ${errorMsg}`, skillResponse.error);
+      return `I couldn't update the task. ${errorMsg}`;
+    }
+  } catch (error: any) {
+    logger.error(`[UpdateNotionTaskCmdHandler] Critical error handling request: ${error.message}`, error);
+    return `I encountered an unexpected critical error while trying to update the task: ${error.message}.`;
+  }
+}

--- a/atomic-docker/project/functions/atom-agent/skills/notionTaskSkills.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/notionTaskSkills.ts
@@ -1,0 +1,345 @@
+import {
+  SkillResponse,
+  NotionTask,
+  CreateNotionTaskParams,
+  QueryNotionTasksParams,
+  UpdateNotionTaskParams,
+  CreateTaskData,
+  UpdateTaskData,
+  TaskQueryResponse,
+  NotionTaskStatus,
+  NotionTaskPriority,
+  // Conceptual NLU entity types (assuming they'd be defined in types.ts or a dedicated nluTypes.ts)
+  // For now, we'll define simple interfaces here or use 'any' for NLU input structure.
+} from '../types';
+
+import {
+  createNotionTask as createNotionTaskBackend,
+  queryNotionTasks as queryNotionTasksBackend,
+  updateNotionTask as updateNotionTaskBackend,
+} from './notionAndResearchSkills'; // Assuming these are the backend callers
+
+import { ATOM_NOTION_TASKS_DATABASE_ID } from '../_libs/constants';
+import { logger } from '../../_utils/logger';
+
+// --- NLU Entity Interfaces (Conceptual - define more formally in types.ts later) ---
+interface CreateTaskNluEntities {
+  task_description: string;
+  due_date_text?: string;
+  priority_text?: string;
+  list_name_text?: string;
+  // notes_text?: string; // If NLU can pick up additional notes
+}
+
+interface QueryTasksNluEntities {
+  date_condition_text?: string;
+  priority_text?: string;
+  list_name_text?: string;
+  status_text?: string;
+  description_contains_text?: string;
+  sort_by_text?: "dueDate" | "priority" | "createdDate"; // Match NotionTask properties
+  sort_order_text?: "ascending" | "descending";
+  limit_number?: number;
+}
+
+interface UpdateTaskNluEntities {
+  task_identifier_text: string; // Text to help identify the task
+  new_status_text?: string;
+  new_due_date_text?: string;
+  new_priority_text?: string;
+  new_list_name_text?: string;
+  new_description_text?: string;
+}
+
+
+// --- Date Parsing (Simplified - Placeholder) ---
+// A more robust library like date-fns, dayjs, or chrono-node would be needed for real-world parsing.
+// NLU should ideally provide structured date objects.
+function parseDueDate(dateText?: string): string | null {
+  if (!dateText) return null;
+
+  // Extremely basic examples, NOT production-ready
+  if (dateText.toLowerCase() === 'today') {
+    return new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+  }
+  if (dateText.toLowerCase() === 'tomorrow') {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return tomorrow.toISOString().split('T')[0]; // YYYY-MM-DD
+  }
+  // Try to parse with Date.parse - very limited
+  const parsed = Date.parse(dateText);
+  if (!isNaN(parsed)) {
+    return new Date(parsed).toISOString(); // Full ISO string, Notion API might prefer YYYY-MM-DD for date-only
+  }
+  logger.warn(`[notionTaskSkills] Could not parse due date: "${dateText}". Needs robust parsing.`);
+  return null; // Indicate parsing failure
+}
+
+// --- Value Mapping ---
+function mapPriority(priorityText?: string): NotionTaskPriority | null {
+  if (!priorityText) return null;
+  const lowerPriority = priorityText.toLowerCase();
+  if (lowerPriority.includes('high')) return 'High';
+  if (lowerPriority.includes('medium') || lowerPriority.includes('med')) return 'Medium';
+  if (lowerPriority.includes('low')) return 'Low';
+  return null;
+}
+
+function mapStatus(statusText?: string): NotionTaskStatus | null {
+  if (!statusText) return null;
+  const lowerStatus = statusText.toLowerCase();
+  if (lowerStatus.includes('to do') || lowerStatus.includes('todo')) return 'To Do';
+  if (lowerStatus.includes('in progress') || lowerStatus.includes('doing')) return 'In Progress';
+  if (lowerStatus.includes('done') || lowerStatus.includes('completed')) return 'Done';
+  if (lowerStatus.includes('blocked')) return 'Blocked';
+  if (lowerStatus.includes('cancelled') || lowerStatus.includes('canceled')) return 'Cancelled';
+  return null;
+}
+
+
+// --- Skill Implementations ---
+
+export async function handleCreateNotionTask(
+  userId: string,
+  entities: CreateTaskNluEntities,
+): Promise<SkillResponse<CreateTaskData & { userMessage: string }>> {
+  logger.info(`[handleCreateNotionTask] User: ${userId}, Entities: ${JSON.stringify(entities)}`);
+
+  if (!ATOM_NOTION_TASKS_DATABASE_ID) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Notion Tasks Database ID (ATOM_NOTION_TASKS_DATABASE_ID) is not configured.' } };
+  }
+  if (!entities.task_description) {
+    return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'Task description is required.' } };
+  }
+
+  const dueDateISO = parseDueDate(entities.due_date_text);
+  // If dueDateISO is null and entities.due_date_text was provided, it means parsing failed.
+  // Depending on strictness, you might return an error here or proceed without a due date.
+  if (entities.due_date_text && !dueDateISO) {
+      logger.warn(`[handleCreateNotionTask] Due date text "${entities.due_date_text}" provided but could not be parsed.`);
+      // Optionally, inform the user: `Could not understand the due date "${entities.due_date_text}". Task created without it.`
+  }
+
+
+  const params: CreateNotionTaskParams = {
+    notionTasksDbId: ATOM_NOTION_TASKS_DATABASE_ID,
+    description: entities.task_description,
+    dueDate: dueDateISO, // Use parsed date
+    priority: mapPriority(entities.priority_text),
+    listName: entities.list_name_text || null, // Default to null if not provided
+    status: 'To Do', // Default status
+    // notes: entities.notes_text || null, // If NLU provides notes
+  };
+
+  const result = await createNotionTaskBackend(userId, params);
+
+  if (result.ok && result.data) {
+    let userMessage = `Okay, I've created the task: "${params.description}".`;
+    if (params.listName) userMessage += ` on your "${params.listName}" list`;
+    if (dueDateISO) userMessage += ` due ${entities.due_date_text || new Date(dueDateISO).toLocaleDateString()}`; // Use original text if available
+    if (params.priority) userMessage += ` (Priority: ${params.priority})`;
+    userMessage += ".";
+
+    return {
+      ok: true,
+      data: { ...result.data, userMessage },
+    };
+  } else {
+    return {
+      ok: false,
+      error: result.error || { code: 'BACKEND_ERROR', message: 'Failed to create task in Notion via backend.' },
+      data: { userMessage: `Sorry, I couldn't create the task. ${result.error?.message || 'There was an issue.'}` }
+    };
+  }
+}
+
+// Placeholder for handleQueryNotionTasks
+export async function handleQueryNotionTasks(
+  userId: string,
+  entities: QueryTasksNluEntities,
+): Promise<SkillResponse<{ tasks: NotionTask[], userMessage: string }>> {
+  logger.info(`[handleQueryNotionTasks] User: ${userId}, Entities: ${JSON.stringify(entities)}`);
+   if (!ATOM_NOTION_TASKS_DATABASE_ID) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Notion Tasks Database ID (ATOM_NOTION_TASKS_DATABASE_ID) is not configured.' } };
+  }
+  // TODO: Implement mapping from NLU entities to QueryNotionTasksParams
+  // This includes parsing date_condition_text, mapping priority/status, etc.
+  const queryParams: QueryNotionTasksParams = {
+      notionTasksDbId: ATOM_NOTION_TASKS_DATABASE_ID,
+      descriptionContains: entities.description_contains_text || null,
+      priority: mapPriority(entities.priority_text),
+      status: mapStatus(entities.status_text),
+      listName: entities.list_name_text || null,
+      limit: entities.limit_number || 10,
+      // Date parsing for conditions (dueDateBefore, dueDateAfter) is complex
+      // sortBy and sortOrder also need mapping if NLU provides them.
+  };
+
+  // Basic date condition parsing
+  if (entities.date_condition_text) {
+    const now = new Date();
+    const todayDateStr = now.toISOString().split('T')[0];
+
+    const tomorrow = new Date(now);
+    tomorrow.setDate(now.getDate() + 1);
+    const tomorrowDateStr = tomorrow.toISOString().split('T')[0];
+
+    const yesterday = new Date(now);
+    yesterday.setDate(now.getDate() - 1);
+    const yesterdayDateStr = yesterday.toISOString().split('T')[0];
+
+    switch (entities.date_condition_text.toLowerCase()) {
+      case 'today':
+        queryParams.dueDateEquals = todayDateStr; // Python backend needs to support dueDateEquals
+        // Or, if only Before/After supported:
+        // queryParams.dueDateAfter = todayDateStr;
+        // queryParams.dueDateBefore = todayDateStr; // Assuming inclusive, or adjust
+        break;
+      case 'tomorrow':
+        queryParams.dueDateEquals = tomorrowDateStr;
+        break;
+      case 'yesterday':
+        queryParams.dueDateEquals = yesterdayDateStr;
+        break;
+      case 'overdue':
+        queryParams.dueDateBefore = todayDateStr; // Tasks due before today
+        if (queryParams.status && queryParams.status !== 'Done') {
+            // If status is already specified and not 'Done', it's fine.
+            // If status is 'Done', this combination is contradictory.
+            // If status is not specified, add not_equals 'Done'.
+        } else if (!queryParams.status) {
+            queryParams.status_not_equals = 'Done'; // Ensure we don't show completed overdue tasks unless specified
+        }
+        break;
+      // "this week", "next week" would require more complex date range calculations.
+      default:
+        // Try to parse as a specific date if possible (very basic)
+        const specificDate = parseDueDate(entities.date_condition_text);
+        if (specificDate) {
+            queryParams.dueDateEquals = specificDate.split('T')[0]; // Use YYYY-MM-DD part
+        } else {
+            logger.warn(`[handleQueryNotionTasks] Could not parse date_condition_text: "${entities.date_condition_text}"`);
+        }
+    }
+  }
+
+  if (entities.sort_by_text) {
+      queryParams.sortBy = entities.sort_by_text;
+      if (entities.sort_order_text) {
+          queryParams.sortOrder = entities.sort_order_text;
+      }
+  }
+
+  // logger.warn("[handleQueryNotionTasks] Date condition parsing and sorting not fully implemented yet.");
+
+
+  const result = await queryNotionTasksBackend(userId, queryParams);
+
+  if (result.success && result.tasks) {
+    let userMessage = "";
+    if (result.tasks.length === 0) {
+      userMessage = "I couldn't find any tasks matching your criteria.";
+    } else {
+      userMessage = `Here are the tasks I found:\n`;
+      result.tasks.forEach((task, index) => {
+        userMessage += `${index + 1}. ${task.description}`;
+        if (task.dueDate) userMessage += ` (Due: ${new Date(task.dueDate).toLocaleDateString()})`;
+        if (task.priority) userMessage += ` [P: ${task.priority}]`;
+        if (task.listName) userMessage += ` (List: ${task.listName})`;
+        if (task.status) userMessage += ` (Status: ${task.status})`;
+        userMessage += `\n`;
+      });
+    }
+    return { ok: true, data: { tasks: result.tasks, userMessage } };
+  } else {
+    return {
+        ok: false,
+        error: { code: 'BACKEND_ERROR', message: result.error || 'Failed to query tasks.' },
+        data: { tasks: [], userMessage: `Sorry, I couldn't fetch tasks. ${result.error || 'There was an issue.'}`}
+    };
+  }
+}
+
+// Placeholder for handleUpdateNotionTask
+export async function handleUpdateNotionTask(
+  userId: string,
+  entities: UpdateTaskNluEntities,
+): Promise<SkillResponse<UpdateTaskData & { userMessage: string }>> {
+  logger.info(`[handleUpdateNotionTask] User: ${userId}, Entities: ${JSON.stringify(entities)}`);
+  if (!ATOM_NOTION_TASKS_DATABASE_ID) {
+    // While not strictly needed for update by ID, good to have for context or if task resolution queries this DB.
+    logger.warn("[handleUpdateNotionTask] ATOM_NOTION_TASKS_DATABASE_ID not configured, might affect task resolution.");
+  }
+
+  // --- Task Resolution (Complex Step - V1: Basic name matching) ---
+  // This needs to be robust. For V1, we might try a simple query.
+  // A better approach involves NLU providing a task_id or the agent maintaining context.
+  let taskIdToUpdate: string | null = null;
+
+  if (entities.task_identifier_text) {
+    logger.info(`[handleUpdateNotionTask] Attempting to resolve task by identifier: "${entities.task_identifier_text}"`);
+    const potentialTasks = await queryNotionTasksBackend(userId, {
+      notionTasksDbId: ATOM_NOTION_TASKS_DATABASE_ID!, // Assume it's configured for this flow
+      descriptionContains: entities.task_identifier_text,
+      status_not_equals: "Done", // Prefer to update active tasks
+      limit: 5, // Fetch a few to check for ambiguity
+    });
+
+    if (potentialTasks.success && potentialTasks.tasks.length === 1) {
+      taskIdToUpdate = potentialTasks.tasks[0].id;
+      logger.info(`[handleUpdateNotionTask] Resolved to task ID: ${taskIdToUpdate}`);
+    } else if (potentialTasks.success && potentialTasks.tasks.length > 1) {
+      // TODO: Implement disambiguation: Ask user which task they meant.
+      const options = potentialTasks.tasks.map((t, i) => `${i+1}. ${t.description} (List: ${t.listName || 'N/A'})`).join('\n');
+      const userMessage = `I found a few tasks matching "${entities.task_identifier_text}". Which one did you mean?\n${options}`;
+      logger.warn(`[handleUpdateNotionTask] Multiple tasks found for "${entities.task_identifier_text}". Disambiguation needed.`);
+      return { ok: false, error: { code: 'AMBIGUOUS_TASK', message: userMessage }, data: { userMessage } as any };
+
+    } else {
+      logger.warn(`[handleUpdateNotionTask] Could not find a unique task matching "${entities.task_identifier_text}".`);
+      return { ok: false, error: { code: 'TASK_NOT_FOUND', message: `I couldn't find a task matching "${entities.task_identifier_text}".` }, data: { userMessage: `I couldn't find a task matching "${entities.task_identifier_text}".`} as any };
+    }
+  } else {
+    return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'Task identifier is required to update a task.' } };
+  }
+  // --- End Task Resolution ---
+
+  const newDueDateISO = parseDueDate(entities.new_due_date_text);
+  if (entities.new_due_date_text && !newDueDateISO) {
+      logger.warn(`[handleUpdateNotionTask] New due date text "${entities.new_due_date_text}" provided but could not be parsed.`);
+  }
+
+
+  const params: UpdateNotionTaskParams = {
+    taskId: taskIdToUpdate!, // Asserting it's non-null after resolution logic
+    description: entities.new_description_text,
+    dueDate: newDueDateISO,
+    status: mapStatus(entities.new_status_text),
+    priority: mapPriority(entities.new_priority_text),
+    listName: entities.new_list_name_text,
+  };
+
+  // Filter out undefined params so only provided fields are updated
+  const filteredParams = Object.fromEntries(Object.entries(params).filter(([_, v]) => v !== undefined)) as UpdateNotionTaskParams;
+  if (Object.keys(filteredParams).length <= 1 && filteredParams.taskId) { // Only taskId means no actual updates
+     return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'No properties provided to update for the task.' } };
+  }
+
+
+  const result = await updateNotionTaskBackend(userId, filteredParams);
+
+  if (result.ok && result.data) {
+    const userMessage = `Okay, I've updated the task (ID: ${result.data.taskId}). Properties changed: ${result.data.updatedProperties.join(', ')}.`;
+    return {
+      ok: true,
+      data: { ...result.data, userMessage },
+    };
+  } else {
+    return {
+      ok: false,
+      error: result.error || { code: 'BACKEND_ERROR', message: 'Failed to update task in Notion via backend.' },
+      data: { userMessage: `Sorry, I couldn't update the task. ${result.error?.message || 'There was an issue.'}` }
+    };
+  }
+}


### PR DESCRIPTION
- Created `notionTaskSkills.ts` with handlers for creating, querying, and updating Notion tasks.
- These skills parse NLU entities (including basic date/priority mapping) and call backend wrappers in `notionAndResearchSkills.ts`.
- Updated `taskFromChatSkill.ts` to use the actual task creation backend wrapper instead of placeholder logic.
- Integrated these skills into the main `handler.ts` via new command handler files (`createNotionTaskCommandHandler.ts`, etc.).
- Updated `FEATURES.md` and `README.md` with details on Notion task management configuration and capabilities.
- Added a manual testing plan for Notion tasks: `atomic-docker/docs/manual_testing/notion_task_management_tests.md`.