### PR TITLE
feat: Add DOCX and TXT processing to document pipeline (Phase 19)

### DIFF
--- a/atomic-docker/python-api/ingestion_pipeline/document_processor.py
+++ b/atomic-docker/python-api/ingestion_pipeline/document_processor.py
@@ -4,183 +4,216 @@ import logging
 from typing import List, Dict, Any, Optional
 from pdfminer.high_level import extract_text_to_fp
 from pdfminer.layout import LAParams
+from datetime import datetime, timezone # For ingested_at timestamp
 
-# Assuming note_utils.py is accessible for embedding.
-# This path might need adjustment based on actual execution environment or by making embedding a service call.
-# For now, direct import if they are part of the same broader Python package/environment.
+# Attempt to import python-docx
 try:
-    # Adjust path if note_utils is not directly importable like this
-    # This assumes that the 'functions' directory is in PYTHONPATH or they are installed as a package
-    from project.functions import note_utils # Example: if 'functions' is a top-level package for the python_api_service
+    import docx # from python-docx
+    PYTHON_DOCX_AVAILABLE = True
 except ImportError:
-    # Fallback if the above isn't right - this is tricky without seeing full PYTHONPATH setup for python-api
-    # This is a common way to handle sibling directory imports if script is run from python-api/ingestion_pipeline
+    logging.getLogger(__name__).warning("python-docx library not found. DOCX processing will not be available.")
+    PYTHON_DOCX_AVAILABLE = False
+    docx = None
+
+# Embedding and LanceDB imports (adjust paths as necessary based on execution context)
+try:
     import sys
     FUNCTIONS_DIR_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'project', 'functions'))
     if FUNCTIONS_DIR_PATH not in sys.path:
         sys.path.append(FUNCTIONS_DIR_PATH)
-    try:
-        import note_utils # Now try importing from the adjusted path
-    except ImportError as e:
-        print(f"Critical Error: Could not import note_utils for embeddings: {e}. Ensure FUNCTIONS_DIR_PATH is correct.", file=sys.stderr)
-        note_utils = None # Will cause errors later if embedding is attempted
+    from note_utils import get_text_embedding_openai
+    EMBEDDING_FUNCTION_AVAILABLE = True
+except ImportError as e:
+    logging.getLogger(__name__).warning(f"Could not import get_text_embedding_openai from note_utils: {e}. Embedding will not be available.")
+    get_text_embedding_openai = None
+    EMBEDDING_FUNCTION_AVAILABLE = False
 
-# Import lancedb_handler for DB operations
 try:
-    from . import lancedb_handler # If lancedb_handler is in the same directory
+    from . import lancedb_handler
 except ImportError:
-    import lancedb_handler # Fallback if run standalone or path issues
+    import lancedb_handler # Fallback for different execution contexts
+    logging.getLogger(__name__).warning("Imported lancedb_handler using fallback.")
+
 
 logger = logging.getLogger(__name__)
 if not logger.hasHandlers():
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-
-def extract_text_from_pdf(pdf_file_path: str) -> str:
-    """Extracts text content from a PDF file."""
+# --- Text Extraction Utilities ---
+def extract_text_from_pdf(pdf_file_path_or_bytes: Any) -> str:
     try:
         output_string = io.StringIO()
-        with open(pdf_file_path, 'rb') as fin:
-            laparams = LAParams() # Use default LAParams
-            extract_text_to_fp(fin, output_string, laparams=laparams, output_type='text', codec='utf-8')
+        laparams = LAParams()
+        if isinstance(pdf_file_path_or_bytes, str):
+            if not os.path.exists(pdf_file_path_or_bytes):
+                raise FileNotFoundError(f"PDF file not found at path: {pdf_file_path_or_bytes}")
+            with open(pdf_file_path_or_bytes, 'rb') as fin:
+                extract_text_to_fp(fin, output_string, laparams=laparams, output_type='text', codec='utf-8')
+        elif isinstance(pdf_file_path_or_bytes, bytes):
+             with io.BytesIO(pdf_file_path_or_bytes) as fin:
+                extract_text_to_fp(fin, output_string, laparams=laparams, output_type='text', codec='utf-8')
+        else:
+            raise ValueError("Input for PDF extraction must be a file path (str) or bytes.")
         return output_string.getvalue()
     except Exception as e:
-        logger.error(f"Error extracting text from PDF {pdf_file_path}: {e}", exc_info=True)
-        raise  # Re-raise to be handled by caller
+        logger.error(f"Error extracting text from PDF input: {e}", exc_info=True)
+        raise
 
+def extract_text_from_docx(file_path_or_bytes: Any) -> str:
+    if not PYTHON_DOCX_AVAILABLE or not docx:
+        raise ImportError("python-docx library is required for DOCX processing but not found.")
+    try:
+        if isinstance(file_path_or_bytes, str):
+            if not os.path.exists(file_path_or_bytes):
+                raise FileNotFoundError(f"DOCX file not found at path: {file_path_or_bytes}")
+            document = docx.Document(file_path_or_bytes)
+        elif isinstance(file_path_or_bytes, bytes):
+            document = docx.Document(io.BytesIO(file_path_or_bytes))
+        else:
+            raise ValueError("Input for DOCX extraction must be a file path (str) or bytes.")
+        full_text = [para.text for para in document.paragraphs if para.text.strip()]
+        return '\n\n'.join(full_text) # Join paragraphs with double newline for some separation
+    except Exception as e:
+        logger.error(f"Error extracting text from DOCX input: {e}", exc_info=True)
+        raise
 
+def extract_text_from_txt(file_path_or_bytes: Any, encoding: str = 'utf-8') -> str:
+    try:
+        if isinstance(file_path_or_bytes, str):
+            if not os.path.exists(file_path_or_bytes):
+                raise FileNotFoundError(f"TXT file not found at path: {file_path_or_bytes}")
+            with open(file_path_or_bytes, 'r', encoding=encoding) as f:
+                return f.read()
+        elif isinstance(file_path_or_bytes, bytes):
+            return file_path_or_bytes.decode(encoding)
+        else:
+            raise ValueError("Input for TXT extraction must be a file path (str) or bytes.")
+    except UnicodeDecodeError as ude:
+        logger.error(f"Unicode error for TXT (encoding: {encoding}): {ude}", exc_info=True)
+        raise ValueError(f"Encoding error: Could not decode TXT with {encoding}.") from ude
+    except Exception as e:
+        logger.error(f"Error extracting text from TXT input: {e}", exc_info=True)
+        raise
+
+# --- Text Chunking Utility ---
 def chunk_text(text: str, chunk_size: int = 1000, chunk_overlap: int = 100) -> List[str]:
-    """
-    Splits text into overlapping chunks.
-    A simple implementation based on character count. More sophisticated methods exist (e.g., by sentences, tokens).
-    """
-    if not text:
-        return []
-
-    chunks = []
-    start = 0
-    text_len = len(text)
-
+    if not text: return []
+    chunks = []; start = 0; text_len = len(text)
     while start < text_len:
         end = start + chunk_size
         chunks.append(text[start:end])
-        if end >= text_len:
-            break
+        if end >= text_len: break
         start += (chunk_size - chunk_overlap)
-        if start >= text_len: # Ensure we don't create an empty chunk if overlap pushes start to end
-            break
-
+        if start >= text_len: break
     return chunks
 
-
-async def process_pdf_and_store(
+# --- Main Orchestration Function ---
+async def process_document_and_store(
     user_id: str,
-    pdf_file_path: str,
-    document_id: str, # Pre-generated UUID for the document
-    source_uri: str,
+    file_path_or_bytes: Any, # Can be path (str) or content (bytes)
+    document_id: str,
+    source_uri: str, # Original URI of the document
+    original_doc_type: str, # Original type, e.g., "gdoc", "pdf_upload", "gdrive_docx"
+    processing_mime_type: str, # MIME type of file_path_or_bytes (e.g., "application/pdf", "text/plain")
     title: Optional[str] = None,
-    doc_source_type: str = "pdf_upload", # Default source type
-    doc_metadata_json: Optional[str] = None, # Additional metadata for the document table
-    openai_api_key_param: Optional[str] = None # Pass if not relying on global OPENAI_API_KEY_GLOBAL in note_utils
+    doc_metadata_json: Optional[str] = None,
+    openai_api_key_param: Optional[str] = None
 ) -> Dict[str, Any]:
     """
-    Orchestrates PDF processing: text extraction, chunking, embedding, and storage in LanceDB.
+    Orchestrates document processing: text extraction based on MIME type, chunking,
+    embedding, and storage in LanceDB.
     """
-    logger.info(f"Starting processing for PDF: {source_uri}, doc_id: {document_id}, user_id: {user_id}")
+    logger.info(f"Processing document: id={document_id}, user={user_id}, source_uri={source_uri}, original_type='{original_doc_type}', processing_mime='{processing_mime_type}'")
 
-    if not note_utils: # Check if import failed
-        return {"status": "error", "message": "Embedding utility (note_utils) not available.", "code": "INTERNAL_SETUP_ERROR"}
+    if not EMBEDDING_FUNCTION_AVAILABLE or not get_text_embedding_openai:
+        return {"status": "error", "message": "Embedding utility (note_utils/get_text_embedding_openai) not available.", "code": "EMBEDDING_SERVICE_UNAVAILABLE"}
+    if not lancedb_handler:
+         return {"status": "error", "message": "LanceDB handler not available.", "code": "LANCEDB_HANDLER_UNAVAILABLE"}
 
+    extracted_text = ""
     try:
-        extracted_text = extract_text_from_pdf(pdf_file_path)
-        if not extracted_text.strip():
-            logger.warning(f"No text extracted from PDF: {source_uri}")
-            # Store document metadata with status 'processing_failed' or 'empty'
-            # For now, returning error, but could also store an entry indicating empty content.
-            doc_meta_to_store = {
-                "id": document_id, "user_id": user_id, "source_uri": source_uri,
-                "doc_type": doc_source_type, "title": title, "metadata_json": doc_metadata_json,
-                "ingested_at": datetime.now(timezone.utc).isoformat(),
-                "processing_status": "failed_empty_content",
-                "error_message": "No text content extracted from PDF."
-            }
-            db_conn = await lancedb_handler.get_lancedb_connection()
-            if db_conn:
-                await lancedb_handler.create_generic_document_tables_if_not_exist(db_conn) # Ensure tables exist
-                # This function needs to be added to lancedb_handler.py
-                await lancedb_handler.add_document_metadata_only(db_conn, doc_meta_to_store)
-            return {"status": "error", "message": "No text extracted from PDF.", "code": "PDF_PROCESSING_EMPTY"}
-
-        text_chunks = chunk_text(extracted_text) # Uses default chunk_size and overlap
-        logger.info(f"Extracted {len(extracted_text)} chars, split into {len(text_chunks)} chunks for doc_id: {document_id}")
-
-        chunks_with_embeddings_data = []
-        for i, chunk_text_content in enumerate(text_chunks):
-            if not chunk_text_content.strip():
-                logger.info(f"Skipping empty chunk {i} for doc_id: {document_id}")
-                continue
-
-            # Generate embedding for the chunk
-            # note_utils.get_text_embedding_openai needs to be callable, ensure it's correctly imported/configured
-            embedding_resp = note_utils.get_text_embedding_openai(
-                text_to_embed=chunk_text_content,
-                openai_api_key_param=openai_api_key_param # Pass key if provided, else note_utils uses global
-            )
-            if embedding_resp["status"] == "success":
-                vector = embedding_resp["data"]
-                chunks_with_embeddings_data.append({
-                    # "id" for chunk can be auto-generated by lancedb_handler or passed (e.g., f"{document_id}_chunk_{i}")
-                    "chunk_sequence": i,
-                    "text_content": chunk_text_content,
-                    "vector": vector,
-                    "metadata_json": None, # Placeholder for now
-                    "char_count": len(chunk_text_content)
-                })
-            else:
-                logger.warning(f"Failed to generate embedding for chunk {i} of doc_id {document_id}: {embedding_resp.get('message')}")
-                # Decide: skip chunk or fail entire document processing? For now, skip chunk.
-
-        if not chunks_with_embeddings_data:
-            logger.warning(f"No chunks were successfully embedded for doc_id: {document_id}")
-            # Similar to empty PDF, could store metadata with error, or return error.
-            # For now, treat as error if no chunks could be stored.
-            return {"status": "error", "message": "No chunks could be embedded for the document.", "code": "EMBEDDING_FAILURE_ALL_CHUNKS"}
-
-        # Prepare document metadata for storage
-        doc_meta_to_store = {
-            "id": document_id, "user_id": user_id, "source_uri": source_uri,
-            "doc_type": doc_source_type, "title": title, "metadata_json": doc_metadata_json,
-            "ingested_at": datetime.now(timezone.utc).isoformat(), # Use timezone aware
-            "processing_status": "completed",
-        }
-
-        # Store in LanceDB
-        db_conn = await lancedb_handler.get_lancedb_connection()
-        if not db_conn:
-            return {"status": "error", "message": "Failed to connect to LanceDB.", "code": "LANCEDB_CONNECTION_ERROR"}
-
-        # These table creation functions will be added to lancedb_handler.py
-        await lancedb_handler.create_generic_document_tables_if_not_exist(db_conn)
-
-        # This function will be added to lancedb_handler.py
-        # It should add to 'documents' table and 'document_chunks' table
-        storage_result = await lancedb_handler.add_processed_document(
-            db_conn=db_conn,
-            doc_meta=doc_meta_to_store,
-            chunks_with_embeddings=chunks_with_embeddings_data # Pass the list of chunk dicts
-        )
-
-        if storage_result["status"] == "success":
-            logger.info(f"Successfully processed and stored PDF: {source_uri}, doc_id: {document_id}")
-            return {"status": "success", "data": {"doc_id": document_id, "num_chunks_stored": len(chunks_with_embeddings_data)}}
+        if processing_mime_type == "application/pdf":
+            extracted_text = extract_text_from_pdf(file_path_or_bytes)
+        elif processing_mime_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document" or \
+             original_doc_type.endswith("docx"): # Broader check for docx
+            extracted_text = extract_text_from_docx(file_path_or_bytes)
+        elif processing_mime_type == "text/plain" or original_doc_type.endswith("txt"):
+            extracted_text = extract_text_from_txt(file_path_or_bytes)
         else:
-            logger.error(f"Failed to store processed document {document_id} in LanceDB: {storage_result.get('message')}")
-            # Update document processing_status to 'failed_storage' if possible
-            return {"status": "error", "message": f"LanceDB storage failed: {storage_result.get('message')}", "code": storage_result.get("code", "LANCEDB_STORAGE_ERROR")}
+            logger.error(f"Unsupported processing_mime_type: {processing_mime_type} for document {document_id}")
+            # Update document metadata in LanceDB to 'failed_unsupported_type'
+            # This requires doc_meta to be created first, then updated.
+            # For now, just return error. A more robust flow would pre-register the doc then update status.
+            return {"status": "error", "message": f"Unsupported document type for processing: {processing_mime_type}", "code": "UNSUPPORTED_PROCESSING_TYPE"}
+    except Exception as extraction_error:
+        logger.error(f"Text extraction failed for document {document_id} (type: {processing_mime_type}): {extraction_error}", exc_info=True)
+        # TODO: Update document status in LanceDB to "failed_extraction"
+        return {"status": "error", "message": f"Text extraction failed: {str(extraction_error)}", "code": "TEXT_EXTRACTION_FAILED"}
 
-    except Exception as e:
-        logger.error(f"Unhandled error in process_pdf_and_store for {source_uri}, doc_id {document_id}: {e}", exc_info=True)
-        # Potentially update document status to 'failed' in DB here if doc_id was already created
-        return {"status": "error", "message": f"Unexpected error processing PDF: {str(e)}", "code": "PYTHON_INTERNAL_ERROR_PDF_PROCESSING"}
+    if not extracted_text.strip():
+        logger.warning(f"No text extracted from document: {source_uri} (ID: {document_id})")
+        doc_meta_to_store = {
+            "doc_id": document_id, "user_id": user_id, "source_uri": source_uri,
+            "doc_type": original_doc_type, "title": title, "metadata_json": doc_metadata_json,
+            "ingested_at": datetime.now(timezone.utc).isoformat(), # Store as ISO string
+            "processing_status": "failed_empty_content", "error_message": "No text content extracted."
+        }
+        db_conn = await lancedb_handler.get_lancedb_connection()
+        if db_conn:
+            await lancedb_handler.create_generic_document_tables_if_not_exist(db_conn)
+            await lancedb_handler.add_processed_document(db_conn, doc_meta_to_store, []) # Store metadata even if no chunks
+        return {"status": "warning", "message": "No text extracted from document, only metadata stored.", "code": "PDF_PROCESSING_EMPTY", "data": {"doc_id": document_id, "num_chunks_stored": 0}}
+
+    text_chunks = chunk_text(extracted_text)
+    logger.info(f"Extracted {len(extracted_text)} chars, split into {len(text_chunks)} chunks for doc_id: {document_id}")
+
+    chunks_with_embeddings_data = []
+    for i, chunk_text_content in enumerate(text_chunks):
+        if not chunk_text_content.strip(): continue
+        embedding_resp = get_text_embedding_openai(text_to_embed=chunk_text_content, openai_api_key_param=openai_api_key_param)
+        if embedding_resp["status"] == "success":
+            chunks_with_embeddings_data.append({
+                "chunk_sequence": i, "text_content": chunk_text_content, "vector": embedding_resp["data"],
+                "metadata_json": None, "char_count": len(chunk_text_content)
+                # doc_id and user_id will be added by lancedb_handler.add_processed_document
+            })
+        else:
+            logger.warning(f"Embedding failed for chunk {i} of doc_id {document_id}: {embedding_resp.get('message')}")
+
+    if not chunks_with_embeddings_data:
+        doc_meta_err_embed = {
+            "doc_id": document_id, "user_id": user_id, "source_uri": source_uri,
+            "doc_type": original_doc_type, "title": title, "metadata_json": doc_metadata_json,
+            "ingested_at": datetime.now(timezone.utc).isoformat(),
+            "processing_status": "failed_embedding", "error_message": "No chunks could be embedded."
+        }
+        db_conn = await lancedb_handler.get_lancedb_connection()
+        if db_conn:
+            await lancedb_handler.create_generic_document_tables_if_not_exist(db_conn)
+            await lancedb_handler.add_processed_document(db_conn, doc_meta_err_embed, [])
+        return {"status": "error", "message": "No chunks could be embedded for the document.", "code": "EMBEDDING_FAILURE_ALL_CHUNKS"}
+
+    doc_meta_to_store = {
+        "doc_id": document_id, "user_id": user_id, "source_uri": source_uri,
+        "doc_type": original_doc_type, "title": title, "metadata_json": doc_metadata_json,
+        "ingested_at": datetime.now(timezone.utc).isoformat(),
+        "processing_status": "completed",
+    }
+
+    db_conn = await lancedb_handler.get_lancedb_connection()
+    if not db_conn:
+        return {"status": "error", "message": "Failed to connect to LanceDB.", "code": "LANCEDB_CONNECTION_ERROR"}
+
+    await lancedb_handler.create_generic_document_tables_if_not_exist(db_conn)
+    storage_result = await lancedb_handler.add_processed_document(
+        db_conn=db_conn, doc_meta=doc_meta_to_store, chunks_with_embeddings=chunks_with_embeddings_data
+    )
+
+    if storage_result["status"] == "success":
+        logger.info(f"Successfully processed and stored document: {source_uri}, doc_id: {document_id}")
+        return {"status": "success", "data": {"doc_id": document_id, "num_chunks_stored": len(chunks_with_embeddings_data)}}
+    else:
+        logger.error(f"Failed to store processed document {document_id} in LanceDB: {storage_result.get('message')}")
+        return {"status": "error", "message": f"LanceDB storage failed: {storage_result.get('message')}", "code": storage_result.get("code", "LANCEDB_STORAGE_ERROR")}
 
 ```


### PR DESCRIPTION
Enhances the Python document ingestion pipeline to support DOCX and plain TXT files, in addition to existing PDF functionality.

- Modified `document_processor.py`:
  - Added `extract_text_from_docx()` using `python-docx` library.
  - Added `extract_text_from_txt()` for plain text files.
  - Refactored `process_pdf_and_store()` into a generic `process_document_and_store()` function. This function now:
    - Accepts `original_doc_type` and `processing_mime_type` to determine how to extract text.
    - Dispatches to `extract_text_from_pdf`, `extract_text_from_docx`, or `extract_text_from_txt` based on `processing_mime_type`.
    - Handles unsupported types gracefully.
    - Stores the `original_doc_type` in LanceDB metadata.
    - Improved error handling for empty content and extraction failures.
  - Added conditional import for `python-docx`.
- Noted `python-docx` as a new dependency for `requirements.txt`.
- Conceptually reviewed calling handlers (`document_handler.py`, `gdrive_handler.py`) for necessary updates to pass correct type information to the new processor.
- Outlined conceptual tests and documentation updates for these multi-format processing capabilities.