### PR TITLE
Feat: Enhance LanceDB semantic search capabilities

### DIFF
--- a/atomic-docker/python-api/ingestion_pipeline/document_processor.py
+++ b/atomic-docker/python-api/ingestion_pipeline/document_processor.py
@@ -173,9 +173,14 @@ async def process_document_and_store(
         embedding_resp = get_text_embedding_openai(text_to_embed=chunk_text_content, openai_api_key_param=openai_api_key_param)
         if embedding_resp["status"] == "success":
             chunks_with_embeddings_data.append({
-                "chunk_sequence": i, "text_content": chunk_text_content, "vector": embedding_resp["data"],
-                "metadata_json": None, "char_count": len(chunk_text_content)
-                # doc_id and user_id will be added by lancedb_handler.add_processed_document
+                "doc_id": document_id, # Ensure doc_id is part of the chunk data
+                "user_id": user_id,   # Ensure user_id is part of the chunk data
+                "parent_doc_type": original_doc_type, # Add parent_doc_type
+                "chunk_sequence": i,
+                "text_content": chunk_text_content,
+                "embedding": embedding_resp["data"], # Ensure key is 'embedding'
+                "metadata_json": None,
+                "char_count": len(chunk_text_content)
             })
         else:
             logger.warning(f"Embedding failed for chunk {i} of doc_id {document_id}: {embedding_resp.get('message')}")

--- a/atomic-docker/python-api/ingestion_pipeline/lancedb_handler.py
+++ b/atomic-docker/python-api/ingestion_pipeline/lancedb_handler.py
@@ -87,6 +87,7 @@ class DocumentChunkModel(LanceModel):
     user_id: str
     chunk_sequence: int
     text_content: str
+    parent_doc_type: Optional[str] = None # Added for filtering by parent document type
     metadata_json: Optional[str] = None
     char_count: Optional[int] = None
 


### PR DESCRIPTION
This commit introduces several improvements to the LanceDB semantic search:

1.  **Improved Date Handling:**
    *   More robust parsing of ISO date strings for `date_after` and `date_before` filters in `lancedb_search_service.py`.
    *   Handles date-only strings by defaulting to full-day coverage (UTC).
    *   Assumes UTC if no timezone offset is provided in the date string.
    *   Explicitly disables direct date filtering on document chunks via `date_after`/`date_before` as it usually relies on parent document dates, logging this behavior.

2.  **Enabled Type-Specific Filters for Document Chunks:**
    *   Added `parent_doc_type: Optional[str]` to `DocumentChunkModel` in `lancedb_handler.py`.
    *   Updated `document_processor.py` to populate this field during ingestion using the parent document's `original_doc_type`.
    *   The existing filter `AND parent_doc_type = ...` in `lancedb_search_service.py` is now functional.

3.  **Enriched Parent Document Information for Chunks:**
    *   `lancedb_search_service.py` now fetches metadata (title, source_uri, doc_type) for parent documents from `DOCUMENTS_TABLE_NAME` when returning document chunk results.
    *   Chunk titles in search results are now more descriptive (e.g., "Chunk X of Parent Title").
    *   `UniversalSearchResultItem` for chunks now includes `parent_document_title`, `document_source_uri`, and `document_doc_type` more reliably.