### PR TITLE
feat: Implement frontend UI for semantic search results

### DIFF
--- a/atomic-docker/app_build_docker/components/chat/custom/SearchResultsDisplay.tsx
+++ b/atomic-docker/app_build_docker/components/chat/custom/SearchResultsDisplay.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+// Assuming FrontendMeetingSearchResult and SearchResultsDisplayProps are defined in a shared types location
+// For now, let's redefine or assume they will be imported correctly if this file is part of a larger system.
+// If not, these definitions would need to be co-located or imported from e.g., '@lib/dataTypes/SearchResultsTypes'
+
+// Define types locally if not importing, ensuring they match the expected structure
+export interface FrontendMeetingSearchResult {
+  notion_page_id: string;
+  notion_page_title: string;
+  notion_page_url: string;
+  text_preview: string;
+  last_edited: string; // ISO date string
+  score: number;
+}
+
+export interface SearchResultsDisplayProps {
+  results: FrontendMeetingSearchResult[];
+}
+
+// dayjs is used in Message.tsx, assuming it's available globally or via context/import
+// If not, it would need to be imported: import dayjs from 'dayjs';
+// For this component, we can try to use browser's built-in Date formatting for simplicity
+// or ensure dayjs is properly set up in the project.
+// Let's use toLocaleDateString for now if dayjs is not directly importable here.
+const formatDate = (isoString: string): string => {
+  if (!isoString) return "N/A";
+  try {
+    // More robust date formatting than just toLocaleDateString if dayjs was used project-wide
+    // For example: dayjs(isoString).format("MMM D, YYYY h:mm A");
+    return new Date(isoString).toLocaleDateString(undefined, {
+      year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit'
+    });
+  } catch (e) {
+    console.error("Error formatting date:", isoString, e);
+    return "Invalid Date";
+  }
+};
+
+const SearchResultItem: React.FC<{ item: FrontendMeetingSearchResult }> = ({ item }) => {
+  const displayDate = formatDate(item.last_edited);
+
+  return (
+    <div className="mb-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition-shadow">
+      <h4 className="text-md font-semibold mb-1">
+        <a
+          href={item.notion_page_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 hover:underline"
+          title={item.notion_page_title || "View Notion Page"}
+        >
+          {item.notion_page_title || "Untitled Note"}
+        </a>
+      </h4>
+      <div className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+        <span title={item.last_edited}>Edited: {displayDate}</span>
+        <span className="ml-2 pl-2 border-l border-gray-300 dark:border-gray-600">
+          Relevance: {item.score !== undefined ? item.score.toFixed(2) : 'N/A'}
+        </span>
+      </div>
+      {item.text_preview && (
+        <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed text-ellipsis overflow-hidden max-h-24">
+          {/* Simple preview, could be more sophisticated with truncation */}
+          {item.text_preview}
+        </p>
+      )}
+    </div>
+  );
+};
+
+const SearchResultsDisplay: React.FC<SearchResultsDisplayProps> = ({ results }) => {
+  if (!results || results.length === 0) {
+    return <div className="p-3 text-sm text-gray-500 dark:text-gray-400">No relevant meeting notes found for your query.</div>;
+  }
+
+  return (
+    <div className="mt-1 p-1 bg-gray-50 dark:bg-gray-700/50 rounded-md max-h-80 overflow-y-auto text-left">
+      {/* Container for the results, ensuring text alignment is left for content within */}
+      {results.map((item, index) => (
+        // Using index in key for simplicity IF notion_page_id + preview start isn't guaranteed unique
+        // (e.g. multiple chunks from same page with similar starts, though API currently returns 1 result per page)
+        // Since API returns one result per page for now, notion_page_id is fine.
+        <SearchResultItem key={item.notion_page_id || `search-result-${index}`} item={item} />
+      ))}
+    </div>
+  );
+};
+
+export default SearchResultsDisplay;

--- a/atomic-docker/app_build_docker/lib/dataTypes/Messaging/MessagingTypes.ts
+++ b/atomic-docker/app_build_docker/lib/dataTypes/Messaging/MessagingTypes.ts
@@ -34,12 +34,16 @@ export type SkillMessageHistoryType = {
     htmlEmail?: string,
 }
 
+import { FrontendMeetingSearchResult } from "../SearchResultsTypes"; // Import the new type
+
 export type UserChatType = {
     role: 'user' | 'assistant',
-    content: string,
+    content: string, // Will hold summary text like "Search results:"
     id: number,
     date: string,
     audioUrl?: string; // Added for TTS audio playback
+    customComponentType?: 'semantic_search_results' | 'other_custom_component'; // To identify component type
+    customComponentProps?: { results: FrontendMeetingSearchResult[] } | any; // Props for the component
 }
 
 export type ChatHistoryType = UserChatType[]

--- a/atomic-docker/app_build_docker/lib/dataTypes/SearchResultsTypes.ts
+++ b/atomic-docker/app_build_docker/lib/dataTypes/SearchResultsTypes.ts
@@ -1,0 +1,22 @@
+// Defines the structure for semantic search results on the frontend
+
+export interface FrontendMeetingSearchResult {
+  notion_page_id: string;
+  notion_page_title: string;
+  notion_page_url: string;
+  text_preview: string;
+  last_edited: string; // ISO date string
+  score: number;
+}
+
+// Props for the SearchResultsDisplay component
+export interface SearchResultsDisplayProps {
+  results: FrontendMeetingSearchResult[];
+}
+
+// Data structure agent might send for this type of display
+export interface SemanticSearchResultsPayload {
+  type: 'semantic_search_results';
+  summaryText: string; // e.g., "Found 5 results..."
+  results: FrontendMeetingSearchResult[];
+}

--- a/atomic-docker/app_build_docker/pages/Calendar/Chat/UserViewChat.tsx
+++ b/atomic-docker/app_build_docker/pages/Calendar/Chat/UserViewChat.tsx
@@ -495,9 +495,13 @@ function UserViewChat() {
                                     <Message
                                         key={m.id || `msg-item-${i}`}
                                         message={m}
-                                        isLoading={showFormsForThisMessage && isLoading} // Only show loading for last assistant message slot
-                                        // formData={showFormsForThisMessage && isForm ? renderSelectTimezone() : undefined} // Conditionally render form
-                                        // htmlEmail={showFormsForThisMessage ? htmlEmail : undefined} // Conditionally render email
+                                        isLoading={showFormsForThisMessage && isLoading}
+                                        formData={
+                                            showFormsForThisMessage && m.customComponentType === 'semantic_search_results' && m.customComponentProps ?
+                                            React.createElement(React.lazy(() => import('@components/chat/custom/SearchResultsDisplay')), m.customComponentProps)
+                                            : (showFormsForThisMessage && isForm ? renderSelectTimezone() : undefined)
+                                        }
+                                        htmlEmail={showFormsForThisMessage && m.role === 'assistant' ? htmlEmail : undefined} // Only pass htmlEmail for assistant messages
                                     />
                                 </div>
                             )


### PR DESCRIPTION
This commit introduces a dedicated React component to display semantic search results in the chat interface, enhancing user experience.

Key changes:

Frontend (`app_build_docker`):
- Created `SearchResultsDisplay.tsx` component (`components/chat/custom/`) to render a list of search results, each showing title, link, date, score, and text preview.
- Defined frontend types `FrontendMeetingSearchResult` and `SearchResultsDisplayProps` in `lib/dataTypes/SearchResultsTypes.ts`.
- Updated `UserChatType` in `lib/dataTypes/Messaging/MessagingTypes.ts` to include `customComponentType` and `customComponentProps` to support rendering custom components like search results.
- Modified `ChatHelper.ts` (`receiveMessageFromBrain`) to detect structured search result payloads from the agent and populate the new fields in `UserChatType`.
- Updated `UserViewChat.tsx` to dynamically render the `SearchResultsDisplay` component using `React.lazy` when a message has `customComponentType: 'semantic_search_results'`.

Atom-Agent (`project/functions/atom-agent`):
- Refactored `semanticSearchSkills.ts` (`handleSearchMeetingNotes`) to return a structured object (`{ displayType: 'semantic_search_results', summaryText: ..., data: ... }`) when search results are found, instead of a pre-formatted string. This enables the frontend to use the new custom UI component.

Configuration:
- Updated `docker-compose.yaml` for the `functions` service (atom-agent host) to correctly set `PYTHON_API_SERVICE_BASE_URL` for calls to the Python backend.

This provides an improved user experience for viewing semantic search results within the Atom application.