### PR TITLE
feat: Integrate filter object into frontend search skill

### DIFF
--- a/atomic-docker/project/functions/atom-agent/types.ts
+++ b/atomic-docker/project/functions/atom-agent/types.ts
@@ -1335,3 +1335,15 @@ export interface HybridSearchResultItem {
   extracted_text_preview?: string | null;
   additional_properties?: Record<string, any> | null;
 }
+
+/**
+ * Defines the structure for the filters object used in hybrid search.
+ * This should be constructed by the frontend and passed to the search skill.
+ */
+export interface HybridSearchFilters {
+  doc_types?: string[];
+  date_after?: string; // ISO 8601 string
+  date_before?: string; // ISO 8601 string
+  date_field_to_filter?: 'ingested_at' | 'created_at_source' | 'last_modified_source';
+  metadata_properties?: Record<string, string>;
+}

--- a/src/skills/lanceDbStorageSkills.ts
+++ b/src/skills/lanceDbStorageSkills.ts
@@ -207,12 +207,12 @@ export interface SemanticSearchFilters {
 }
 
 // Ensure UniversalSearchResultItem is imported from types.ts
-import { UniversalSearchResultItem, SearchResultSourceType, HybridSearchResultItem } from '../../atomic-docker/project/functions/atom-agent/types';
+import { UniversalSearchResultItem, SearchResultSourceType, HybridSearchResultItem, HybridSearchFilters } from '../../atomic-docker/project/functions/atom-agent/types';
 
 export interface HybridSearchOptions {
   semanticLimit?: number;
   keywordLimit?: number;
-  filters?: any; // Define a more specific filter type if needed
+  filters?: HybridSearchFilters; // Use the new specific filter type
 }
 
 export async function hybridSearch(


### PR DESCRIPTION
This commit wires up the frontend skills to handle the new advanced filtering capabilities of the hybrid search backend.

Key Changes:

1.  **New Filter Type (`types.ts`):**
    *   I added the `HybridSearchFilters` TypeScript interface to provide a clear, type-safe structure for filter objects. This interface matches the unified filter structure expected by the backend API.

2.  **Updated Search Skill (`lanceDbStorageSkills.ts`):**
    *   I updated the `HybridSearchOptions` interface to use the new `HybridSearchFilters` type.
    *   The `hybridSearch` function now accepts a typed `filters` object within its options and passes it to the `/api/search/hybrid` backend endpoint.

3.  **Non-Breaking Change:**
    *   The changes are non-breaking for existing callers like `smartMeetingPrepSkill.ts`, which can continue to call `hybridSearch` without providing the optional `filters` object.

This completes the data pipeline for advanced filtering, enabling a future UI to construct a filter object that will be passed through to the backend for processing.