### PR TITLE
feat: Implement retries for Hasura and OpenAI calls in functions-service

### DIFF
--- a/atomic-docker/functions_build_docker/package.json
+++ b/atomic-docker/functions_build_docker/package.json
@@ -50,7 +50,8 @@
     "@opentelemetry/auto-instrumentations-node": "^0.40.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.48.0",
     "@opentelemetry/sdk-metrics": "^1.21.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "^0.48.0"
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.48.0",
+    "async-retry": "^1.3.3"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
This commit introduces resilience enhancements to the `functions-service` by adding retry mechanisms for key external API interactions within `project/functions/gpt/_libs/api-helper.ts`.

Key changes:

1.  **Dependency:** Added `async-retry` to `functions_build_docker/package.json`.

2.  **Hasura Call Retries (using `got`):
    *   Configured explicit retry logic for all `got.post` calls to Hasura (e.g., for `getCalendarIntegration`, `upsertEventsPostPlanner`, `getUserPreferences`, etc.).
    *   Retry configuration includes a limit of 3 retries, retrying on POST methods, specific transient HTTP status codes (408, 429, 5xx), common network error codes, and exponential backoff with jitter.
    *   Request timeouts have also been set for these calls.

3.  **Google Token Refresh Retries (using `got`):
    *   Applied similar `got` retry configuration to the `refreshGoogleToken` function.

4.  **OpenAI Call Retries (using `async-retry`):
    *   Refactored the `callOpenAI` function to use the `async-retry` library.
    *   Configured with 3 retries, exponential backoff with jitter.
    *   Includes logic to `bail` (stop retrying) on non-retryable OpenAI API errors (e.g., 400, 401, 403, 404).
    *   Timeout per OpenAI attempt is also configured.

These changes aim to improve the robustness of `functions-service` when dealing with transient failures from its critical dependencies (Hasura and OpenAI), reducing immediate failures and improving overall service availability. Placeholder console logs within the retry logic should be replaced with structured logging in a subsequent effort.