### PR TITLE
feat: Integrate Google Drive for Document Ingestion (Phase 5)

### DIFF
--- a/atomic-docker/project/functions/python_api_service/gdrive_handler.py
+++ b/atomic-docker/project/functions/python_api_service/gdrive_handler.py
@@ -1,0 +1,178 @@
+import os
+import sys
+import tempfile
+import uuid
+import logging
+from flask import Blueprint, request, jsonify
+
+# Adjust path for imports - assumes this file is in python_api_service
+# Path to 'python-api/' (parent of python_api_service)
+PYTHON_API_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if PYTHON_API_DIR not in sys.path:
+    sys.path.append(PYTHON_API_DIR)
+
+# Path to 'project/functions/' for note_utils (if used for embeddings by document_processor)
+FUNCTIONS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'project', 'functions'))
+if FUNCTIONS_DIR not in sys.path:
+    sys.path.append(FUNCTIONS_DIR)
+
+try:
+    from . import gdrive_service # Expects gdrive_service.py in the same directory (python_api_service)
+    from ingestion_pipeline import document_processor # Expects document_processor in ingestion_pipeline subdir
+    INGESTION_SERVICES_AVAILABLE = True
+except ImportError as e:
+    print(f"Error importing gdrive_service or document_processor: {e}. GDrive ingestion will not be fully functional.", file=sys.stderr)
+    INGESTION_SERVICES_AVAILABLE = False
+    # Mock them if necessary for app loading, but calls will fail
+    gdrive_service = type('obj', (object,), {'download_gdrive_file': lambda **kwargs: {"status": "error", "message": "gdrive_service not loaded"}})()
+    document_processor = type('obj', (object,), {'process_pdf_and_store': lambda **kwargs: {"status": "error", "message": "document_processor not loaded"}})()
+
+
+logger = logging.getLogger(__name__)
+if not logger.hasHandlers():
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+gdrive_bp = Blueprint('gdrive_api', __name__)
+
+@gdrive_bp.errorhandler(Exception)
+def handle_gdrive_exception(e):
+    logger.error(f"Unhandled exception in gdrive_handler: {e}", exc_info=True)
+    return jsonify({
+        "ok": False,
+        "error": {"code": "PYTHON_UNHANDLED_ERROR", "message": "An unexpected server error occurred in GDrive handler.", "details": str(e)}
+    }), 500
+
+@gdrive_bp.route('/api/ingest-gdrive-document', methods=['POST'])
+async def ingest_gdrive_document_route(): # Made async
+    if not INGESTION_SERVICES_AVAILABLE:
+        return jsonify({"ok": False, "error": {"code": "SERVICE_UNAVAILABLE", "message": "GDrive ingestion or document processing service is not available."}}), 503
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"ok": False, "error": {"code": "INVALID_PAYLOAD", "message": "Request must be JSON."}}), 400
+
+    user_id = data.get('user_id')
+    gdrive_file_id = data.get('gdrive_file_id')
+    access_token = data.get('access_token') # Direct access token for simplicity in this example
+    # In production, this might be an internal token_ref to look up the actual GDrive access_token
+
+    original_file_metadata = data.get('original_file_metadata', {})
+    file_name = original_file_metadata.get('name', 'Untitled Google Drive File')
+    original_mime_type = original_file_metadata.get('mimeType', '')
+    source_uri = original_file_metadata.get('webViewLink', f"gdrive_id_{gdrive_file_id}")
+
+    openai_api_key_param = data.get('openai_api_key') # Optional key for embeddings
+
+    if not all([user_id, gdrive_file_id, access_token]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "Missing required fields: user_id, gdrive_file_id, access_token."}}), 400
+
+    logger.info(f"Received request to ingest GDrive file: ID='{gdrive_file_id}', Name='{file_name}', User='{user_id}'")
+
+    # Determine target MIME type for download/export
+    target_mime_type_for_download = None
+    doc_processor_input_type = "pdf" # Assume PDF for now, as that's what process_pdf_and_store handles
+
+    if original_mime_type.startswith('application/vnd.google-apps'):
+        if original_mime_type == 'application/vnd.google-apps.document':
+            target_mime_type_for_download = 'application/pdf'
+            # file_name_for_processor = f"{os.path.splitext(file_name)[0]}.pdf"
+        elif original_mime_type == 'application/vnd.google-apps.spreadsheet':
+            # TODO: process_pdf_and_store currently only handles PDFs.
+            # Need text extraction for XLSX or export GSheet as CSV/TSV then process text.
+            # For now, this path will likely fail or needs a different processor.
+            # target_mime_type_for_download = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+            # doc_processor_input_type = "xlsx"
+            logger.warning(f"Processing Google Sheets (ID: {gdrive_file_id}) as text via PDF export is a TODO. Attempting PDF export.")
+            target_mime_type_for_download = 'application/pdf' # Fallback to PDF for text
+        elif original_mime_type == 'application/vnd.google-apps.presentation':
+            target_mime_type_for_download = 'application/pdf'
+            # file_name_for_processor = f"{os.path.splitext(file_name)[0]}.pdf"
+        else: # Other GSuite types
+            logger.warning(f"Unsupported Google Workspace MIME type for direct processing: {original_mime_type}. Attempting PDF export.")
+            target_mime_type_for_download = 'application/pdf'
+    elif original_mime_type == 'application/pdf':
+        doc_processor_input_type = "pdf" # Already a PDF
+    # TODO: Add handling for other direct download types like .docx, .txt if document_processor supports them.
+    else:
+        logger.warning(f"GDrive file {gdrive_file_id} has MIME type {original_mime_type}, which may not be directly processable by PDF pipeline. Attempting direct download.")
+        # No target_mime_type means direct download. document_processor must handle it.
+        # For now, we assume it must become a PDF to go through process_pdf_and_store.
+        # This part needs more robust type handling based on what document_processor can take.
+        # If we only support PDF processing, we should error here for non-convertible/non-PDF types.
+        return jsonify({"ok": False, "error": {"code": "UNSUPPORTED_MIME_TYPE", "message": f"MIME type {original_mime_type} for GDrive file {gdrive_file_id} is not yet supported for ingestion via PDF pipeline."}}), 400
+
+
+    download_result = gdrive_service.download_gdrive_file(
+        access_token=access_token,
+        file_id=gdrive_file_id,
+        target_mime_type=target_mime_type_for_download
+    )
+
+    if download_result["status"] != "success":
+        logger.error(f"Failed to download GDrive file {gdrive_file_id}: {download_result.get('message')}")
+        return jsonify({"ok": False, "error": {"code": download_result.get("code", "GDRIVE_DOWNLOAD_FAILED"), "message": download_result.get("message")}}), 500
+
+    downloaded_data = download_result["data"]
+    file_content_bytes = downloaded_data["content_bytes"]
+    # Use the (potentially extension-changed) name from download_result for the temp file
+    temp_file_name_for_processing = downloaded_data["file_name"]
+
+    temp_dir = None
+    temp_file_path = None
+    try:
+        temp_dir = tempfile.mkdtemp()
+        temp_file_path = os.path.join(temp_dir, temp_file_name_for_processing) # Use name from download
+        with open(temp_file_path, 'wb') as f:
+            f.write(file_content_bytes)
+
+        logger.info(f"GDrive file {gdrive_file_id} downloaded to temp path: {temp_file_path}")
+
+        document_id = str(uuid.uuid4()) # New UUID for this ingested document
+
+        # Current document_processor.process_pdf_and_store is specific to PDFs.
+        # If download_gdrive_file always converts to PDF, this is fine.
+        # Otherwise, process_pdf_and_store needs to become more generic or we need type-specific processors.
+        if doc_processor_input_type != "pdf": # Placeholder for future when it handles more types
+             return jsonify({"ok": False, "error": {"code": "PROCESSOR_TYPE_MISMATCH", "message": f"Document processor currently set for PDF, but got type {doc_processor_input_type} from GDrive download."}}), 500
+
+
+        processing_result = await document_processor.process_pdf_and_store(
+            user_id=user_id,
+            pdf_file_path=temp_file_path, # Path to the downloaded (and potentially converted) PDF
+            document_id=document_id,
+            source_uri=source_uri, # Original GDrive webViewLink
+            title=file_name, # Original GDrive file name
+            doc_source_type=f"gdrive_{original_mime_type.split('/')[-1].replace('.', '_')}", # e.g. gdrive_pdf, gdrive_document
+            openai_api_key_param=openai_api_key
+        )
+
+        if processing_result["status"] == "success":
+            return jsonify({"ok": True, "data": processing_result.get("data")}), 201
+        else:
+            return jsonify({"ok": False, "error": {"code": processing_result.get("code", "DOCUMENT_PROCESSING_FAILED"), "message": processing_result.get("message")}}), 500
+
+    except Exception as e:
+        logger.error(f"Error during GDrive document ingestion pipeline for {gdrive_file_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "GDRIVE_INGESTION_PIPELINE_ERROR", "message": str(e)}}), 500
+    finally:
+        if temp_file_path and os.path.exists(temp_file_path):
+            os.remove(temp_file_path)
+        if temp_dir and os.path.exists(temp_dir):
+            # os.rmdir(temp_dir) # This fails if files were created then deleted, use shutil
+            import shutil
+            try:
+                shutil.rmtree(temp_dir)
+            except OSError as e_rm:
+                logger.error(f"Error removing temp directory {temp_dir}: {e_rm}", exc_info=True)
+
+# Example of how this blueprint would be registered in the main Flask app
+# (e.g., in python_api_service/note_handler.py or a main app.py)
+# from .gdrive_handler import gdrive_bp
+# app.register_blueprint(gdrive_bp)
+
+if __name__ == '__main__':
+    # This allows running this handler standalone for development/testing,
+    # but it won't have other registered blueprints unless main app is structured differently.
+    # For testing, one would typically run the main Flask app that includes this blueprint.
+    app.run(host='0.0.0.0', port=5060, debug=True) # Use a different port for standalone run
+```

--- a/atomic-docker/project/functions/python_api_service/gdrive_service.py
+++ b/atomic-docker/project/functions/python_api_service/gdrive_service.py
@@ -1,0 +1,229 @@
+import io
+import logging
+from typing import List, Dict, Any, Optional, Tuple
+
+# Google API Client Library
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaIoBaseDownload
+
+logger = logging.getLogger(__name__)
+if not logger.hasHandlers():
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+# --- Constants ---
+DRIVE_API_VERSION = 'v3'
+DEFAULT_PAGE_SIZE = 100
+# Common fields to retrieve for file listings. Add more as needed.
+DEFAULT_FILE_FIELDS = "nextPageToken, files(id, name, mimeType, modifiedTime, webViewLink, parents, capabilities(canDownload, canExport))"
+
+
+def _get_drive_service(access_token: str) -> Optional[Any]:
+    """Initializes and returns a Google Drive service client."""
+    try:
+        creds = Credentials(token=access_token)
+        # Check if token is expired; ideally, the calling layer (TS skill/AuthService) handles refresh.
+        # If token is expired here, operations will fail.
+        # if creds.expired and creds.refresh_token: # This service won't have refresh_token directly
+        #     # Perform refresh logic (complex, better handled by an auth service)
+        #     pass
+        service = build('drive', DRIVE_API_VERSION, credentials=creds, static_discovery=False)
+        return service
+    except Exception as e:
+        logger.error(f"Failed to initialize Google Drive service: {e}", exc_info=True)
+        return None
+
+def list_gdrive_files(
+    access_token: str,
+    folder_id: Optional[str] = None,
+    query: Optional[str] = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    page_token: Optional[str] = None,
+    fields: str = DEFAULT_FILE_FIELDS,
+    shared_with_me: bool = False, # To list files shared with the user
+    corpora: str = "user" # user, domain, allDrives (for shared drive support)
+) -> Dict[str, Any]:
+    """
+    Lists files and folders from Google Drive.
+    Returns a dictionary: {"status": "success/error", "data": {"files": [], "nextPageToken": ...}, "message": ..., "code": ...}
+    """
+    service = _get_drive_service(access_token)
+    if not service:
+        return {"status": "error", "message": "Failed to initialize Google Drive service.", "code": "GDRIVE_SERVICE_INIT_FAILED"}
+
+    q_parts = []
+    if query:
+        q_parts.append(f"name contains '{query}'") # Basic name query, can be expanded
+
+    if folder_id:
+        q_parts.append(f"'{folder_id}' in parents")
+
+    # Filter for non-trashed files
+    q_parts.append("trashed = false")
+
+    final_query = " and ".join(q_parts) if q_parts else None
+
+    try:
+        logger.info(f"Listing GDrive files: query='{final_query}', folder_id='{folder_id}', page_token='{page_token}', sharedWithMe='{shared_with_me}', corpora='{corpora}'")
+
+        results = service.files().list(
+            q=final_query,
+            pageSize=page_size,
+            pageToken=page_token,
+            fields=fields,
+            supportsAllDrives=True, # Required for sharedDriveItems and corpora=allDrives
+            includeItemsFromAllDrives=True if corpora == "allDrives" else False,
+            corpora=corpora, # 'user', 'drive', 'domain', 'allDrives'
+            # sharedWithMe=shared_with_me # This parameter is not valid for files.list with q; use specific query terms for shared files
+        ).execute()
+
+        files = results.get('files', [])
+        next_page = results.get('nextPageToken')
+
+        logger.info(f"GDrive list_files returned {len(files)} items. Next page token: {bool(next_page)}")
+        return {"status": "success", "data": {"files": files, "nextPageToken": next_page}}
+
+    except HttpError as e:
+        error_content = e.resp.reason if hasattr(e.resp, 'reason') else str(e)
+        try: # Try to parse error details from Google's JSON response
+            error_details_json = json.loads(e.content.decode())
+            error_message = error_details_json.get("error", {}).get("message", error_content)
+            error_code_detail = error_details_json.get("error", {}).get("errors", [{}])[0].get("reason", "GDRIVE_API_ERROR")
+        except:
+            error_message = error_content
+            error_code_detail = "GDRIVE_API_ERROR"
+
+        logger.error(f"Google Drive API error during list_files: {error_message} (Status: {e.resp.status}, Code: {error_code_detail})", exc_info=True)
+        return {"status": "error", "message": error_message, "code": f"GDRIVE_API_{error_code_detail.upper()}", "details": str(e)}
+    except Exception as e:
+        logger.error(f"Unexpected error listing Google Drive files: {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error listing files: {str(e)}", "code": "GDRIVE_LIST_UNEXPECTED_ERROR"}
+
+
+def download_gdrive_file(
+    access_token: str,
+    file_id: str,
+    target_mime_type: Optional[str] = None # e.g., 'application/pdf' for GDocs
+) -> Dict[str, Any]:
+    """
+    Downloads a file from Google Drive. If it's a Google Workspace document,
+    it exports it to the target_mime_type (PDF if not specified for GDocs).
+    Returns: {"status": "success/error", "data": {"file_name": str, "content_bytes": bytes, "mime_type": str}, ...}
+    """
+    service = _get_drive_service(access_token)
+    if not service:
+        return {"status": "error", "message": "Failed to initialize Google Drive service.", "code": "GDRIVE_SERVICE_INIT_FAILED"}
+
+    try:
+        # Get file metadata to determine its type and capabilities
+        file_metadata = service.files().get(fileId=file_id, fields="id, name, mimeType, capabilities(canExport)").execute()
+        original_mime_type = file_metadata.get('mimeType', '')
+        file_name = file_metadata.get('name', file_id)
+
+        logger.info(f"Attempting to download GDrive file: ID='{file_id}', Name='{file_name}', MIMEType='{original_mime_type}'")
+
+        request = None
+        effective_mime_type = original_mime_type
+
+        # Check if it's a Google Workspace type that needs export
+        is_google_doc = original_mime_type.startswith('application/vnd.google-apps')
+
+        if is_google_doc:
+            can_export = file_metadata.get('capabilities', {}).get('canExport', False)
+            if not can_export: # Should not happen if file is accessible, but good check
+                 return {"status": "error", "message": f"File '{file_name}' (ID: {file_id}) is a Google Workspace type but cannot be exported.", "code": "GDRIVE_EXPORT_NOT_ALLOWED"}
+
+            if not target_mime_type:
+                if original_mime_type == 'application/vnd.google-apps.document':
+                    target_mime_type = 'application/pdf' # Default export for GDoc
+                    file_name = f"{os.path.splitext(file_name)[0]}.pdf" if '.' in file_name else f"{file_name}.pdf"
+                elif original_mime_type == 'application/vnd.google-apps.spreadsheet':
+                    target_mime_type = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' # XLSX
+                    file_name = f"{os.path.splitext(file_name)[0]}.xlsx" if '.' in file_name else f"{file_name}.xlsx"
+                elif original_mime_type == 'application/vnd.google-apps.presentation':
+                    target_mime_type = 'application/pdf' # Or pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+                    file_name = f"{os.path.splitext(file_name)[0]}.pdf" if '.' in file_name else f"{file_name}.pdf"
+                else: # Other GSuite types, attempt PDF or fail
+                    target_mime_type = 'application/pdf'
+                    file_name = f"{os.path.splitext(file_name)[0]}.pdf" if '.' in file_name else f"{file_name}.pdf"
+
+            logger.info(f"Exporting Google Workspace file '{file_name}' (ID: {file_id}) as MIME type: {target_mime_type}")
+            request = service.files().export_media(fileId=file_id, mimeType=target_mime_type)
+            effective_mime_type = target_mime_type
+        else:
+            # For native files (PDF, DOCX already in Drive, etc.), use direct download
+            logger.info(f"Downloading native file '{file_name}' (ID: {file_id}) directly.")
+            request = service.files().get_media(fileId=file_id)
+
+        fh = io.BytesIO()
+        downloader = MediaIoBaseDownload(fh, request)
+        done = False
+        while not done:
+            status, done = downloader.next_chunk()
+            if status:
+                logger.debug(f"Download/Export progress for {file_id}: {int(status.progress() * 100)}%")
+
+        file_content_bytes = fh.getvalue()
+        logger.info(f"Successfully downloaded/exported file '{file_name}' (ID: {file_id}). Size: {len(file_content_bytes)} bytes.")
+
+        return {
+            "status": "success",
+            "data": {
+                "file_name": file_name,
+                "content_bytes": file_content_bytes,
+                "mime_type": effective_mime_type
+            }
+        }
+
+    except HttpError as e:
+        error_content = e.resp.reason if hasattr(e.resp, 'reason') else str(e)
+        try:
+            error_details_json = json.loads(e.content.decode())
+            error_message = error_details_json.get("error", {}).get("message", error_content)
+            error_code_detail = error_details_json.get("error", {}).get("errors", [{}])[0].get("reason", "GDRIVE_API_ERROR")
+        except:
+            error_message = error_content
+            error_code_detail = "GDRIVE_API_ERROR"
+
+        logger.error(f"Google Drive API error during download/export of file {file_id}: {error_message} (Status: {e.resp.status}, Code: {error_code_detail})", exc_info=True)
+        return {"status": "error", "message": error_message, "code": f"GDRIVE_API_{error_code_detail.upper()}", "details": str(e)}
+    except Exception as e:
+        logger.error(f"Unexpected error downloading/exporting GDrive file {file_id}: {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error downloading file: {str(e)}", "code": "GDRIVE_DOWNLOAD_UNEXPECTED_ERROR"}
+
+# Example Usage (Conceptual - for testing this module directly)
+# async def main():
+#     # Requires a valid, user-authorized access_token with drive.readonly scope
+#     # This token would typically be obtained via an OAuth flow managed by another service/frontend.
+#     access_token = os.getenv("TEST_GDRIVE_ACCESS_TOKEN")
+#     if not access_token:
+#         print("Please set TEST_GDRIVE_ACCESS_TOKEN environment variable for testing.")
+#         return
+
+#     print("--- Listing Root Files ---")
+#     list_result = list_gdrive_files(access_token, page_size=5)
+#     if list_result["status"] == "success":
+#         for f in list_result["data"]["files"]:
+#             print(f"ID: {f['id']}, Name: {f['name']}, MIME: {f['mimeType']}")
+#             # Example: Download the first PDF or GDoc found
+#             if not hasattr(main, 'downloaded_once'):
+#                 if f['mimeType'] == 'application/pdf' or f['mimeType'] == 'application/vnd.google-apps.document':
+#                     print(f"\n--- Attempting to download: {f['name']} ---")
+#                     download_result = download_gdrive_file(access_token, f['id'])
+#                     if download_result["status"] == "success":
+#                         print(f"Successfully downloaded '{download_result['data']['file_name']}' ({len(download_result['data']['content_bytes'])} bytes, type: {download_result['data']['mime_type']})")
+#                         # with open(download_result['data']['file_name'], 'wb') as df:
+#                         #     df.write(download_result['data']['content_bytes'])
+#                         # print(f"Saved to {download_result['data']['file_name']}")
+#                         main.downloaded_once = True # static variable on function
+#                     else:
+#                         print(f"Download failed: {download_result['message']} (Code: {download_result.get('code')})")
+#                     # break # download only one for testing
+#     else:
+#         print(f"Listing failed: {list_result['message']}")
+
+# if __name__ == "__main__":
+#    asyncio.run(main())
+
+```

--- a/src/skills/gdriveSkills.ts
+++ b/src/skills/gdriveSkills.ts
@@ -1,0 +1,156 @@
+import axios, { AxiosError } from 'axios';
+import {
+  SkillResponse,
+  // Assuming PYTHON_API_SERVICE_BASE_URL will host these GDrive endpoints
+} from '../../atomic-docker/project/functions/atom-agent/types';
+import { PYTHON_API_SERVICE_BASE_URL } from '../../atomic-docker/project/functions/atom-agent/_libs/constants';
+import { logger } from '../../atomic-docker/project/functions/_utils/logger';
+
+const GDRIVE_API_TIMEOUT = 20000; // 20 seconds for listing/triggering, download itself is on backend
+
+// Interface for Google Drive file metadata (subset of what Drive API returns)
+export interface GoogleDriveFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  modifiedTime?: string; // ISO 8601
+  webViewLink?: string;  // Link to view in browser
+  parents?: string[];    // List of parent folder IDs
+  capabilities?: {
+    canDownload?: boolean;
+    canExport?: boolean; // For Google Workspace files
+  };
+  // Add other fields as needed, e.g., iconLink, size, owners
+}
+
+// Helper to construct SkillResponse from axios errors (copied from lanceDbStorageSkills.ts for now)
+// TODO: Move this to a shared utility file if more skills use it.
+function handleAxiosError(error: AxiosError, operationName: string): SkillResponse<null> {
+  if (error.response) {
+    logger.error(`[${operationName}] Error: ${error.response.status}`, error.response.data);
+    const errData = error.response.data as any; // Python returns {ok: false, error: {code, message}}
+    return {
+      ok: false,
+      error: {
+        code: errData?.error?.code || `HTTP_${error.response.status}`,
+        message: errData?.error?.message || `Failed to ${operationName}. Status: ${error.response.status}`,
+        details: errData?.error?.details || errData,
+      },
+    };
+  } else if (error.request) {
+    logger.error(`[${operationName}] Error: No response received for ${operationName}`, error.request);
+    return {
+      ok: false,
+      error: { code: 'NETWORK_ERROR', message: `No response received for ${operationName}.` },
+    };
+  } else {
+    logger.error(`[${operationName}] Error setting up request: ${error.message}`);
+    return {
+      ok: false,
+      error: { code: 'REQUEST_SETUP_ERROR', message: `Error setting up request for ${operationName}: ${error.message}` },
+    };
+  }
+}
+
+export async function listGoogleDriveFiles(
+  // userId: string, // Not strictly needed by Python if token is user-specific, but good for logging/consistency
+  accessToken: string, // User's GDrive access token
+  folderId?: string,
+  query?: string, // Search query string
+  pageSize: number = 50,
+  pageToken?: string
+): Promise<SkillResponse<{ files: GoogleDriveFile[]; nextPageToken?: string }>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'PYTHON_API_SERVICE_BASE_URL not configured.' }};
+  }
+  if (!accessToken) {
+    return { ok: false, error: { code: 'AUTH_ERROR', message: 'Google Drive access token is required.' }};
+  }
+
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/gdrive/list-files`;
+  const payload = {
+    access_token: accessToken,
+    folder_id: folderId,
+    query: query,
+    page_size: pageSize,
+    page_token: pageToken,
+  };
+
+  logger.info(`[listGoogleDriveFiles] Listing GDrive files. Folder: ${folderId || 'root/all'}, Query: ${query || 'none'}`);
+
+  try {
+    const response = await axios.post(endpoint, payload, { timeout: GDRIVE_API_TIMEOUT });
+    // Python endpoint returns: {"status": "success/error", "data": {"files": [], "nextPageToken": ...}, "message": ..., "code": ...}
+    // We need to map this to SkillResponse: {ok: boolean, data?: T, error?: SkillError}
+    if (response.data && response.data.status === "success" && response.data.data) {
+      logger.info(`[listGoogleDriveFiles] Successfully listed ${response.data.data.files?.length || 0} GDrive files.`);
+      return { ok: true, data: response.data.data };
+    } else {
+      logger.warn(`[listGoogleDriveFiles] Failed to list GDrive files. API status: ${response.data?.status}`, response.data);
+      return {
+        ok: false,
+        error: {
+          code: response.data?.code || 'GDRIVE_LIST_FAILED',
+          message: response.data?.message || 'Failed to list Google Drive files via Python API.' ,
+          details: response.data?.details
+        }
+      };
+    }
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'listGoogleDriveFiles');
+  }
+}
+
+export async function triggerGoogleDriveFileIngestion(
+  userId: string,
+  accessToken: string, // User's GDrive access token
+  gdriveFileId: string,
+  originalFileMetadata: { // Pass essential metadata for processing and context
+    name: string;
+    mimeType: string;
+    webViewLink?: string; // Used as source_uri
+  }
+): Promise<SkillResponse<{ doc_id: string; num_chunks_stored: number } | null >> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+     return { ok: false, error: { code: 'CONFIG_ERROR', message: 'PYTHON_API_SERVICE_BASE_URL not configured.' }};
+  }
+  if (!userId) return { ok: false, error: {code: 'VALIDATION_ERROR', message: 'userId is required.'}};
+  if (!accessToken) return { ok: false, error: {code: 'AUTH_ERROR', message: 'Google Drive access token is required.'}};
+  if (!gdriveFileId) return { ok: false, error: {code: 'VALIDATION_ERROR', message: 'gdriveFileId is required.'}};
+  if (!originalFileMetadata || !originalFileMetadata.name || !originalFileMetadata.mimeType) {
+    return { ok: false, error: {code: 'VALIDATION_ERROR', message: 'originalFileMetadata (with name and mimeType) is required.'}};
+  }
+
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/ingest-gdrive-document`;
+  const payload = {
+    user_id: userId,
+    access_token: accessToken,
+    gdrive_file_id: gdriveFileId,
+    original_file_metadata: originalFileMetadata,
+    // openai_api_key: USER_SPECIFIC_KEY_IF_ANY // Optional: pass if embeddings should use a specific key
+  };
+
+  logger.info(`[triggerGoogleDriveFileIngestion] Triggering ingestion for GDrive file ID ${gdriveFileId} for user ${userId}`);
+
+  try {
+    // Python endpoint returns: {"ok": True/False, "data": ... or "error": ...}
+    const response = await axios.post(endpoint, payload, { timeout: GDRIVE_API_TIMEOUT * 2 }); // Longer for download + initial processing call
+
+    if (response.data && response.data.ok && response.data.data) {
+      logger.info(`[triggerGoogleDriveFileIngestion] Successfully triggered ingestion for GDrive file ${gdriveFileId}. Doc ID: ${response.data.data.doc_id}`);
+      return { ok: true, data: response.data.data };
+    } else {
+      logger.warn(`[triggerGoogleDriveFileIngestion] Failed. Python API ok: ${response.data?.ok}`, response.data?.error);
+      return {
+        ok: false,
+        error: response.data?.error || {
+          code: 'GDRIVE_INGEST_TRIGGER_FAILED',
+          message: 'Failed to trigger GDrive file ingestion via Python API.'
+        }
+      };
+    }
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'triggerGoogleDriveFileIngestion');
+  }
+}
+```


### PR DESCRIPTION
Implements capability to list files from Google Drive and ingest selected documents (PDFs, GDocs as PDFs) into LanceDB.

Python Backend:
- Created `gdrive_service.py`:
  - `list_gdrive_files`: Lists GDrive files/folders with query & pagination.
  - `download_gdrive_file`: Downloads native files or exports GWorkspace files (e.g., GDocs to PDF, GSheets to XLSX, GSlides to PDF).
- Created `gdrive_handler.py` with Flask Blueprint `gdrive_bp`:
  - `POST /api/gdrive/list-files`: Endpoint for listing GDrive files.
  - `POST /api/ingest-gdrive-document`: Endpoint that:
    - Downloads/exports a specified GDrive file using `gdrive_service`.
    - Saves it temporarily.
    - Calls `document_processor.process_pdf_and_store` to process the (potentially converted) PDF into LanceDB.
    - Handles temporary file cleanup.

TypeScript Skills:
- Created `gdriveSkills.ts`:
  - `GoogleDriveFile` interface for GDrive file metadata.
  - `listGoogleDriveFiles`: Calls the `/api/gdrive/list-files` endpoint.
  - `triggerGoogleDriveFileIngestion`: Calls `/api/ingest-gdrive-document` to initiate processing of a GDrive file.

OAuth & Documentation (Conceptual):
- Designed OAuth 2.0 flow for Google Drive, including scopes, GCP setup, token storage, and new environment variable requirements.
- Outlined conceptual tests for all new Python and TypeScript components.
- Detailed documentation needs for the new integration.