### PR TITLE
refactor: Centralize AgentSkillContext and AgentClientCommand types

### DIFF
--- a/atomic-docker/project/functions/atom-agent/handler.ts
+++ b/atomic-docker/project/functions/atom-agent/handler.ts
@@ -56,6 +56,8 @@ import {
   ComplexTaskSubTaskNlu,
   ExecutedSubTaskResult,
   OrchestratedComplexTaskReport,
+  AgentClientCommand, // Import from central types
+  AgentSkillContext,  // Import from central types
 } from '../types';
 
 // Import the specific skill response type if available, or define locally
@@ -81,31 +83,8 @@ interface SemanticSearchStructuredData {
 import { executeGraphQLQuery } from './_libs/graphqlClient'; // For getUserIdByEmail
 
 // --- Interface Definitions for Agent-Client Communication and Skill Context ---
-
-// Defines the structure of commands sent from the agent to the client (e.g., via WebSocket)
-// This should align with the command structure expected by the frontend client.
-interface AgentClientCommand {
-  command_id: string; // Unique ID for tracking the command
-  action: 'START_RECORDING_SESSION' | 'STOP_RECORDING_SESSION' | 'CANCEL_RECORDING_SESSION'; // Specific actions client can perform
-  payload?: {
-    suggestedTitle?: string;
-    linkedEventId?: string;
-    // Other relevant parameters for the client action
-  };
-}
-
-// Defines the context object that will be passed to agent skills.
-// It includes common utilities or functions that skills might need.
-interface AgentSkillContext {
-  userId: string;
-  // Function to send a command to the connected client.
-  // The actual implementation of this function is expected to be injected by the calling environment (e.g., WebSocket handler in server.ts).
-  sendCommandToClient: (userId: string, command: AgentClientCommand) => Promise<boolean>;
-  // Potentially add other context items:
-  // - Access to LTM/STM (though memoryManager functions are currently imported directly)
-  // - User preferences relevant to skills
-  // - API clients if they are not globally available or need user-specific configuration
-}
+// Local definitions of AgentClientCommand and AgentSkillContext are removed.
+// They are now imported from '../types'.
 
 // Extend existing options for _internalHandleMessage to include the sendCommandToClientFunction.
 // This allows the core message handling logic to be equipped with the capability to send commands to the client.

--- a/atomic-docker/project/functions/atom-agent/skills/inPersonAudioNoteSkills.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/inPersonAudioNoteSkills.ts
@@ -1,26 +1,11 @@
 // In: atomic-docker/project/functions/atom-agent/skills/inPersonAudioNoteSkills.ts
 
 import { listUpcomingEvents } from './calendarSkills'; // Import the calendar skill
-import { CalendarEvent, ProcessedNLUResponse } from '../types'; // Import central types
+// Import central types including AgentSkillContext and AgentClientCommand
+import { CalendarEvent, ProcessedNLUResponse, AgentSkillContext, AgentClientCommand } from '../types';
 
-// --- Redefined types to match handler.ts until they are centralized ---
-// Ideally, these would be imported from a shared types file used by both handler and skills.
-// For now, ensuring they match the definitions in handler.ts.
-
-interface AgentClientCommand {
-  command_id: string;
-  action: 'START_RECORDING_SESSION' | 'STOP_RECORDING_SESSION' | 'CANCEL_RECORDING_SESSION';
-  payload?: {
-    suggestedTitle?: string;
-    linkedEventId?: string;
-  };
-}
-
-interface AgentSkillContext {
-  userId: string;
-  sendCommandToClient: (userId: string, command: AgentClientCommand) => Promise<boolean>; // Matches handler.ts
-}
-// --- End Redefined types ---
+// Local/redefined types for AgentClientCommand and AgentSkillContext are removed.
+// They are now imported from ../types
 
 
 // This response type is specific to this skill's handlers

--- a/atomic-docker/project/functions/atom-agent/types.ts
+++ b/atomic-docker/project/functions/atom-agent/types.ts
@@ -1246,3 +1246,34 @@ export interface OrchestratedComplexTaskReport {
   // Example: output of sub-task 1 (e.g., an email ID) could be stored here to be used as input for sub-task 2.
   inter_task_context?: Record<string, any>;
 }
+
+// --- Agent Skill Context and Client Command Types (centralized from handler.ts) ---
+
+/**
+ * Defines the structure of commands sent from the agent to the client (e.g., via WebSocket)
+ * This should align with the command structure expected by the frontend client.
+ */
+export interface AgentClientCommand {
+  command_id: string; // Unique ID for tracking the command
+  action: 'START_RECORDING_SESSION' | 'STOP_RECORDING_SESSION' | 'CANCEL_RECORDING_SESSION'; // Specific actions client can perform
+  payload?: {
+    suggestedTitle?: string;
+    linkedEventId?: string;
+    // Other relevant parameters for the client action, e.g. recording quality hints
+  };
+}
+
+/**
+ * Defines the context object that will be passed to agent skills.
+ * It includes common utilities or functions that skills might need.
+ */
+export interface AgentSkillContext {
+  userId: string;
+  // Function to send a command to the connected client.
+  // The actual implementation of this function is expected to be injected by the calling environment (e.g., WebSocket handler in server.ts).
+  sendCommandToClient: (userId: string, command: AgentClientCommand) => Promise<boolean>;
+  // Potentially add other context items:
+  // - Access to LTM/STM (though memoryManager functions are currently imported directly)
+  // - User preferences relevant to skills
+  // - API clients if they are not globally available or need user-specific configuration
+}


### PR DESCRIPTION
Moved the definitions of `AgentSkillContext` and `AgentClientCommand` interfaces from `handler.ts` to the central types file `atomic-docker/project/functions/atom-agent/types.ts`.

Updated `handler.ts` and `inPersonAudioNoteSkills.ts` to import these types from the central location, removing redundant local definitions.

This improves code maintainability and consistency by establishing a single source of truth for these core agent interfaces.