### PR TITLE
feat: Integrate semantic search into atom-agent

### DIFF
--- a/atomic-docker/project/docker-compose.yaml
+++ b/atomic-docker/project/docker-compose.yaml
@@ -158,6 +158,8 @@ services:
       HASURA_GRAPHQL_METADATA_URL: http://graphql-engine:8080/v1/metadata
       GOOGLE_CLIENT_SECRET_WEB: ${GOOGLE_CLIENT_SECRET_WEB}
       EMAIL: ${EMAIL}
+      # Base URL for the Python API service (running in python-agent)
+      PYTHON_API_SERVICE_BASE_URL: ${PYTHON_API_SERVICE_BASE_URL:-http://python-agent:5000}
       DOMAIN: ${DOMAIN}
       S3_ENDPOINT: http://minio:8484
       S3_BUCKET: nhost


### PR DESCRIPTION
This commit implements the 'search_meeting_notes' skill in the atom-agent, enabling users to perform semantic searches across their meeting transcripts via natural language queries.

Key changes in `atomic-docker/project/functions/atom-agent/skills/semanticSearchSkills.ts`:
- Updated the `ApiMeetingSearchResult` interface to match the actual response from the Python backend API, including fields like `notion_page_url`, `text_preview`, and `last_edited`.
- Refined the `handleSearchMeetingNotes` function to correctly parse these new fields and format them into a user-friendly string for display in the chat interface. This includes displaying text snippets and direct web URLs to Notion pages.
- Improved error message formatting from backend API errors.

Configuration Updates in `atomic-docker/project/docker-compose.yaml`:
- Updated the `functions` service (which runs `atom-agent`) to include the `PYTHON_API_SERVICE_BASE_URL` environment variable, defaulting to `http://python-agent:5000`. This ensures the agent can call the Python semantic search API.

Documentation:
- Skipped direct updates to FEATURES.MD and NLU_INTENT_GUIDANCE.MD due to persistent tooling issues with file access.
- The skill definition within `semanticSearchSkills.ts` serves as implicit documentation for NLU integration.
- Core configurations are captured in `docker-compose.yaml` and relevant `.env.example` files from previous features.