### PR TITLE
feat: Implement circuit breaker for Hasura calls in functions-service

### DIFF
--- a/atomic-docker/functions_build_docker/package.json
+++ b/atomic-docker/functions_build_docker/package.json
@@ -51,7 +51,8 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.48.0",
     "@opentelemetry/sdk-metrics": "^1.21.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.48.0",
-    "async-retry": "^1.3.3"
+    "async-retry": "^1.3.3",
+    "opossum": "^8.1.3"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
This commit introduces a circuit breaker pattern for Hasura interactions within the `functions-service` (specifically in `project/functions/gpt/_libs/api-helper.ts`) to enhance resilience against an unstable Hasura dependency.

Key changes:

1.  **Dependency:** Added `opossum` (version ^8.1.3) to `functions_build_docker/package.json`.

2.  **Circuit Breaker Implementation (`gpt/_libs/api-helper.ts`):
    *   Imported `opossum`.
    *   Instantiated a shared `opossum` circuit breaker (`hasuraGotBreaker`) configured with:
        *   `timeout: false` (as `got` handles its own request timeouts).
        *   `errorThresholdPercentage: 50%`.
        *   `resetTimeout: 30000` (30 seconds).
        *   `volumeThreshold: 10`.
    *   Added event listeners (`open`, `close`, `halfOpen`, `reject`) to the breaker to log state changes using placeholder `console.warn/error` (intended to be captured by a structured logger).
    *   Wrapped all `got.post` calls made to Hasura within this file (e.g., for `getCalendarIntegration`, `updateCalendarIntegration`, `upsertEventsPostPlanner`, `getGlobalCalendar`, `listEventsForDate`, `getUserPreferences`) using `hasuraGotBreaker.fire()`.
    *   Updated the `catch` blocks for these functions to recognize and specifically report errors when the circuit breaker is open (`EOPENBREAKER`).

This change helps prevent `functions-service` from repeatedly overwhelming a failing Hasura instance and allows it to fail fast when the dependency is deemed unhealthy by the circuit breaker.