### PR TITLE
Add LLM Summary, Decisions & Actions to Meeting Worker

### DIFF
--- a/atomic-docker/docs/live-meeting-attendance-setup.md
+++ b/atomic-docker/docs/live-meeting-attendance-setup.md
@@ -212,9 +212,11 @@ The frontend interacts with the `live-meeting-worker` API. Refer to `atomic-dock
     *   Lists available audio devices within its container environment using `sounddevice`.
     *   Performs real audio capture using `sounddevice` and saves it to a temporary WAV file.
     *   Transcribes the captured WAV file using OpenAI Whisper API (requires `OPENAI_API_KEY`).
-    *   **Creates a new Notion page** with the specified title and populates it with the transcript (requires `NOTION_API_KEY` and optionally `NOTION_PARENT_PAGE_ID`). The URL of this page is stored in `final_notes_location`.
-    *   Deletes the temporary WAV file after transcription and Notion upload attempts.
-    *   (Future) More advanced note generation/summarization can be added.
+    *   Creates an initial Notion page with the specified title and the full transcript (requires `NOTION_API_KEY` and optionally `NOTION_PARENT_PAGE_ID`). The URL of this page is stored in `final_notes_location`.
+    *   **Generates a summary, key decisions, and action items** from the transcript using an LLM (OpenAI by default).
+    *   **Appends these generated sections (Summary, Key Decisions, Action Items)** to the previously created Notion page.
+    *   The `notes_preview` field in the task status may contain a snippet of the generated summary.
+    *   Deletes the temporary WAV file after all processing.
 3.  **Docker & Docker Compose:**
     *   Manages the running of all services, including the new `live-meeting-worker`.
     *   Handles inter-service communication via defined networks and service names.


### PR DESCRIPTION
Features:
- Implemented LLM-based generation of meeting summaries, key decisions, and action items from transcripts in the `live-meeting-worker`.
- Added new functions in `main.py`:
  - `get_llm_summary(transcript, task_id)`
  - `get_llm_decisions(transcript, task_id)`
  - `get_llm_action_items(transcript, task_id)`
  - `_call_openai_chat_completion` helper for OpenAI API calls.
- Implemented `append_to_notion_page(page_id, task_id, content_blocks)` to append new content (summary, decisions, actions) to the existing Notion page created for the transcript.
  - Handles Notion API block limits for appending.
- Integrated these LLM processing and Notion append steps into the `audio_capture_loop`'s `finally` block.
  - Occurs after successful STT and initial Notion page creation.
  - Task messages and `notes_preview` are updated to reflect these new processing stages.
- Designed specific prompts for summary, decisions, and action item extraction.
- Updated documentation (`live-meeting-attendance-setup.md` and `manual_testing/live_meeting_attendance_tests.md`) to cover the new LLM-based content generation, its integration with Notion, and updated testing procedures.

Description:
This commit enhances the Live Meeting Attendance worker by adding AI-powered analysis of meeting transcripts. After a transcript is generated and saved to an initial Notion page, the worker now uses an LLM (OpenAI GPT-3.5-turbo by default) to:
1. Generate a concise summary.
2. Extract key decisions.
3. Identify action items (including potential assignees).

These generated sections are then formatted and appended to the Notion page previously created for the full transcript, providing a more structured and actionable meeting record.

The implementation includes new helper functions for interacting with the LLM and for appending content to Notion pages, along with updates to the main task lifecycle. Documentation has been revised to reflect these new capabilities and guide testing.