### PR TITLE
Feat: Add backend APIs and update skills for GDrive UI

### DIFF
--- a/src/skills/gdriveSkills.ts
+++ b/src/skills/gdriveSkills.ts
@@ -4,9 +4,18 @@ import {
 } from '../../atomic-docker/project/functions/atom-agent/types';
 import { PYTHON_API_SERVICE_BASE_URL } from '../../atomic-docker/project/functions/atom-agent/_libs/constants';
 import { logger } from '../../atomic-docker/project/functions/_utils/logger';
-import { AuthService } from '../services/authService';
+import { AuthService } from '../services/authService'; // Retain for potential future use or if other skills need it directly
 
-const GDRIVE_API_TIMEOUT = 20000;
+const GDRIVE_API_TIMEOUT = 20000; // Default for most GDrive ops
+const GDRIVE_STATUS_TIMEOUT = 5000; // Shorter for status checks
+const GDRIVE_DISCONNECT_TIMEOUT = 10000;
+
+// Interface for GDrive Connection Status
+export interface GDriveConnectionStatusInfo {
+  isConnected: boolean;
+  email?: string;
+  reason?: string;
+}
 
 // Updated Interface for Google Drive file metadata
 export interface GoogleDriveFile {
@@ -70,26 +79,170 @@ export async function listGoogleDriveFiles(
     return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId is required to list Google Drive files.' }};
   }
 
-  const accessToken = await AuthService.getGoogleDriveAccessToken(userId);
-  if (!accessToken) {
-    return { ok: false, error: { code: 'AUTH_TOKEN_MISSING', message: 'Failed to retrieve Google Drive access token. Please ensure your Google Drive account is connected and authorized.' }};
-  }
-
+  // No longer directly fetching access_token here; backend will handle it.
   const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/gdrive/list-files`;
-  const payload = { access_token: accessToken, folder_id: folderId, query: query, page_size: pageSize, page_token: pageToken };
+  const payload = {
+    user_id: userId, // Send user_id instead of access_token
+    folder_id: folderId,
+    query: query,
+    page_size: pageSize,
+    page_token: pageToken
+  };
   logger.info(`[listGoogleDriveFiles] Listing GDrive files for user ${userId}. Folder: ${folderId || 'root/all'}, Query: ${query || 'none'}`);
 
   try {
-    const response = await axios.post(endpoint, payload, { timeout: GDRIVE_API_TIMEOUT });
-    if (response.data && response.data.status === "success" && response.data.data) {
+    // Python endpoint now returns SkillResponse-like structure directly
+    const response = await axios.post<SkillResponse<{ files: GoogleDriveFile[]; nextPageToken?: string }>>(endpoint, payload, { timeout: GDRIVE_API_TIMEOUT });
+
+    if (response.data && response.data.ok && response.data.data) {
       logger.info(`[listGoogleDriveFiles] Successfully listed ${response.data.data.files?.length || 0} GDrive files for user ${userId}.`);
       return { ok: true, data: response.data.data };
+    } else if (response.data && !response.data.ok && response.data.error) {
+      logger.warn(`[listGoogleDriveFiles] Failed for user ${userId}. API Error:`, response.data.error);
+      return { ok: false, error: response.data.error };
     } else {
-      logger.warn(`[listGoogleDriveFiles] Failed for user ${userId}. API status: ${response.data?.status}`, response.data);
-      return { ok: false, error: { code: response.data?.code || 'GDRIVE_LIST_FAILED', message: response.data?.message || 'Failed to list GDrive files via Python API.' , details: response.data?.details }};
+      // Fallback for unexpected response structure
+      logger.warn(`[listGoogleDriveFiles] Failed for user ${userId}. Unexpected response structure.`, response.data);
+      return { ok: false, error: { code: 'UNEXPECTED_RESPONSE', message: 'Unexpected response from GDrive list files API.' }};
     }
   } catch (error) {
     return handleAxiosError(error as AxiosError, 'listGoogleDriveFiles');
+  }
+}
+
+export async function getGoogleDriveFileMetadata(
+  userId: string,
+  fileId: string,
+  fields?: string // Optional fields string for the API
+): Promise<SkillResponse<GoogleDriveFile>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'PYTHON_API_SERVICE_BASE_URL not configured.' }};
+  }
+  if (!userId) return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId is required.' }};
+  if (!fileId) return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'fileId is required.' }};
+
+  // No longer directly fetching access_token here.
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/gdrive/get-file-metadata`;
+  const payload: { user_id: string; file_id: string; fields?: string } = { // user_id instead of access_token
+    user_id: userId,
+    file_id: fileId
+  };
+  if (fields) payload.fields = fields;
+
+  logger.info(`[getGoogleDriveFileMetadata] Fetching metadata for GDrive file ID ${fileId} for user ${userId}`);
+  try {
+    const response = await axios.post<SkillResponse<GoogleDriveFile>>(endpoint, payload, { timeout: GDRIVE_API_TIMEOUT });
+    if (response.data && response.data.ok && response.data.data) {
+      logger.info(`[getGoogleDriveFileMetadata] Successfully fetched metadata for GDrive file ID ${fileId}`);
+      return { ok: true, data: response.data.data };
+    } else if (response.data && !response.data.ok && response.data.error) {
+      logger.warn(`[getGoogleDriveFileMetadata] Failed for file ID ${fileId}. API Error:`, response.data.error);
+      return { ok: false, error: response.data.error };
+    } else {
+      logger.warn(`[getGoogleDriveFileMetadata] Failed for file ID ${fileId}. Unexpected response.`, response.data);
+      return { ok: false, error: { code: 'UNEXPECTED_RESPONSE', message: 'Unexpected response from GDrive get metadata API.' }};
+    }
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'getGoogleDriveFileMetadata');
+  }
+}
+
+export async function triggerGoogleDriveFileIngestion(
+  userId: string,
+  gdriveFileId: string,
+  originalFileMetadata: {
+    name: string;
+    mimeType: string;
+    webViewLink?: string;
+  }
+): Promise<SkillResponse<{ doc_id: string; num_chunks_stored: number } | null >> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+     return { ok: false, error: { code: 'CONFIG_ERROR', message: 'PYTHON_API_SERVICE_BASE_URL not configured.' }};
+  }
+  if (!userId) return { ok: false, error: {code: 'VALIDATION_ERROR', message: 'userId is required.'}};
+  if (!gdriveFileId) return { ok: false, error: {code: 'VALIDATION_ERROR', message: 'gdriveFileId is required.'}};
+  if (!originalFileMetadata || !originalFileMetadata.name || !originalFileMetadata.mimeType) {
+    return { ok: false, error: {code: 'VALIDATION_ERROR', message: 'originalFileMetadata (with name and mimeType) is required.'}};
+  }
+
+  // No longer directly fetching access_token here.
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/ingest-gdrive-document`;
+  const payload = { // user_id instead of access_token
+    user_id: userId,
+    gdrive_file_id: gdriveFileId,
+    original_file_metadata: originalFileMetadata,
+  };
+
+  logger.info(`[triggerGoogleDriveFileIngestion] Triggering ingestion for GDrive file ID ${gdriveFileId} for user ${userId}`);
+  try {
+    const response = await axios.post<SkillResponse<{ doc_id: string; num_chunks_stored: number } | null >>(endpoint, payload, { timeout: GDRIVE_API_TIMEOUT * 2 });
+    if (response.data && response.data.ok && response.data.data) {
+      logger.info(`[triggerGoogleDriveFileIngestion] Successfully triggered ingestion for GDrive file ${gdriveFileId}. Doc ID: ${response.data.data.doc_id}`);
+      return { ok: true, data: response.data.data };
+    } else if (response.data && !response.data.ok && response.data.error) {
+      logger.warn(`[triggerGoogleDriveFileIngestion] Failed. API Error:`, response.data.error);
+      return { ok: false, error: response.data.error };
+    } else {
+      logger.warn(`[triggerGoogleDriveFileIngestion] Failed. Unexpected response.`, response.data);
+      return { ok: false, error: { code: 'UNEXPECTED_RESPONSE', message: 'Unexpected response from GDrive trigger ingestion API.' }};
+    }
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'triggerGoogleDriveFileIngestion');
+  }
+}
+
+// --- New functions for GDrive Connection Management ---
+
+export async function getGDriveConnectionStatus(userId: string): Promise<SkillResponse<GDriveConnectionStatusInfo>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'PYTHON_API_SERVICE_BASE_URL not configured.' }};
+  }
+  if (!userId) return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId is required.' }};
+
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/gdrive/connection-status?user_id=${userId}`;
+  logger.info(`[getGDriveConnectionStatus] Checking GDrive connection status for user ${userId}`);
+
+  try {
+    const response = await axios.get<SkillResponse<GDriveConnectionStatusInfo>>(endpoint, { timeout: GDRIVE_STATUS_TIMEOUT });
+    if (response.data && response.data.ok && typeof response.data.data?.isConnected === 'boolean') {
+      logger.info(`[getGDriveConnectionStatus] Status for user ${userId}: Connected - ${response.data.data.isConnected}, Email - ${response.data.data.email}`);
+      return { ok: true, data: response.data.data };
+    } else if (response.data && !response.data.ok && response.data.error) {
+      logger.warn(`[getGDriveConnectionStatus] Failed. API Error:`, response.data.error);
+      return { ok: false, error: response.data.error };
+    } else {
+      logger.warn(`[getGDriveConnectionStatus] Failed. Unexpected response.`, response.data);
+      return { ok: false, error: { code: 'UNEXPECTED_RESPONSE', message: 'Unexpected response from GDrive connection status API.' }};
+    }
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'getGDriveConnectionStatus');
+  }
+}
+
+export async function disconnectGDrive(userId: string): Promise<SkillResponse<{ message: string }>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'PYTHON_API_SERVICE_BASE_URL not configured.' }};
+  }
+  if (!userId) return { ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId is required.' }};
+
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/auth/gdrive/disconnect`;
+  const payload = { user_id: userId };
+  logger.info(`[disconnectGDrive] Disconnecting GDrive for user ${userId}`);
+
+  try {
+    const response = await axios.post<SkillResponse<{ message: string }>>(endpoint, payload, { timeout: GDRIVE_DISCONNECT_TIMEOUT });
+    if (response.data && response.data.ok) {
+      logger.info(`[disconnectGDrive] Successfully disconnected GDrive for user ${userId}. Message: ${response.data.message}`);
+      return { ok: true, data: { message: response.data.message || "Successfully disconnected." }, message: response.data.message };
+    } else if (response.data && !response.data.ok && response.data.error) {
+      logger.warn(`[disconnectGDrive] Failed. API Error:`, response.data.error);
+      return { ok: false, error: response.data.error };
+    } else {
+      logger.warn(`[disconnectGDrive] Failed. Unexpected response.`, response.data);
+      return { ok: false, error: { code: 'UNEXPECTED_RESPONSE', message: 'Unexpected response from GDrive disconnect API.' }};
+    }
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'disconnectGDrive');
   }
 }
 


### PR DESCRIPTION
This commit implements the backend API endpoints necessary to support a user interface for Google Drive file selection and management.

Changes include:

In `auth_handler.py`:
- Added `POST /api/auth/gdrive/disconnect` for users to disconnect GDrive.
- Created an internal utility `_get_valid_gdrive_access_token` to manage fetching and refreshing GDrive access tokens server-side using user_id.
- Refactored `GET /api/auth/gdrive/get-access-token` to use this utility.

In `gdrive_handler.py`:
- Added `GET /api/gdrive/connection-status` for UI to check GDrive link status.
- Added `POST /api/gdrive/list-files` for UI to list GDrive files/folders.
- Updated `POST /api/ingest-gdrive-document` and `POST /api/gdrive/get-file-metadata` to accept `user_id` in the payload and use the new server-side token utility, instead of expecting an access token from the client.

In `gdriveSkills.ts`:
- Updated `listGoogleDriveFiles`, `getGoogleDriveFileMetadata`, and `triggerGoogleDriveFileIngestion` to send `user_id` in payloads to the backend and removed client-side fetching of access tokens for these calls.
- Added new functions `getGDriveConnectionStatus` and `disconnectGDrive` to interface with the new backend APIs.