### PR TITLE
feat: Replace Hasura with PostGraphile and update client code

### DIFF
--- a/atomic-docker/app_build_docker/lib/Calendar/Attendee/AttendeeHelper.ts
+++ b/atomic-docker/app_build_docker/lib/Calendar/Attendee/AttendeeHelper.ts
@@ -29,84 +29,125 @@ export const upsertAttendeesInDb = async (
   resource?: boolean | null,
 ) => {
   try {
+    // ASSUMPTION: A custom mutation 'bulkUpsertAttendees' is defined in PostGraphile (e.g., via a PG function)
+    // The dynamic update_columns logic is now handled by the PG function.
+    // The input type will likely be [AttendeeInput!]
     const upsertQuery = gql`
-    mutation InsertAttendee($attendees: [Attendee_insert_input!]!) {
-            insert_Attendee(
-                objects: $attendees,
-                on_conflict: {
-                    constraint: Attendee_pkey,
-                    update_columns: [
-                      ${name ? 'name,' : ''},
-                      ${contactId ? 'contactId,' : ''},
-                      emails,
-                      ${phoneNumbers ? 'phoneNumbers,' : ''},
-                      ${imAddresses ? 'imAddresses,' : ''},
-                      eventId,
-                      ${additionalGuests ? 'additionalGuests,' : ''},
-                      ${optional ? 'optional,' : ''},
-                      ${resource ? 'resource,' : ''},
-                      responseStatus,
-                      comment,
-                      deleted,
-                      updatedAt,
-                    ]
-                }){
-                returning {
-                  id
-                  additionalGuests
-                  comment
-                  contactId
-                  createdDate
-                  deleted
-                  emails
-                  eventId
-                  imAddresses
-                  name
-                  optional
-                  phoneNumbers
-                  resource
-                  responseStatus
-                  updatedAt
-                  userId
-                }
-                affected_rows
-              }
-            }
-          `
+    mutation BulkUpsertAttendees($attendees: [AttendeeInput!]!) {
+      bulkUpsertAttendees(input: { attendees: $attendees }) {
+        # Assuming the custom function returns a list of the upserted attendees,
+        # wrapped in a standard PostGraphile payload structure.
+        results: attendees { # Or similar, depending on PG function and PostGraphile schema
+          id
+          additionalGuests
+          comment
+          contactId
+          createdDate
+          deleted
+          emails # Assuming emails is a JSONB or similar scalar that PostGraphile handles
+          eventId
+          imAddresses # Assuming imAddresses is a JSONB or similar scalar
+          name
+          optional
+          phoneNumbers # Assuming phoneNumbers is a JSONB or similar scalar
+          resource
+          responseStatus
+          updatedAt
+          userId
+        }
+        # affectedCount # If the function returns a count
+      }
+    }
+  `
+    // The type for client.mutate and variable preparation will need to adjust.
+    // The 'attendees' variable now directly takes the array.
+    const attendeesInput = [
+      {
+        id,
+        userId,
+        eventId,
+        emails, // Ensure this matches the expected input type (e.g., JSON string or object array if PG can map it)
+        name,
+        contactId,
+        phoneNumbers, // Ensure this matches the expected input type
+        imAddresses,  // Ensure this matches the expected input type
+        additionalGuests,
+        optional,
+        resource,
+        updatedAt: dayjs().toISOString(),
+        createdDate: dayjs().toISOString(), // createdDate might be set by DB default
+        deleted: false,
+      },
+    ];
 
-    const { data } = await client.mutate<{ insert_Attendee: { returning: AttendeeType[], affected_rows: number } }>({
+    const { data } = await client.mutate<{ bulkUpsertAttendees: { results: AttendeeType[] } } /* Adjust return type based on actual payload */>({
       mutation: upsertQuery,
       variables: {
-        attendees: [
-          {
-            id,
-            userId,
-            eventId,
-            emails,
-            name,
-            contactId,
-            phoneNumbers,
-            imAddresses,
-            additionalGuests,
-            optional,
-            resource,
-            updatedAt: dayjs().toISOString(),
-            createdDate: dayjs().toISOString(),
-            deleted: false,
-          },
-        ],
+        attendees: attendeesInput,
       },
       update(cache, { data }) {
-        if (data?.insert_Attendee?.affected_rows && data?.insert_Attendee?.affected_rows > 0) {
-          console.log('insert_Attendee?.affected_rows', data)
-        }
+        // The cache update logic might need significant changes based on how PostGraphile returns data
+        // and how list queries are structured. This is a placeholder adjustment.
+        const upsertedAttendees = data?.bulkUpsertAttendees?.results;
+        if (upsertedAttendees && upsertedAttendees.length > 0) {
+          console.log('bulkUpsertAttendees results', upsertedAttendees);
 
-        cache.modify({
-          fields: {
-            Attendee(existingAttendees = []) {
-              const newAttendeeRef = cache.writeFragment({
-                data: data?.insert_Attendee?.returning?.[0],
-                fragment: gql`
+          // If you have a list query like 'allAttendees' that you want to update:
+          // cache.modify({
+          //   fields: {
+          //     allAttendees(existingConnection = { nodes: [] }, { readField }) {
+          //       const newConnection = { ...existingConnection, nodes: [...existingConnection.nodes] };
+          //       upsertedAttendees.forEach(attendee => {
+          //         const existingNode = newConnection.nodes.find(nodeRef => readField('id', nodeRef) === attendee.id);
+          //         if (existingNode) {
+          //           // If exists, Apollo Client might merge automatically, or you might need to explicitly update fields.
+          //           // For simplicity, often re-fetching the list is easier unless fine-grained control is needed.
+          //         } else {
+          //           const newAttendeeRef = cache.writeFragment({
+          //             data: attendee,
+          //             fragment: gql`
+          //               fragment NewAttendeeOnUpsert on Attendee {
+          //                 id
+          //                 # ... include all fields from the fragment below
+          //                 additionalGuests
+          //                 comment
+          //                 contactId
+          //                 createdDate
+          //                 deleted
+          //                 emails
+          //                 eventId
+          //                 imAddresses
+          //                 name
+          //                 optional
+          //                 phoneNumbers
+          //                 resource
+          //                 responseStatus
+          //                 updatedAt
+          //                 userId
+          //               }
+          //             `
+          //           });
+          //           newConnection.nodes.push(newAttendeeRef);
+          //         }
+          //       });
+          //       return newConnection;
+          //     }
+          //   }
+          // });
+
+          // The original cache logic was modifying a root field 'Attendee'.
+          // This is less common with PostGraphile which usually uses connection types like 'allAttendees'.
+          // This part is highly dependent on your actual queries and PostGraphile schema.
+          // For now, I'll adapt the fragment writing part, but the field name 'Attendee' might be incorrect.
+          cache.modify({
+            fields: {
+              // This field name 'Attendee' is likely incorrect for PostGraphile.
+              // It would typically be 'allAttendees' or a specific query name.
+              // This will need to be verified against the actual PostGraphile schema and queries used to populate the cache.
+              Attendee: (existingAttendees = []) => { // Placeholder for existing cache update logic
+                const newAttendeeRef = cache.writeFragment({
+                  data: upsertedAttendees[0], // Assuming only one is upserted here, or loop if many
+                  fragment: gql`
                     fragment NewAttendee on Attendee {
                       id
                       additionalGuests

--- a/atomic-docker/app_build_docker/lib/apollo/apollo.ts
+++ b/atomic-docker/app_build_docker/lib/apollo/apollo.ts
@@ -13,7 +13,9 @@ import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { createClient } from 'graphql-ws'
 import { onError } from "@apollo/client/link/error"
 
-import { hasuraWSUrl, hasuraDbUrl } from '@lib/constants'
+// TODO: Update constants in @lib/constants to define postgraphileDbUrl and postgraphileWSUrl
+// For now, we'll use placeholder names and assume they will be correctly defined.
+import { postgraphileDbUrl, postgraphileWSUrl } from '@lib/constants'
 import Session from "supertokens-web-js/recipe/session";
 //endpointURL
 
@@ -52,13 +54,26 @@ const makeApolloClient = (token: String) => {
     }
   });
 
+  // IMPORTANT: PostGraphile V4 subscriptions require server-side setup
+  // with plugins like @graphile/pg-pubsub. The endpoint path might also differ (e.g., /graphql/subscriptions).
+  // This wsLink setup ASSUMES such an endpoint is available and uses a similar auth pattern.
+  // This will likely NOT work without further PostGraphile server-side configuration.
   const wsLink = new GraphQLWsLink(createClient({
-    url: hasuraWSUrl,
-    connectionParams: {
-      Authorization: `Bearer ${token}`,
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
+    url: postgraphileWSUrl, // Use the new PostGraphile WebSocket URL
+    connectionParams: () => { // connectionParams can be a function to dynamically get the token
+      return {
+        // PostGraphile's default JWT handling via `pgSettings` might pick up the role from the token.
+        // Explicitly sending Authorization header might be needed depending on PostGraphile server setup.
+        // Check PostGraphile's documentation for WebSocket authentication.
+        // Authorization: `Bearer ${token}`, // Original token passed to makeApolloClient
+        // headers: { // Headers might not be standard for graphql-ws connectionParams, often it's a flat object
+        //   Authorization: `Bearer ${token}`
+        // }
+        // It's often better to rely on the JWT containing necessary claims (like role)
+        // that PostGraphile can interpret via pgSettings.
+        // If a token is needed for the initial WS connection itself:
+        token: token // Or however the PostGraphile WS auth is configured.
+      };
     },
   }))
 
@@ -73,8 +88,8 @@ const makeApolloClient = (token: String) => {
   })
 
   const httpLink = new HttpLink({
-    uri: hasuraDbUrl,
-    // headers: {
+    uri: postgraphileDbUrl, // Use the new PostGraphile HTTP URL
+    // headers: { // Headers are now set by linkTokenHeader via setContext
     //   Authorization: `Bearer ${}`
     // },
   })

--- a/atomic-docker/app_build_docker/lib/apollo/gql/deleteCalendarById.ts
+++ b/atomic-docker/app_build_docker/lib/apollo/gql/deleteCalendarById.ts
@@ -3,22 +3,16 @@ import { gql } from "@apollo/client";
 
 export default gql`
 mutation DeleteCalendarById($id: String!) {
-  delete_Calendar_by_pk(id: $id) {
-    accessLevel
-    account
-    backgroundColor
-    colorId
-    createdDate
-    defaultReminders
-    deleted
-    foregroundColor
-    globalPrimary
-    id
-    modifiable
-    resource
-    title
-    updatedAt
-    userId
+  deleteCalendarById(input: { id: $id }) { # Renamed and using input object
+    calendar { # Standard PostGraphile payload often returns the deleted object or its ID
+      id # Commonly, only the ID of the deleted object is returned
+      # title # Other fields might be available if the PG function returns the full record
+    }
+    # clientMutationId # Optional, for Relay compatibility
+    # deletedCalendarId # Alternative way PostGraphile might return the ID
   }
 }
 `
+// Note: The exact return fields (e.g., 'calendar { id }' vs 'deletedCalendarId')
+// depend on PostGraphile's default CRUD mutations or how a custom delete function is defined.
+// Returning just the ID is common. The original query returned many fields, which is less typical for PostGraphile deletes.

--- a/atomic-docker/app_build_docker/lib/apollo/gql/getCalendarById.ts
+++ b/atomic-docker/app_build_docker/lib/apollo/gql/getCalendarById.ts
@@ -2,10 +2,10 @@ import { gql } from '@apollo/client';
 
 export default gql`
 query GetCalendarById($id: String!) {
-  Calendar_by_pk(id: $id) {
+  calendarById(id: $id) { # Renamed from Calendar_by_pk
     id
     title
-    colorId
+    colorId # Assuming field names remain similar or are camelCased by PostGraphile
     account
     accessLevel
     modifiable
@@ -20,6 +20,7 @@ query GetCalendarById($id: String!) {
     backgroundColor
     pageToken
     syncToken
+    # Ensure all field names are camelCase if originally snake_case in DB
   }
 }
 `

--- a/atomic-docker/app_build_docker/lib/constants.ts
+++ b/atomic-docker/app_build_docker/lib/constants.ts
@@ -13,8 +13,17 @@ export const lanceEventMatcherUrl = process.env.NEXT_PUBLIC_LANCE_EVENT_MATCHER_
 
 export const openTrainEventVectorName = 'embeddings'
 export const eventVectorName = openTrainEventVectorName
-export const hasuraDbUrl = process.env.NEXT_PUBLIC_HASURA_GRAPHQL_GRAPHQL_URL
-export const hasuraWSUrl = process.env.NEXT_PUBLIC_HASURA_GRAPHQL_GRAPHQL_WS_URL
+// export const hasuraDbUrl = process.env.NEXT_PUBLIC_HASURA_GRAPHQL_GRAPHQL_URL
+// export const hasuraWSUrl = process.env.NEXT_PUBLIC_HASURA_GRAPHQL_GRAPHQL_WS_URL
+export const postgraphileDbUrl = process.env.NEXT_PUBLIC_POSTGRAPHILE_GRAPHQL_URL
+// IMPORTANT: PostGraphile V4 needs a plugin like @graphile/pg-pubsub for WebSocket subscriptions.
+// The actual WebSocket URL might be different (e.g., ws://localhost:5000/graphql/subscriptions or similar)
+// and needs to be configured on the PostGraphile server side.
+// For now, we'll assume it's the same base URL with `/graphql` path, but this is a placeholder.
+export const postgraphileWSUrl = process.env.NEXT_PUBLIC_POSTGRAPHILE_GRAPHQL_URL
+  ? process.env.NEXT_PUBLIC_POSTGRAPHILE_GRAPHQL_URL.replace(/^http/, 'ws')
+  : undefined;
+
 
 export const googleCalendarAndroidAuthUrl = process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_ANDROID_AUTH_URL
 export const googleClientIdAtomicWeb = process.env.GOOGLE_CLIENT_ID_ATOMIC_WEB


### PR DESCRIPTION
Replaced Hasura with PostGraphile as the GraphQL API generation layer.

Key changes include:
- Updated docker-compose.yaml to use the graphile/postgraphile image, configured environment variables, and updated service dependencies.
- Modified AWS CDK stack (aws-stack.ts) to deploy PostGraphile instead of Hasura in ECS, including updates to secrets, ECS service definitions, target groups, and listener rules.
- Updated documentation (atomic-docker/README.md) to reflect the change.
- Updated Apollo Client configuration to point to PostGraphile endpoints.
- Began updating GraphQL queries and mutations in client-side code to align with PostGraphile conventions. This includes representative examples in various helper files and GQL definition files.

This change addresses the requirement to move away from Hasura V3 due to licensing changes and adopt a fully open-source alternative. PostGraphile was chosen for its strong PostgreSQL integration and automatic GraphQL API generation capabilities.

Further work required by the development team:
- Thoroughly test all application functionality.
- Complete the manual update of all remaining client-side GraphQL queries and mutations based on the live PostGraphile schema.
- Implement any necessary custom PostgreSQL functions to support complex upsert or business logic previously handled by Hasura's capabilities or implicit in its mutation arguments.
- Configure PostGraphile plugins as needed (e.g., for subscriptions, schema naming conventions).
- Regenerate TypeScript types if using GraphQL Code Generator and fix any resulting type errors.