### PR TITLE
feat: Add actionable buttons to frontend daily briefing

### DIFF
--- a/atomic-docker/app_build_docker/components/chat/Message.tsx
+++ b/atomic-docker/app_build_docker/components/chat/Message.tsx
@@ -9,6 +9,7 @@ import { cn } from "@lib/Chat/utils"; // Import cn for class utility
 // Dynamically import the SearchResultsDisplay component
 const SearchResultsDisplay = React.lazy(() => import('./custom/SearchResultsDisplay'));
 const MeetingPrepDisplay = React.lazy(() => import('./custom/MeetingPrepDisplay'));
+const DailyBriefingDisplay = React.lazy(() => import('./custom/DailyBriefingDisplay'));
 
 
 type Props = {
@@ -100,6 +101,11 @@ function Message({ message, isLoading, formData, htmlEmail }: Props) {
                         {message.customComponentType === 'meeting_prep_results' && message.customComponentProps?.briefing && (
                             <Suspense fallback={<div className="text-sm text-gray-500 dark:text-gray-400">Loading meeting preparation...</div>}>
                                 <MeetingPrepDisplay briefing={message.customComponentProps.briefing} />
+                            </Suspense>
+                        )}
+                        {message.customComponentType === 'daily_briefing_results' && message.customComponentProps?.briefing && (
+                            <Suspense fallback={<div className="text-sm text-gray-500 dark:text-gray-400">Loading daily briefing...</div>}>
+                                <DailyBriefingDisplay briefing={message.customComponentProps.briefing} />
                             </Suspense>
                         )}
                         {htmlEmail && !message.customComponentType && (

--- a/atomic-docker/app_build_docker/components/chat/custom/DailyBriefingDisplay.tsx
+++ b/atomic-docker/app_build_docker/components/chat/custom/DailyBriefingDisplay.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { DailyBriefingData, BriefingItem } from '@lib/dataTypes/Messaging/MessagingTypes'; // Adjust path as needed
+import { cn } from '@lib/Chat/utils';
+import { Button } from '../ui/button'; // Assuming a generic Button component is available
+import { IconArrowRight, IconCalendar, IconCheck, IconMail, IconMessage, IconMessage2 } from '../ui/icons'; // Assuming icons are available
+
+const getIconForType = (type: BriefingItem['type']) => {
+  const iconProps = { className: "mr-2 h-4 w-4" };
+  switch (type) {
+    case 'meeting':
+      return <IconCalendar {...iconProps} />;
+    case 'task':
+      return <IconCheck {...iconProps} />;
+    case 'email':
+      return <IconMail {...iconProps} />;
+    case 'slack_message':
+      return <IconMessage {...iconProps} />; // Assuming IconMessage for Slack
+    case 'teams_message':
+      return <IconMessage2 {...iconProps} />; // Assuming IconMessage2 for Teams
+    default:
+      return null;
+  }
+};
+
+const getButtonTextForType = (type: BriefingItem['type']): string => {
+    switch (type) {
+        case 'meeting': return "View Event";
+        case 'task': return "Open Task";
+        case 'email': return "View Email";
+        case 'slack_message': return "View Message";
+        case 'teams_message': return "View Message";
+        default: return "Open Link";
+    }
+};
+
+const BriefingItemCard: React.FC<{ item: BriefingItem }> = ({ item }) => {
+  const icon = getIconForType(item.type);
+  const buttonText = getButtonTextForType(item.type);
+
+  return (
+    <div className={cn(
+      "p-3 mb-3 border rounded-lg shadow-sm transition-shadow hover:shadow-md",
+      "bg-white dark:bg-gray-800",
+      "border-gray-200 dark:border-gray-700"
+    )}>
+      <div className="flex items-center mb-1">
+        {icon}
+        <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-100">{item.title}</h4>
+      </div>
+      <p className="text-xs text-gray-600 dark:text-gray-400 pl-6 mb-2">{item.details}</p>
+
+      {item.link && (
+        <div className="pl-6 mt-2">
+            <a
+                href={item.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(
+                    buttonVariants({ variant: 'outline', size: 'sm' }),
+                    "h-8 text-xs"
+                )}
+            >
+                {buttonText} <IconArrowRight className="ml-1 h-3 w-3" />
+            </a>
+        </div>
+      )}
+    </div>
+  );
+};
+
+
+const DailyBriefingDisplay: React.FC<{ briefing: DailyBriefingData }> = ({ briefing }) => {
+  if (!briefing) {
+    return <div className="p-3 text-sm text-gray-600 dark:text-gray-400 font-sans">No briefing data available.</div>;
+  }
+
+  return (
+    <div className={cn(
+      "p-4 my-2 rounded-lg shadow font-sans",
+      "bg-gray-50 dark:bg-gray-800/50",
+      "border border-gray-200 dark:border-gray-700"
+    )}>
+      {briefing.overall_summary_message && (
+        <p className="text-sm text-gray-800 dark:text-gray-200 mb-4 whitespace-pre-wrap">
+          {briefing.overall_summary_message}
+        </p>
+      )}
+
+      <div className="max-h-96 overflow-y-auto custom-scrollbar pr-2">
+        {briefing.priority_items.length > 0 ? (
+          briefing.priority_items.map((item, index) => (
+            <BriefingItemCard key={item.source_id || `item-${index}`} item={item} />
+          ))
+        ) : (
+          <p className="text-sm text-gray-500 dark:text-gray-400">You have no priority items for this day.</p>
+        )}
+      </div>
+
+      {briefing.errors_encountered && briefing.errors_encountered.length > 0 && (
+        <div className="mt-4 p-3 rounded-lg bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700/50">
+           <h4 className="text-sm font-semibold mb-1 text-red-800 dark:text-red-200">Data Retrieval Issues</h4>
+           <ul className="list-disc list-inside pl-2 space-y-1">
+                {briefing.errors_encountered.map((error, index) => (
+                    <li key={index} className="text-xs text-red-700 dark:text-red-300">
+                        <span className="font-medium">{error.source_area}:</span> {error.message}
+                    </li>
+                ))}
+            </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DailyBriefingDisplay;


### PR DESCRIPTION
This commit enhances the Daily Briefing feature by introducing a new, interactive frontend component to display the results, making them more actionable for you.

Key Changes:

1.  **New `DailyBriefingDisplay.tsx` Component:**
    *   I created a new custom component to render the structured `DailyBriefingData`.
    *   It displays the overall summary and a list of priority items.

2.  **New `BriefingItemCard` Sub-Component:**
    *   Each priority item is rendered as a card with a relevant icon (`meeting`, `task`, `email`, etc.).
    *   An action button is now included for each item that has a link.

3.  **Context-Aware Actions:**
    *   The button text is context-aware (e.g., "View Event", "Open Task", "View Email") based on the item type, improving user experience.
    *   The button correctly links to the URL provided for the item.

4.  **Integration with Chat (`Message.tsx`):**
    *   The main chat message component now recognizes a new `customComponentType` of `daily_briefing_results` and will render the new `DailyBriefingDisplay` component when appropriate.

This provides the necessary frontend foundation to transform the daily briefing from a static text block into an interactive dashboard.