### PR TITLE
Feat: Add HTML file ingestion support

### DIFF
--- a/atomic-docker/project/functions/requirements.txt
+++ b/atomic-docker/project/functions/requirements.txt
@@ -10,3 +10,5 @@ python-dotenv
 uuid
 notion-client>=2.0.0
 psycopg2-binary~=2.9.0
+beautifulsoup4~=4.12.0
+lxml~=5.1.0


### PR DESCRIPTION
This commit introduces the capability to process and ingest HTML files into the document pipeline.

Changes:
- Added `beautifulsoup4` and `lxml` to `atomic-docker/project/functions/requirements.txt` for HTML parsing.
- In `atomic-docker/python-api/ingestion_pipeline/document_processor.py`:
    - Added a new function `extract_text_from_html` that uses BeautifulSoup (with lxml parser and html.parser fallback) to parse HTML, remove script/style tags, and extract textual content.
    - Updated the main `process_document_and_store` function to recognize HTML files (by MIME type `text/html` or `original_doc_type` like 'html', 'htm', 'webpage').
    - For identified HTML files, `extract_text_from_html` is now called.
    - The `original_doc_type` for HTML documents is normalized to 'html' before being passed for metadata storage.