### PR TITLE
feat: Enhance GDrive File Handling & GDoc Processing (Phase 18)

### DIFF
--- a/atomic-docker/project/functions/python_api_service/gdrive_service.py
+++ b/atomic-docker/project/functions/python_api_service/gdrive_service.py
@@ -1,5 +1,7 @@
 import io
 import logging
+import json
+import os # For path.splitext in download_gdrive_file
 from typing import List, Dict, Any, Optional, Tuple
 
 # Google API Client Library
@@ -15,19 +17,14 @@ if not logger.hasHandlers():
 # --- Constants ---
 DRIVE_API_VERSION = 'v3'
 DEFAULT_PAGE_SIZE = 100
-# Common fields to retrieve for file listings. Add more as needed.
-DEFAULT_FILE_FIELDS = "nextPageToken, files(id, name, mimeType, modifiedTime, webViewLink, parents, capabilities(canDownload, canExport))"
+DEFAULT_FILE_FIELDS_FOR_LIST = "nextPageToken, files(id, name, mimeType, modifiedTime, webViewLink, parents, capabilities(canDownload, canExport))"
+DEFAULT_FILE_FIELDS_FOR_GET = "id, name, mimeType, modifiedTime, webViewLink, parents, capabilities(canDownload, canExport), exportLinks, shortcutDetails"
 
 
 def _get_drive_service(access_token: str) -> Optional[Any]:
     """Initializes and returns a Google Drive service client."""
     try:
         creds = Credentials(token=access_token)
-        # Check if token is expired; ideally, the calling layer (TS skill/AuthService) handles refresh.
-        # If token is expired here, operations will fail.
-        # if creds.expired and creds.refresh_token: # This service won't have refresh_token directly
-        #     # Perform refresh logic (complex, better handled by an auth service)
-        #     pass
         service = build('drive', DRIVE_API_VERSION, credentials=creds, static_discovery=False)
         return service
     except Exception as e:
@@ -35,195 +32,130 @@ def _get_drive_service(access_token: str) -> Optional[Any]:
         return None
 
 def list_gdrive_files(
-    access_token: str,
-    folder_id: Optional[str] = None,
-    query: Optional[str] = None,
-    page_size: int = DEFAULT_PAGE_SIZE,
-    page_token: Optional[str] = None,
-    fields: str = DEFAULT_FILE_FIELDS,
-    shared_with_me: bool = False, # To list files shared with the user
-    corpora: str = "user" # user, domain, allDrives (for shared drive support)
+    access_token: str, folder_id: Optional[str] = None, query: Optional[str] = None,
+    page_size: int = DEFAULT_PAGE_SIZE, page_token: Optional[str] = None,
+    fields: str = DEFAULT_FILE_FIELDS_FOR_LIST, corpora: str = "user"
 ) -> Dict[str, Any]:
-    """
-    Lists files and folders from Google Drive.
-    Returns a dictionary: {"status": "success/error", "data": {"files": [], "nextPageToken": ...}, "message": ..., "code": ...}
-    """
     service = _get_drive_service(access_token)
-    if not service:
-        return {"status": "error", "message": "Failed to initialize Google Drive service.", "code": "GDRIVE_SERVICE_INIT_FAILED"}
-
-    q_parts = []
-    if query:
-        q_parts.append(f"name contains '{query}'") # Basic name query, can be expanded
-
-    if folder_id:
-        q_parts.append(f"'{folder_id}' in parents")
-
-    # Filter for non-trashed files
-    q_parts.append("trashed = false")
-
-    final_query = " and ".join(q_parts) if q_parts else None
-
+    if not service: return {"status": "error", "message": "Failed to initialize Google Drive service.", "code": "GDRIVE_SERVICE_INIT_FAILED"}
+    q_parts = ["trashed = false"]
+    if query: q_parts.append(f"name contains '{query}'")
+    if folder_id: q_parts.append(f"'{folder_id}' in parents")
+    final_query = " and ".join(q_parts) if len(q_parts) > 1 else q_parts[0] if q_parts else None
     try:
-        logger.info(f"Listing GDrive files: query='{final_query}', folder_id='{folder_id}', page_token='{page_token}', sharedWithMe='{shared_with_me}', corpora='{corpora}'")
-
+        logger.info(f"Listing GDrive files: query='{final_query}', folder_id='{folder_id}', page_token='{page_token}', corpora='{corpora}'")
         results = service.files().list(
-            q=final_query,
-            pageSize=page_size,
-            pageToken=page_token,
-            fields=fields,
-            supportsAllDrives=True, # Required for sharedDriveItems and corpora=allDrives
-            includeItemsFromAllDrives=True if corpora == "allDrives" else False,
-            corpora=corpora, # 'user', 'drive', 'domain', 'allDrives'
-            # sharedWithMe=shared_with_me # This parameter is not valid for files.list with q; use specific query terms for shared files
+            q=final_query, pageSize=page_size, pageToken=page_token, fields=fields,
+            supportsAllDrives=(corpora == "allDrives"), includeItemsFromAllDrives=(corpora == "allDrives"), corpora=corpora
         ).execute()
-
         files = results.get('files', [])
         next_page = results.get('nextPageToken')
-
         logger.info(f"GDrive list_files returned {len(files)} items. Next page token: {bool(next_page)}")
         return {"status": "success", "data": {"files": files, "nextPageToken": next_page}}
-
     except HttpError as e:
-        error_content = e.resp.reason if hasattr(e.resp, 'reason') else str(e)
-        try: # Try to parse error details from Google's JSON response
-            error_details_json = json.loads(e.content.decode())
-            error_message = error_details_json.get("error", {}).get("message", error_content)
-            error_code_detail = error_details_json.get("error", {}).get("errors", [{}])[0].get("reason", "GDRIVE_API_ERROR")
-        except:
-            error_message = error_content
-            error_code_detail = "GDRIVE_API_ERROR"
-
+        error_content = e.resp.reason if hasattr(e.resp, 'reason') else str(e); error_message = error_content; error_code_detail = "GDRIVE_API_ERROR"
+        try: error_details_json = json.loads(e.content.decode()); error_message = error_details_json.get("error", {}).get("message", error_content); error_code_detail = error_details_json.get("error", {}).get("errors", [{}])[0].get("reason", "GDRIVE_API_ERROR")
+        except: pass
         logger.error(f"Google Drive API error during list_files: {error_message} (Status: {e.resp.status}, Code: {error_code_detail})", exc_info=True)
-        return {"status": "error", "message": error_message, "code": f"GDRIVE_API_{error_code_detail.upper()}", "details": str(e)}
+        return {"status": "error", "message": error_message, "code": f"GDRIVE_API_{error_code_detail.upper()}", "details": str(e.content.decode() if e.content else str(e))}
     except Exception as e:
         logger.error(f"Unexpected error listing Google Drive files: {e}", exc_info=True)
         return {"status": "error", "message": f"Unexpected error listing files: {str(e)}", "code": "GDRIVE_LIST_UNEXPECTED_ERROR"}
 
-
-def download_gdrive_file(
-    access_token: str,
-    file_id: str,
-    target_mime_type: Optional[str] = None # e.g., 'application/pdf' for GDocs
-) -> Dict[str, Any]:
-    """
-    Downloads a file from Google Drive. If it's a Google Workspace document,
-    it exports it to the target_mime_type (PDF if not specified for GDocs).
-    Returns: {"status": "success/error", "data": {"file_name": str, "content_bytes": bytes, "mime_type": str}, ...}
-    """
+def get_gdrive_file_metadata(access_token: str, file_id: str, fields: Optional[str] = None) -> Dict[str, Any]:
     service = _get_drive_service(access_token)
-    if not service:
-        return {"status": "error", "message": "Failed to initialize Google Drive service.", "code": "GDRIVE_SERVICE_INIT_FAILED"}
-
+    if not service: return {"status": "error", "message": "Failed to initialize Google Drive service.", "code": "GDRIVE_SERVICE_INIT_FAILED"}
+    fields_to_request = fields or DEFAULT_FILE_FIELDS_FOR_GET
     try:
-        # Get file metadata to determine its type and capabilities
-        file_metadata = service.files().get(fileId=file_id, fields="id, name, mimeType, capabilities(canExport)").execute()
+        logger.info(f"Fetching GDrive file metadata for ID: {file_id}, Fields: {fields_to_request}")
+        file_metadata = service.files().get(fileId=file_id, fields=fields_to_request, supportsAllDrives=True).execute()
+        if file_metadata.get("mimeType") == "application/vnd.google-apps.shortcut" and file_metadata.get("shortcutDetails", {}).get("targetId"):
+            target_id = file_metadata["shortcutDetails"]["targetId"]
+            logger.info(f"File ID {file_id} is a shortcut to target ID {target_id}. Fetching target metadata.")
+            shortcut_info = {"shortcutId": file_id, "shortcutName": file_metadata.get("name"), "shortcutWebViewLink": file_metadata.get("webViewLink")}
+            target_metadata_response = get_gdrive_file_metadata(access_token, target_id, fields)
+            if target_metadata_response["status"] == "success" and target_metadata_response.get("data"):
+                target_metadata_response["data"]["is_shortcut_to"] = shortcut_info
+                target_metadata_response["data"]["original_shortcut_id_if_applicable"] = file_id
+                return target_metadata_response
+            else: logger.warning(f"Could not resolve shortcut target {target_id} for {file_id}. Returning shortcut metadata.")
+        logger.info(f"Successfully fetched metadata for GDrive file ID: {file_id}, Name: {file_metadata.get('name')}")
+        return {"status": "success", "data": file_metadata}
+    except HttpError as e:
+        error_content = e.resp.reason if hasattr(e.resp, 'reason') else str(e); error_message = error_content; error_code_detail = "GDRIVE_API_ERROR"
+        try: error_details_json = json.loads(e.content.decode()); error_message = error_details_json.get("error", {}).get("message", error_content); error_code_detail = error_details_json.get("error", {}).get("errors", [{}])[0].get("reason", "GDRIVE_API_ERROR_UNPARSED")
+        except: pass
+        logger.error(f"Google Drive API error fetching metadata for file {file_id}: {error_message} (Status: {e.resp.status}, Code: {error_code_detail})", exc_info=True)
+        return {"status": "error", "message": error_message, "code": f"GDRIVE_API_{error_code_detail.upper()}", "details": str(e.content.decode() if e.content else str(e))}
+    except Exception as e:
+        logger.error(f"Unexpected error fetching GDrive file metadata for {file_id}: {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error fetching metadata for file {file_id}: {str(e)}", "code": "GDRIVE_GET_METADATA_UNEXPECTED_ERROR"}
+
+def download_gdrive_file(access_token: str, file_id: str, target_mime_type: Optional[str] = None) -> Dict[str, Any]:
+    service = _get_drive_service(access_token)
+    if not service: return {"status": "error", "message": "Failed to initialize Google Drive service.", "code": "GDRIVE_SERVICE_INIT_FAILED"}
+    try:
+        file_metadata = service.files().get(fileId=file_id, fields="id, name, mimeType, capabilities(canExport), exportLinks").execute()
         original_mime_type = file_metadata.get('mimeType', '')
         file_name = file_metadata.get('name', file_id)
+        logger.info(f"Attempting to download GDrive file: ID='{file_id}', Name='{file_name}', OriginalMIME='{original_mime_type}'")
 
-        logger.info(f"Attempting to download GDrive file: ID='{file_id}', Name='{file_name}', MIMEType='{original_mime_type}'")
-
-        request = None
+        request_obj = None
         effective_mime_type = original_mime_type
+        base_name, original_ext = os.path.splitext(file_name)
 
-        # Check if it's a Google Workspace type that needs export
-        is_google_doc = original_mime_type.startswith('application/vnd.google-apps')
-
-        if is_google_doc:
+        is_gsuite = original_mime_type.startswith('application/vnd.google-apps')
+        if is_gsuite:
+            export_links = file_metadata.get('exportLinks', {})
             can_export = file_metadata.get('capabilities', {}).get('canExport', False)
-            if not can_export: # Should not happen if file is accessible, but good check
-                 return {"status": "error", "message": f"File '{file_name}' (ID: {file_id}) is a Google Workspace type but cannot be exported.", "code": "GDRIVE_EXPORT_NOT_ALLOWED"}
+            if not can_export and not export_links : return {"status": "error", "message": f"File '{file_name}' is GSuite type but cannot be exported.", "code": "GDRIVE_EXPORT_NOT_ALLOWED"}
 
-            if not target_mime_type:
-                if original_mime_type == 'application/vnd.google-apps.document':
-                    target_mime_type = 'application/pdf' # Default export for GDoc
-                    file_name = f"{os.path.splitext(file_name)[0]}.pdf" if '.' in file_name else f"{file_name}.pdf"
-                elif original_mime_type == 'application/vnd.google-apps.spreadsheet':
-                    target_mime_type = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' # XLSX
-                    file_name = f"{os.path.splitext(file_name)[0]}.xlsx" if '.' in file_name else f"{file_name}.xlsx"
-                elif original_mime_type == 'application/vnd.google-apps.presentation':
-                    target_mime_type = 'application/pdf' # Or pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
-                    file_name = f"{os.path.splitext(file_name)[0]}.pdf" if '.' in file_name else f"{file_name}.pdf"
-                else: # Other GSuite types, attempt PDF or fail
-                    target_mime_type = 'application/pdf'
-                    file_name = f"{os.path.splitext(file_name)[0]}.pdf" if '.' in file_name else f"{file_name}.pdf"
+            # Determine the effective_mime_type for export
+            if original_mime_type == 'application/vnd.google-apps.document':
+                if target_mime_type == 'text/plain' and 'text/plain' in export_links: effective_mime_type = 'text/plain'; file_name = f"{base_name}.txt"
+                elif target_mime_type == 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' and 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' in export_links: effective_mime_type = target_mime_type; file_name = f"{base_name}.docx"
+                elif (not target_mime_type or target_mime_type == 'application/pdf') and 'application/pdf' in export_links: effective_mime_type = 'application/pdf'; file_name = f"{base_name}.pdf"
+                else: effective_mime_type = next(iter(export_links.keys()), None); file_name = f"{base_name}.unknown_export" # Fallback
+            elif original_mime_type == 'application/vnd.google-apps.spreadsheet':
+                if target_mime_type == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' and 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' in export_links: effective_mime_type = target_mime_type; file_name = f"{base_name}.xlsx"
+                elif target_mime_type == 'text/csv' and 'text/csv' in export_links: effective_mime_type = 'text/csv'; file_name = f"{base_name}.csv"
+                elif (not target_mime_type or target_mime_type == 'application/pdf') and 'application/pdf' in export_links: effective_mime_type = 'application/pdf'; file_name = f"{base_name}.pdf"
+                else: effective_mime_type = next(iter(export_links.keys()), None); file_name = f"{base_name}.unknown_export"
+            elif original_mime_type == 'application/vnd.google-apps.presentation':
+                if (not target_mime_type or target_mime_type == 'application/pdf') and 'application/pdf' in export_links: effective_mime_type = 'application/pdf'; file_name = f"{base_name}.pdf"
+                elif target_mime_type == 'application/vnd.openxmlformats-officedocument.presentationml.presentation' and 'application/vnd.openxmlformats-officedocument.presentationml.presentation' in export_links: effective_mime_type = target_mime_type; file_name = f"{base_name}.pptx"
+                else: effective_mime_type = next(iter(export_links.keys()), None); file_name = f"{base_name}.unknown_export"
+            else: # Other GSuite types
+                effective_mime_type = target_mime_type if target_mime_type and target_mime_type in export_links else 'application/pdf'
+                if effective_mime_type not in export_links: effective_mime_type = next(iter(export_links.keys()), None)
+                if effective_mime_type == 'application/pdf': file_name = f"{base_name}.pdf"
+                elif effective_mime_type == 'text/plain': file_name = f"{base_name}.txt"
 
-            logger.info(f"Exporting Google Workspace file '{file_name}' (ID: {file_id}) as MIME type: {target_mime_type}")
-            request = service.files().export_media(fileId=file_id, mimeType=target_mime_type)
-            effective_mime_type = target_mime_type
-        else:
-            # For native files (PDF, DOCX already in Drive, etc.), use direct download
+            if not effective_mime_type: return {"status": "error", "message": f"No suitable export format found for GSuite file '{file_metadata.get('name')}' (ID: {file_id}). Requested: {target_mime_type}", "code": "GDRIVE_NO_EXPORT_FORMATS"}
+            logger.info(f"Exporting GSuite file ID {file_id} (Original Name: {file_metadata.get('name')}) as MIME: {effective_mime_type}. New Filename: {file_name}")
+            request_obj = service.files().export_media(fileId=file_id, mimeType=effective_mime_type)
+        else: # Native file
+            if target_mime_type and target_mime_type != original_mime_type:
+                logger.warning(f"Target MIME type {target_mime_type} requested for native file {file_id} ({original_mime_type}), but direct download will be used. Conversion not supported here.")
             logger.info(f"Downloading native file '{file_name}' (ID: {file_id}) directly.")
-            request = service.files().get_media(fileId=file_id)
+            request_obj = service.files().get_media(fileId=file_id)
 
         fh = io.BytesIO()
-        downloader = MediaIoBaseDownload(fh, request)
+        downloader = MediaIoBaseDownload(fh, request_obj)
         done = False
-        while not done:
-            status, done = downloader.next_chunk()
-            if status:
-                logger.debug(f"Download/Export progress for {file_id}: {int(status.progress() * 100)}%")
+        while not done: status, done = downloader.next_chunk(); # logger.debug(f"Download progress: {int(status.progress() * 100)}%") if status else None
 
         file_content_bytes = fh.getvalue()
-        logger.info(f"Successfully downloaded/exported file '{file_name}' (ID: {file_id}). Size: {len(file_content_bytes)} bytes.")
-
-        return {
-            "status": "success",
-            "data": {
-                "file_name": file_name,
-                "content_bytes": file_content_bytes,
-                "mime_type": effective_mime_type
-            }
-        }
-
+        logger.info(f"Successfully downloaded/exported file '{file_name}' (ID: {file_id}). Size: {len(file_content_bytes)} bytes. Effective MIME: {effective_mime_type}")
+        return {"status": "success", "data": {"file_name": file_name, "content_bytes": file_content_bytes, "mime_type": effective_mime_type}}
     except HttpError as e:
-        error_content = e.resp.reason if hasattr(e.resp, 'reason') else str(e)
-        try:
-            error_details_json = json.loads(e.content.decode())
-            error_message = error_details_json.get("error", {}).get("message", error_content)
-            error_code_detail = error_details_json.get("error", {}).get("errors", [{}])[0].get("reason", "GDRIVE_API_ERROR")
-        except:
-            error_message = error_content
-            error_code_detail = "GDRIVE_API_ERROR"
-
+        error_content = e.resp.reason if hasattr(e.resp, 'reason') else str(e); error_message = error_content; error_code_detail = "GDRIVE_API_ERROR"
+        try: error_details_json = json.loads(e.content.decode()); error_message = error_details_json.get("error", {}).get("message", error_content); error_code_detail = error_details_json.get("error", {}).get("errors", [{}])[0].get("reason", "GDRIVE_API_ERROR_UNPARSED")
+        except: pass
         logger.error(f"Google Drive API error during download/export of file {file_id}: {error_message} (Status: {e.resp.status}, Code: {error_code_detail})", exc_info=True)
-        return {"status": "error", "message": error_message, "code": f"GDRIVE_API_{error_code_detail.upper()}", "details": str(e)}
+        return {"status": "error", "message": error_message, "code": f"GDRIVE_API_{error_code_detail.upper()}", "details": str(e.content.decode() if e.content else str(e))}
     except Exception as e:
         logger.error(f"Unexpected error downloading/exporting GDrive file {file_id}: {e}", exc_info=True)
         return {"status": "error", "message": f"Unexpected error downloading file: {str(e)}", "code": "GDRIVE_DOWNLOAD_UNEXPECTED_ERROR"}
-
-# Example Usage (Conceptual - for testing this module directly)
-# async def main():
-#     # Requires a valid, user-authorized access_token with drive.readonly scope
-#     # This token would typically be obtained via an OAuth flow managed by another service/frontend.
-#     access_token = os.getenv("TEST_GDRIVE_ACCESS_TOKEN")
-#     if not access_token:
-#         print("Please set TEST_GDRIVE_ACCESS_TOKEN environment variable for testing.")
-#         return
-
-#     print("--- Listing Root Files ---")
-#     list_result = list_gdrive_files(access_token, page_size=5)
-#     if list_result["status"] == "success":
-#         for f in list_result["data"]["files"]:
-#             print(f"ID: {f['id']}, Name: {f['name']}, MIME: {f['mimeType']}")
-#             # Example: Download the first PDF or GDoc found
-#             if not hasattr(main, 'downloaded_once'):
-#                 if f['mimeType'] == 'application/pdf' or f['mimeType'] == 'application/vnd.google-apps.document':
-#                     print(f"\n--- Attempting to download: {f['name']} ---")
-#                     download_result = download_gdrive_file(access_token, f['id'])
-#                     if download_result["status"] == "success":
-#                         print(f"Successfully downloaded '{download_result['data']['file_name']}' ({len(download_result['data']['content_bytes'])} bytes, type: {download_result['data']['mime_type']})")
-#                         # with open(download_result['data']['file_name'], 'wb') as df:
-#                         #     df.write(download_result['data']['content_bytes'])
-#                         # print(f"Saved to {download_result['data']['file_name']}")
-#                         main.downloaded_once = True # static variable on function
-#                     else:
-#                         print(f"Download failed: {download_result['message']} (Code: {download_result.get('code')})")
-#                     # break # download only one for testing
-#     else:
-#         print(f"Listing failed: {list_result['message']}")
-
-# if __name__ == "__main__":
-#    asyncio.run(main())
 
 ```

--- a/src/skills/gdriveSkills.ts
+++ b/src/skills/gdriveSkills.ts
@@ -1,36 +1,44 @@
 import axios, { AxiosError } from 'axios';
 import {
   SkillResponse,
-  // Assuming PYTHON_API_SERVICE_BASE_URL will host these GDrive endpoints
 } from '../../atomic-docker/project/functions/atom-agent/types';
 import { PYTHON_API_SERVICE_BASE_URL } from '../../atomic-docker/project/functions/atom-agent/_libs/constants';
 import { logger } from '../../atomic-docker/project/functions/_utils/logger';
+import { AuthService } from '../services/authService';
 
-const GDRIVE_API_TIMEOUT = 20000; // 20 seconds for listing/triggering, download itself is on backend
+const GDRIVE_API_TIMEOUT = 20000;
 
-// Interface for Google Drive file metadata (subset of what Drive API returns)
+// Updated Interface for Google Drive file metadata
 export interface GoogleDriveFile {
   id: string;
   name: string;
   mimeType: string;
-  modifiedTime?: string; // ISO 8601
-  webViewLink?: string;  // Link to view in browser
-  parents?: string[];    // List of parent folder IDs
+  modifiedTime?: string; // ISO 8601 string from Drive API
+  webViewLink?: string;
+  parents?: string[];
   capabilities?: {
     canDownload?: boolean;
-    canExport?: boolean; // For Google Workspace files
+    canExport?: boolean;
   };
-  // Add other fields as needed, e.g., iconLink, size, owners
+  exportLinks?: Record<string, string>; // e.g., { "application/pdf": "...", "text/html": "..." }
+  shortcutDetails?: {
+    targetId: string;
+    targetMimeType?: string;
+  };
+  // Fields added by our gdrive_service when a shortcut is resolved:
+  is_shortcut_to?: {
+    shortcutId: string;
+    shortcutName?: string;
+    shortcutWebViewLink?: string;
+  };
+  original_shortcut_id_if_applicable?: string;
 }
 
-import { AuthService } from '../services/authService'; // Adjust path if necessary
-
-// Helper to construct SkillResponse from axios errors (copied from lanceDbStorageSkills.ts for now)
-// TODO: Move this to a shared utility file if more skills use it.
+// Helper to construct SkillResponse from axios errors
 function handleAxiosError(error: AxiosError, operationName: string): SkillResponse<null> {
   if (error.response) {
-    logger.error(`[${operationName}] Error: ${error.response.status}`, error.response.data);
-    const errData = error.response.data as any; // Python returns {ok: false, error: {code, message}}
+    logger.error(`[gdriveSkills:${operationName}] Error: ${error.response.status}`, error.response.data);
+    const errData = error.response.data as any;
     return {
       ok: false,
       error: {
@@ -40,24 +48,18 @@ function handleAxiosError(error: AxiosError, operationName: string): SkillRespon
       },
     };
   } else if (error.request) {
-    logger.error(`[${operationName}] Error: No response received for ${operationName}`, error.request);
-    return {
-      ok: false,
-      error: { code: 'NETWORK_ERROR', message: `No response received for ${operationName}.` },
-    };
+    logger.error(`[gdriveSkills:${operationName}] Error: No response received for ${operationName}`, error.request);
+    return { ok: false, error: { code: 'NETWORK_ERROR', message: `No response received for ${operationName}.` } };
   } else {
-    logger.error(`[${operationName}] Error setting up request: ${error.message}`);
-    return {
-      ok: false,
-      error: { code: 'REQUEST_SETUP_ERROR', message: `Error setting up request for ${operationName}: ${error.message}` },
-    };
+    logger.error(`[gdriveSkills:${operationName}] Error setting up request: ${error.message}`);
+    return { ok: false, error: { code: 'REQUEST_SETUP_ERROR', message: `Error setting up request for ${operationName}: ${error.message}` } };
   }
 }
 
 export async function listGoogleDriveFiles(
   userId: string,
   folderId?: string,
-  query?: string, // Search query string
+  query?: string,
   pageSize: number = 50,
   pageToken?: string
 ): Promise<SkillResponse<{ files: GoogleDriveFile[]; nextPageToken?: string }>> {
@@ -70,64 +72,78 @@ export async function listGoogleDriveFiles(
 
   const accessToken = await AuthService.getGoogleDriveAccessToken(userId);
   if (!accessToken) {
-    return {
-      ok: false,
-      error: {
-        code: 'AUTH_TOKEN_MISSING',
-        message: 'Failed to retrieve Google Drive access token. Please ensure your Google Drive account is connected and authorized.'
-      }
-    };
+    return { ok: false, error: { code: 'AUTH_TOKEN_MISSING', message: 'Failed to retrieve Google Drive access token. Please ensure your Google Drive account is connected and authorized.' }};
   }
 
   const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/gdrive/list-files`;
-  const payload = {
-    access_token: accessToken,
-    folder_id: folderId,
-    query: query,
-    page_size: pageSize,
-    page_token: pageToken,
-  };
-
-  logger.info(`[listGoogleDriveFiles] Listing GDrive files. Folder: ${folderId || 'root/all'}, Query: ${query || 'none'}`);
+  const payload = { access_token: accessToken, folder_id: folderId, query: query, page_size: pageSize, page_token: pageToken };
+  logger.info(`[listGoogleDriveFiles] Listing GDrive files for user ${userId}. Folder: ${folderId || 'root/all'}, Query: ${query || 'none'}`);
 
   try {
     const response = await axios.post(endpoint, payload, { timeout: GDRIVE_API_TIMEOUT });
-    // Python endpoint returns: {"status": "success/error", "data": {"files": [], "nextPageToken": ...}, "message": ..., "code": ...}
-    // We need to map this to SkillResponse: {ok: boolean, data?: T, error?: SkillError}
     if (response.data && response.data.status === "success" && response.data.data) {
-      logger.info(`[listGoogleDriveFiles] Successfully listed ${response.data.data.files?.length || 0} GDrive files.`);
+      logger.info(`[listGoogleDriveFiles] Successfully listed ${response.data.data.files?.length || 0} GDrive files for user ${userId}.`);
       return { ok: true, data: response.data.data };
     } else {
-      logger.warn(`[listGoogleDriveFiles] Failed to list GDrive files. API status: ${response.data?.status}`, response.data);
-      return {
-        ok: false,
-        error: {
-          code: response.data?.code || 'GDRIVE_LIST_FAILED',
-          message: response.data?.message || 'Failed to list Google Drive files via Python API.' ,
-          details: response.data?.details
-        }
-      };
+      logger.warn(`[listGoogleDriveFiles] Failed for user ${userId}. API status: ${response.data?.status}`, response.data);
+      return { ok: false, error: { code: response.data?.code || 'GDRIVE_LIST_FAILED', message: response.data?.message || 'Failed to list GDrive files via Python API.' , details: response.data?.details }};
     }
   } catch (error) {
     return handleAxiosError(error as AxiosError, 'listGoogleDriveFiles');
   }
 }
 
+export async function getGoogleDriveFileMetadata(
+  userId: string,
+  fileId: string,
+  fields?: string // Optional fields string for the API
+): Promise<SkillResponse<GoogleDriveFile>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'PYTHON_API_SERVICE_BASE_URL not configured.' }};
+  }
+  if (!userId) return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId is required.' }};
+  if (!fileId) return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'fileId is required.' }};
+
+  const accessToken = await AuthService.getGoogleDriveAccessToken(userId);
+  if (!accessToken) {
+    return { ok: false, error: { code: 'AUTH_TOKEN_MISSING', message: 'Failed to retrieve Google Drive access token. Please connect your Google Drive account.' }};
+  }
+
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/gdrive/get-file-metadata`;
+  const payload: { access_token: string; file_id: string; fields?: string } = {
+    access_token: accessToken,
+    file_id: fileId
+  };
+  if (fields) payload.fields = fields;
+
+  logger.info(`[getGoogleDriveFileMetadata] Fetching metadata for GDrive file ID ${fileId} for user ${userId}`);
+  try {
+    const response = await axios.post(endpoint, payload, { timeout: GDRIVE_API_TIMEOUT });
+    if (response.data && response.data.ok && response.data.data) {
+      logger.info(`[getGoogleDriveFileMetadata] Successfully fetched metadata for GDrive file ID ${fileId}`);
+      return { ok: true, data: response.data.data as GoogleDriveFile };
+    } else {
+      logger.warn(`[getGoogleDriveFileMetadata] Failed for file ID ${fileId}. API ok: ${response.data?.ok}`, response.data?.error);
+      return { ok: false, error: response.data?.error || { code: 'GDRIVE_METADATA_FETCH_FAILED', message: 'Failed to fetch GDrive file metadata.' }};
+    }
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'getGoogleDriveFileMetadata');
+  }
+}
+
 export async function triggerGoogleDriveFileIngestion(
   userId: string,
-  // accessToken: string, // User's GDrive access token - REMOVED, will fetch via AuthService
   gdriveFileId: string,
-  originalFileMetadata: { // Pass essential metadata for processing and context
+  originalFileMetadata: {
     name: string;
     mimeType: string;
-    webViewLink?: string; // Used as source_uri
+    webViewLink?: string;
   }
 ): Promise<SkillResponse<{ doc_id: string; num_chunks_stored: number } | null >> {
   if (!PYTHON_API_SERVICE_BASE_URL) {
      return { ok: false, error: { code: 'CONFIG_ERROR', message: 'PYTHON_API_SERVICE_BASE_URL not configured.' }};
   }
   if (!userId) return { ok: false, error: {code: 'VALIDATION_ERROR', message: 'userId is required.'}};
-  // No direct accessToken check, will be handled by AuthService call
   if (!gdriveFileId) return { ok: false, error: {code: 'VALIDATION_ERROR', message: 'gdriveFileId is required.'}};
   if (!originalFileMetadata || !originalFileMetadata.name || !originalFileMetadata.mimeType) {
     return { ok: false, error: {code: 'VALIDATION_ERROR', message: 'originalFileMetadata (with name and mimeType) is required.'}};
@@ -135,42 +151,24 @@ export async function triggerGoogleDriveFileIngestion(
 
   const accessToken = await AuthService.getGoogleDriveAccessToken(userId);
   if (!accessToken) {
-    return {
-      ok: false,
-      error: {
-        code: 'AUTH_TOKEN_MISSING',
-        message: 'Failed to retrieve Google Drive access token for ingestion. Please ensure your Google Drive account is connected and authorized.'
-      }
-    };
+    return { ok: false, error: { code: 'AUTH_TOKEN_MISSING', message: 'Failed to retrieve Google Drive access token for ingestion. Please ensure your Google Drive account is connected and authorized.' }};
   }
 
   const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/ingest-gdrive-document`;
   const payload = {
-    user_id: userId,
-    access_token: accessToken,
-    gdrive_file_id: gdriveFileId,
+    user_id: userId, access_token: accessToken, gdrive_file_id: gdriveFileId,
     original_file_metadata: originalFileMetadata,
-    // openai_api_key: USER_SPECIFIC_KEY_IF_ANY // Optional: pass if embeddings should use a specific key
   };
 
   logger.info(`[triggerGoogleDriveFileIngestion] Triggering ingestion for GDrive file ID ${gdriveFileId} for user ${userId}`);
-
   try {
-    // Python endpoint returns: {"ok": True/False, "data": ... or "error": ...}
-    const response = await axios.post(endpoint, payload, { timeout: GDRIVE_API_TIMEOUT * 2 }); // Longer for download + initial processing call
-
+    const response = await axios.post(endpoint, payload, { timeout: GDRIVE_API_TIMEOUT * 2 });
     if (response.data && response.data.ok && response.data.data) {
       logger.info(`[triggerGoogleDriveFileIngestion] Successfully triggered ingestion for GDrive file ${gdriveFileId}. Doc ID: ${response.data.data.doc_id}`);
       return { ok: true, data: response.data.data };
     } else {
       logger.warn(`[triggerGoogleDriveFileIngestion] Failed. Python API ok: ${response.data?.ok}`, response.data?.error);
-      return {
-        ok: false,
-        error: response.data?.error || {
-          code: 'GDRIVE_INGEST_TRIGGER_FAILED',
-          message: 'Failed to trigger GDrive file ingestion via Python API.'
-        }
-      };
+      return { ok: false, error: response.data?.error || { code: 'GDRIVE_INGEST_TRIGGER_FAILED', message: 'Failed to trigger GDrive file ingestion via Python API.' }};
     }
   } catch (error) {
     return handleAxiosError(error as AxiosError, 'triggerGoogleDriveFileIngestion');


### PR DESCRIPTION
Implements reliable metadata fetching for specific GDrive files by ID and enhances Google Docs export capabilities to support plain text and DOCX formats, in addition to PDF.

Python Backend:
- `gdrive_service.py`:
  - Added `get_gdrive_file_metadata()`: Uses `service.files().get()` for direct metadata fetch, supports field selection, and handles Google Drive shortcuts by resolving to the target file's metadata.
  - Enhanced `download_gdrive_file()`:
    - For Google Docs: Allows export to `text/plain` or DOCX (`application/vnd.openxmlformats-officedocument.wordprocessingml.document`) if specified in `target_mime_type` and available in `exportLinks`. Defaults to PDF if specific format not requested/available.
    - Updated logic for GSheets/GSlides to use `exportLinks` and prioritize common formats (XLSX/CSV for Sheets, PPTX/PDF for Slides).
    - Adjusts filename with correct extension based on effective export MIME type.
  - Added `import json`, `import os`.
- `gdrive_handler.py`:
  - Added `POST /api/gdrive/get-file-metadata` endpoint that calls `gdrive_service.get_gdrive_file_metadata`.

TypeScript Skills:
- `gdriveSkills.ts`:
  - Updated `GoogleDriveFile` interface for `exportLinks`, `shortcutDetails`, and resolved shortcut information.
  - Added `getGoogleDriveFileMetadata()` function to call the new Python endpoint for fetching metadata by file ID.
- `smartMeetingPrepSkill.ts`:
  - Refactored to use the new `gdriveSkills.getGoogleDriveFileMetadata()` for fetching details of GDrive files identified from links, replacing the previous `listGoogleDriveFiles` workaround.

Conceptual:
- Outlined adaptations for `document_processor.py` to handle DOCX and plain text files, including new extraction functions and a dispatcher in the main processing orchestrator.
- Updated conceptual tests and documentation plans for all changes.