### PR TITLE
feat: Add ADOT sidecar, OTel instrumentation for functions-service, a…

### DIFF
--- a/atomic-docker/functions_build_docker/opentelemetry.js
+++ b/atomic-docker/functions_build_docker/opentelemetry.js
@@ -1,0 +1,148 @@
+// OpenTelemetry SDK setup for Tracing and Metrics
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { alibabaCloudEcsDetector } from '@opentelemetry/resource-detector-alibaba-cloud';
+import { awsEc2Detector, awsEksDetector } // awsEcsDetector is part of sdk-node by default
+from '@opentelemetry/resource-detector-aws';
+import { gcpDetector } from '@opentelemetry/resource-detector-gcp';
+import { envDetector, processDetector, osDetector, hostDetector } from '@opentelemetry/resources';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import { WinstonInstrumentation } from '@opentelemetry/instrumentation-winston'; // If using Winston
+
+// For troubleshooting, set the log level to DiagLogLevel.DEBUG
+// diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO); // Default to INFO
+
+const serviceName = process.env.OTEL_SERVICE_NAME || 'functions-service';
+const serviceVersion = process.env.OTEL_SERVICE_VERSION || '1.0.0';
+
+// Configure OTLP Exporters
+const otlpTraceExporter = new OTLPTraceExporter({
+  url: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || 'http://localhost:4318/v1/traces',
+});
+
+const otlpMetricExporter = new OTLPMetricExporter({
+  url: process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT || 'http://localhost:4318/v1/metrics',
+});
+
+const metricReader = new PeriodicExportingMetricReader({
+  exporter: otlpMetricExporter,
+  exportIntervalMillis: process.env.OTEL_METRIC_EXPORT_INTERVAL ? parseInt(process.env.OTEL_METRIC_EXPORT_INTERVAL) : 10000,
+});
+
+const sdk = new NodeSDK({
+  serviceName: serviceName,
+  serviceVersion: serviceVersion,
+  traceExporter: otlpTraceExporter,
+  metricReader: metricReader,
+  instrumentations: [
+    getNodeAutoInstrumentations({
+      // Example: configure an instrumentation
+      '@opentelemetry/instrumentation-http': {
+        applyCustomAttributesOnSpan: (span, request, response) => {
+          span.setAttribute('http.request.headers', JSON.stringify(request.headers)); // Example: add request headers
+          // Be careful with sensitive data in headers
+        },
+      },
+      '@opentelemetry/instrumentation-aws-sdk': {
+        suppressInternalInstrumentation: true, // Suppress traces from internal SDK operations if too verbose
+      }
+      // WinstonInstrumentation is added explicitly below to ensure it's configured
+    }),
+    // Add WinstonInstrumentation. It needs to be instantiated.
+    new WinstonInstrumentation({
+      // Enabled by default, just need to instantiate if not using the meta-package for winston specifically.
+      // The logHook is useful for adding custom attributes to logs based on span.
+      logHook: (span, record) => {
+        if (span) {
+          const spanContext = span.spanContext();
+          record.trace_id = spanContext.traceId;
+          record.span_id = spanContext.spanId;
+          // record.service_name = serviceName; // Already part of resource, but can be explicit
+          // record.service_version = serviceVersion;
+        }
+      },
+    }),
+  ],
+  resourceDetectors: [
+    alibabaCloudEcsDetector,
+    awsEc2Detector,
+    awsEksDetector, // awsEcsDetector is included by default in recent sdk-node versions
+    gcpDetector,
+    envDetector,
+    processDetector,
+    osDetector,
+    hostDetector,
+  ],
+  // autoDetectResources: true, // This is true by default
+});
+
+// Graceful shutdown
+process.on('SIGTERM', () => {
+  sdk.shutdown()
+    .then(() => console.log('OpenTelemetry SDK terminated successfully'))
+    .catch((error) => console.error('Error shutting down OpenTelemetry SDK', error))
+    .finally(() => process.exit(0));
+});
+
+process.on('SIGINT', () => {
+    sdk.shutdown()
+      .then(() => console.log('OpenTelemetry SDK terminated successfully (SIGINT)'))
+      .catch((error) => console.error('Error shutting down OpenTelemetry SDK (SIGINT)', error))
+      .finally(() => process.exit(0));
+  });
+
+// Start the SDK and load all configured instrumentations
+try {
+  sdk.start();
+  console.log(`OpenTelemetry SDK started for service: ${serviceName}@${serviceVersion}`);
+  console.log(`OTLP Trace Exporter configured for: ${otlpTraceExporter.url}`);
+  console.log(`OTLP Metric Exporter configured for: ${otlpMetricExporter.url}`);
+
+} catch (error) {
+  console.error('Error starting OpenTelemetry SDK:', error);
+}
+
+// Export an initialized Meter for custom metrics
+import { metrics } from '@opentelemetry/api';
+const meter = metrics.getMeterProvider().getMeter(serviceName, serviceVersion);
+
+// Define and export common metrics
+const httpServerRequestsTotal = meter.createCounter('http_server_requests_total', {
+  description: 'Total number of HTTP requests handled.',
+  unit: '1',
+});
+
+const httpServerRequestDurationSeconds = meter.createHistogram('http_server_request_duration_seconds', {
+  description: 'Duration of HTTP server requests.',
+  unit: 's',
+});
+
+const activeWebsocketConnections = meter.createUpDownCounter('websocket_connections_active', {
+    description: 'Number of active WebSocket connections.',
+    unit: '1',
+});
+
+const websocketMessagesReceivedTotal = meter.createCounter('websocket_messages_received_total', {
+    description: 'Total number of messages received over WebSockets.',
+    unit: '1',
+});
+
+export {
+  httpServerRequestsTotal,
+  httpServerRequestDurationSeconds,
+  activeWebsocketConnections,
+  websocketMessagesReceivedTotal,
+  // tracer: sdk.getTracer(serviceName, serviceVersion) // Export tracer if manual tracing is needed beyond auto-instrumentation
+};
+
+
+// For this service, we primarily rely on auto-instrumentation and the NODE_OPTIONS pre-load.
+// If manual instrumentation is needed extensively, exporting tracer/meter would be useful.
+// The `NODE_OPTIONS="--require ./opentelemetry.js"` in CDK handles preloading this file.
+// Ensure this file doesn't have side effects that break the server if it's imported multiple times,
+// though the SDK itself handles singleton instances.
+// The `sdk.start()` should only be called once. This file being required by NODE_OPTIONS ensures it runs early.

--- a/atomic-docker/functions_build_docker/package.json
+++ b/atomic-docker/functions_build_docker/package.json
@@ -44,7 +44,13 @@
     "url-join": "^5.0.0",
     "uuid": "^9.0.0",
     "winston": "^3.10.0",
-    "ws": "^8.13.0"
+    "ws": "^8.13.0",
+    "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/sdk-node": "^0.48.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.40.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.48.0",
+    "@opentelemetry/sdk-metrics": "^1.21.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.48.0"
   },
   "type": "module",
   "devDependencies": {

--- a/atomic-docker/project/functions/package.json
+++ b/atomic-docker/project/functions/package.json
@@ -58,7 +58,13 @@
     "node-quickbooks": "^2.0.43",
     "agenda": "^5.0.0",
     "mongodb": "^5.0.0",
-    "apache-arrow": "^15.0.0"
+    "apache-arrow": "^15.0.0",
+    "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/sdk-node": "^0.48.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.40.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.48.0",
+    "@opentelemetry/sdk-metrics": "^1.21.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.48.0"
   },
   "type": "module",
   "devDependencies": {

--- a/deployment/aws/adot-collector-config.yaml
+++ b/deployment/aws/adot-collector-config.yaml
@@ -1,0 +1,36 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+      http:
+        endpoint: "0.0.0.0:4318"
+
+exporters:
+  awsxray:
+    region: ${AWS_REGION} # AWS_REGION will be injected as an environment variable
+  awsemf:
+    region: ${AWS_REGION} # AWS_REGION will be injected as an environment variable
+    log_group_name: '/aws/ecs/otel-metrics/${CLUSTER_NAME}' # Example log group for metrics
+    log_stream_name: 'otel-metrics-stream-${TASK_ID}' # Example log stream
+    namespace: 'AtomicApp/CustomMetrics' # CloudWatch namespace for metrics
+    # resource_to_telemetry_conversion:
+    #   enabled: true # Converts resource attributes to metric dimensions
+
+processors:
+  batch: {} # Batches telemetry data before sending to exporters
+
+extensions:
+  health_check: {}
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [awsxray]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [awsemf]


### PR DESCRIPTION
…nd new dashboard

This commit introduces OpenTelemetry (OTel) instrumentation for services running on AWS and enhances observability.

Key changes:

1.  **AWS CDK (`aws-stack.ts`):**
    *   Integrated the AWS Distro for OpenTelemetry (ADOT) Collector as a sidecar container into the ECS Fargate task definitions for `FunctionsService`, `AppService`, and `PythonAgentService`.
    *   Configured the primary application containers in these services to export OTLP traces and metrics to the local ADOT sidecar.
    *   Adjusted task CPU and memory resources to accommodate the sidecar.
    *   Defined a new CloudWatch Dashboard: `FunctionsService-Performance`, which includes widgets for alarms, ALB/ECS metrics, custom application metrics (placeholder, pending actual data flow), and a Log Insights query for `functions-service` errors.

2.  **`functions-service` Instrumentation (`atomic-docker/functions_build_docker/`):
    *   Updated `package.json` with necessary OpenTelemetry SDK dependencies.
    *   Added `opentelemetry.js` to initialize the OTel SDK, enabling auto-instrumentation for common modules (HTTP, AWS SDK) and configuring OTLP exporters for traces and metrics.
    *   Configured OTel's WinstonInstrumentation to help inject trace context into logs.
    *   Modified `server.ts`:
        *   Replaced existing logging (Morgan, console.*) with Winston, configured for structured JSON logging in alignment with established guidelines.
        *   Ensured trace IDs and span IDs are included in logs.
        *   Implemented custom OpenTelemetry metrics for HTTP request counts/duration and WebSocket connection/message activity.

This work lays the foundation for comprehensive distributed tracing and custom metrics collection in the AWS environment, and provides a dedicated dashboard for monitoring the `functions-service`.