### PR TITLE
feat: Add Recruiting Manager, Legal, and IT Manager use cases

### DIFF
--- a/atomic-docker/project/functions/python_api_service/docusign_service.py
+++ b/atomic-docker/project/functions/python_api_service/docusign_service.py
@@ -1,0 +1,39 @@
+import os
+import logging
+from typing import Optional, Dict, Any
+from docusign_esign import ApiClient, EnvelopesApi
+
+logger = logging.getLogger(__name__)
+
+async def get_docusign_client(user_id: str, db_conn_pool) -> Optional[ApiClient]:
+    # This is a placeholder. In a real application, you would fetch the user's Docusign credentials
+    # from a secure database. For now, we'll use environment variables.
+    # You'll need to create a table to store these credentials, similar to the Dropbox and Google Drive implementations.
+    access_token = os.environ.get("DOCUSIGN_ACCESS_TOKEN")
+    account_id = os.environ.get("DOCUSIGN_ACCOUNT_ID")
+    base_path = os.environ.get("DOCUSIGN_BASE_PATH")
+
+    if not all([access_token, account_id, base_path]):
+        logger.error("Docusign credentials are not configured in environment variables.")
+        return None
+
+    api_client = ApiClient()
+    api_client.host = base_path
+    api_client.set_default_header("Authorization", "Bearer " + access_token)
+
+    return api_client
+
+async def create_envelope(client: ApiClient, envelope_definition: Dict[str, Any]) -> Dict[str, Any]:
+    envelopes_api = EnvelopesApi(client)
+    results = envelopes_api.create_envelope(os.environ.get("DOCUSIGN_ACCOUNT_ID"), envelope_definition=envelope_definition)
+    return results.to_dict()
+
+async def get_envelope_status(client: ApiClient, envelope_id: str) -> str:
+    envelopes_api = EnvelopesApi(client)
+    results = envelopes_api.get_envelope(os.environ.get("DOCUSIGN_ACCOUNT_ID"), envelope_id)
+    return results.status
+
+async def get_envelope(client: ApiClient, envelope_id: str) -> Dict[str, Any]:
+    envelopes_api = EnvelopesApi(client)
+    results = envelopes_api.get_envelope(os.environ.get("DOCUSIGN_ACCOUNT_ID"), envelope_id)
+    return results

--- a/atomic-docker/project/functions/python_api_service/greenhouse_service.py
+++ b/atomic-docker/project/functions/python_api_service/greenhouse_service.py
@@ -1,0 +1,31 @@
+import os
+import logging
+from typing import Optional, Dict, Any
+from greenhouse import Greenhouse
+
+logger = logging.getLogger(__name__)
+
+async def get_greenhouse_client(user_id: str, db_conn_pool) -> Optional[Greenhouse]:
+    # This is a placeholder. In a real application, you would fetch the user's Greenhouse credentials
+    # from a secure database. For now, we'll use environment variables.
+    # You'll need to create a table to store these credentials, similar to the Dropbox and Google Drive implementations.
+    api_key = os.environ.get("GREENHOUSE_API_KEY")
+
+    if not api_key:
+        logger.error("Greenhouse API key is not configured in environment variables.")
+        return None
+
+    try:
+        client = Greenhouse(api_key)
+        return client
+    except Exception as e:
+        logger.error(f"Failed to create Greenhouse client: {e}", exc_info=True)
+        return None
+
+async def create_candidate(client: Greenhouse, candidate_data: Dict[str, Any]) -> Dict[str, Any]:
+    response = client.candidates.add(candidate_data)
+    return response
+
+async def get_candidate(client: Greenhouse, candidate_id: str) -> Dict[str, Any]:
+    response = client.candidates.get(candidate_id)
+    return response

--- a/atomic-docker/project/functions/python_api_service/it_manager_handler.py
+++ b/atomic-docker/project/functions/python_api_service/it_manager_handler.py
@@ -1,0 +1,63 @@
+import logging
+from flask import Blueprint, request, jsonify, current_app
+from . import it_manager_service
+
+logger = logging.getLogger(__name__)
+
+it_manager_bp = Blueprint('it_manager_bp', __name__)
+
+@it_manager_bp.route('/api/it/create-jira-issue-from-salesforce-case', methods=['POST'])
+async def create_jira_issue_from_salesforce_case():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    salesforce_case_id = data.get('salesforce_case_id')
+    if not all([user_id, salesforce_case_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id and salesforce_case_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await it_manager_service.create_jira_issue_from_salesforce_case(user_id, salesforce_case_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating Jira issue from Salesforce case for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "ISSUE_CREATE_FAILED", "message": str(e)}}), 500
+
+@it_manager_bp.route('/api/it/jira-issue-summary/<issue_id>', methods=['GET'])
+async def get_jira_issue_summary(issue_id):
+    user_id = request.args.get('user_id')
+    if not user_id:
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id is required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await it_manager_service.get_jira_issue_summary(user_id, issue_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error getting Jira issue summary for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "SUMMARY_FETCH_FAILED", "message": str(e)}}), 500
+
+@it_manager_bp.route('/api/it/create-trello-card-from-jira-issue', methods=['POST'])
+async def create_trello_card_from_jira_issue():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    issue_id = data.get('issue_id')
+    trello_list_id = data.get('trello_list_id')
+    if not all([user_id, issue_id, trello_list_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id, issue_id, and trello_list_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await it_manager_service.create_trello_card_from_jira_issue(user_id, issue_id, trello_list_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating Trello card from Jira issue for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "CARD_CREATE_FAILED", "message": str(e)}}), 500

--- a/atomic-docker/project/functions/python_api_service/it_manager_service.py
+++ b/atomic-docker/project/functions/python_api_service/it_manager_service.py
@@ -1,0 +1,61 @@
+import logging
+from . import salesforce_service
+from . import jira_service # We need to create this
+from . import trello_service
+
+logger = logging.getLogger(__name__)
+
+async def create_jira_issue_from_salesforce_case(user_id: str, salesforce_case_id: str, db_conn_pool):
+    """
+    Creates a Jira issue from a Salesforce case.
+    """
+    sf_client = await salesforce_service.get_salesforce_client(user_id, db_conn_pool)
+    if not sf_client:
+        raise Exception("Could not get authenticated Salesforce client.")
+
+    salesforce_case = await salesforce_service.get_case(sf_client, salesforce_case_id)
+
+    jira_client = await jira_service.get_jira_client(user_id, db_conn_pool)
+    if not jira_client:
+        raise Exception("Could not get authenticated Jira client.")
+
+    issue_data = {
+        "project": {"key": os.environ.get("JIRA_PROJECT_KEY")}, # You'll need to get this from the user
+        "summary": salesforce_case['Subject'],
+        "description": salesforce_case['Description'],
+        "issuetype": {"name": "Task"} # This should be configurable
+    }
+
+    issue = await jira_service.create_issue(jira_client, issue_data)
+    return issue
+
+async def get_jira_issue_summary(user_id: str, issue_id: str, db_conn_pool):
+    """
+    Gets a summary of a Jira issue.
+    """
+    jira_client = await jira_service.get_jira_client(user_id, db_conn_pool)
+    if not jira_client:
+        raise Exception("Could not get authenticated Jira client.")
+
+    issue = await jira_service.get_issue(jira_client, issue_id)
+    return issue
+
+async def create_trello_card_from_jira_issue(user_id: str, issue_id: str, trello_list_id: str, db_conn_pool):
+    """
+    Creates a Trello card for a new Jira issue.
+    """
+    jira_client = await jira_service.get_jira_client(user_id, db_conn_pool)
+    if not jira_client:
+        raise Exception("Could not get authenticated Jira client.")
+
+    issue = await jira_service.get_issue(jira_client, issue_id)
+
+    trello_api_key, trello_token = await trello_service.get_trello_credentials(user_id, db_conn_pool)
+    if not trello_api_key or not trello_token:
+        raise Exception("Could not get Trello credentials.")
+
+    card_name = f"New Issue: {issue.fields.summary}"
+    card_desc = f"**Issue ID:** {issue.key}\n**Link:** {issue.permalink()}"
+
+    card = await trello_service.create_card(trello_api_key, trello_token, trello_list_id, card_name, card_desc)
+    return card

--- a/atomic-docker/project/functions/python_api_service/jira_service.py
+++ b/atomic-docker/project/functions/python_api_service/jira_service.py
@@ -1,0 +1,33 @@
+import os
+import logging
+from typing import Optional, Dict, Any
+from jira import JIRA
+
+logger = logging.getLogger(__name__)
+
+async def get_jira_client(user_id: str, db_conn_pool) -> Optional[JIRA]:
+    # This is a placeholder. In a real application, you would fetch the user's Jira credentials
+    # from a secure database. For now, we'll use environment variables.
+    # You'll need to create a table to store these credentials, similar to the Dropbox and Google Drive implementations.
+    server = os.environ.get("JIRA_SERVER")
+    email = os.environ.get("JIRA_EMAIL")
+    token = os.environ.get("JIRA_TOKEN")
+
+    if not all([server, email, token]):
+        logger.error("Jira credentials are not configured in environment variables.")
+        return None
+
+    try:
+        client = JIRA(server=server, basic_auth=(email, token))
+        return client
+    except Exception as e:
+        logger.error(f"Failed to create Jira client: {e}", exc_info=True)
+        return None
+
+async def create_issue(client: JIRA, issue_data: Dict[str, Any]) -> Dict[str, Any]:
+    issue = client.create_issue(fields=issue_data)
+    return issue.raw
+
+async def get_issue(client: JIRA, issue_id: str) -> Dict[str, Any]:
+    issue = client.issue(issue_id)
+    return issue.raw

--- a/atomic-docker/project/functions/python_api_service/legal_handler.py
+++ b/atomic-docker/project/functions/python_api_service/legal_handler.py
@@ -1,0 +1,63 @@
+import logging
+from flask import Blueprint, request, jsonify, current_app
+from . import legal_service
+
+logger = logging.getLogger(__name__)
+
+legal_bp = Blueprint('legal_bp', __name__)
+
+@legal_bp.route('/api/legal/create-docusign-envelope-from-salesforce-opportunity', methods=['POST'])
+async def create_docusign_envelope_from_salesforce_opportunity():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    salesforce_opportunity_id = data.get('salesforce_opportunity_id')
+    if not all([user_id, salesforce_opportunity_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id and salesforce_opportunity_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await legal_service.create_docusign_envelope_from_salesforce_opportunity(user_id, salesforce_opportunity_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating Docusign envelope from Salesforce opportunity for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "ENVELOPE_CREATE_FAILED", "message": str(e)}}), 500
+
+@legal_bp.route('/api/legal/docusign-envelope-status/<envelope_id>', methods=['GET'])
+async def get_docusign_envelope_status(envelope_id):
+    user_id = request.args.get('user_id')
+    if not user_id:
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id is required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await legal_service.get_docusign_envelope_status(user_id, envelope_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error getting Docusign envelope status for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "STATUS_FETCH_FAILED", "message": str(e)}}), 500
+
+@legal_bp.route('/api/legal/create-trello-card-from-docusign-envelope', methods=['POST'])
+async def create_trello_card_from_docusign_envelope():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    envelope_id = data.get('envelope_id')
+    trello_list_id = data.get('trello_list_id')
+    if not all([user_id, envelope_id, trello_list_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id, envelope_id, and trello_list_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await legal_service.create_trello_card_from_docusign_envelope(user_id, envelope_id, trello_list_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating Trello card from Docusign envelope for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "CARD_CREATE_FAILED", "message": str(e)}}), 500

--- a/atomic-docker/project/functions/python_api_service/legal_service.py
+++ b/atomic-docker/project/functions/python_api_service/legal_service.py
@@ -1,0 +1,72 @@
+import logging
+from . import salesforce_service
+from . import docusign_service # We need to create this
+from . import trello_service
+
+logger = logging.getLogger(__name__)
+
+async def create_docusign_envelope_from_salesforce_opportunity(user_id: str, salesforce_opportunity_id: str, db_conn_pool):
+    """
+    Creates a Docusign envelope from a Salesforce opportunity.
+    """
+    sf_client = await salesforce_service.get_salesforce_client(user_id, db_conn_pool)
+    if not sf_client:
+        raise Exception("Could not get authenticated Salesforce client.")
+
+    opportunity = await salesforce_service.get_opportunity(sf_client, salesforce_opportunity_id)
+
+    docusign_client = await docusign_service.get_docusign_client(user_id, db_conn_pool)
+    if not docusign_client:
+        raise Exception("Could not get authenticated Docusign client.")
+
+    # This is a simplified implementation. In a real application, you would need to get the
+    # document to be signed from a template or a file.
+    # For now, we'll just create an empty envelope.
+    envelope_definition = {
+        "email_subject": f"Please sign this document for {opportunity['Name']}",
+        "status": "sent",
+        "recipients": {
+            "signers": [
+                {
+                    "email": opportunity['Contact']['Email'],
+                    "name": opportunity['Contact']['Name'],
+                    "recipient_id": "1",
+                    "routing_order": "1"
+                }
+            ]
+        }
+    }
+
+    envelope = await docusign_service.create_envelope(docusign_client, envelope_definition)
+    return envelope
+
+async def get_docusign_envelope_status(user_id: str, envelope_id: str, db_conn_pool):
+    """
+    Gets the status of a Docusign envelope.
+    """
+    docusign_client = await docusign_service.get_docusign_client(user_id, db_conn_pool)
+    if not docusign_client:
+        raise Exception("Could not get authenticated Docusign client.")
+
+    status = await docusign_service.get_envelope_status(docusign_client, envelope_id)
+    return status
+
+async def create_trello_card_from_docusign_envelope(user_id: str, envelope_id: str, trello_list_id: str, db_conn_pool):
+    """
+    Creates a Trello card for a new Docusign envelope.
+    """
+    docusign_client = await docusign_service.get_docusign_client(user_id, db_conn_pool)
+    if not docusign_client:
+        raise Exception("Could not get authenticated Docusign client.")
+
+    envelope = await docusign_service.get_envelope(docusign_client, envelope_id)
+
+    trello_api_key, trello_token = await trello_service.get_trello_credentials(user_id, db_conn_pool)
+    if not trello_api_key or not trello_token:
+        raise Exception("Could not get Trello credentials.")
+
+    card_name = f"New Envelope: {envelope.email_subject}"
+    card_desc = f"**Envelope ID:** {envelope.envelope_id}\n**Status:** {envelope.status}"
+
+    card = await trello_service.create_card(trello_api_key, trello_token, trello_list_id, card_name, card_desc)
+    return card

--- a/atomic-docker/project/functions/python_api_service/linkedin_service.py
+++ b/atomic-docker/project/functions/python_api_service/linkedin_service.py
@@ -28,3 +28,12 @@ async def get_linkedin_api(user_id: str, db_conn_pool) -> Optional[linkedin.Link
     )
     application = linkedin.LinkedInApplication(authentication)
     return application
+
+async def search_linkedin_profiles(api: linkedin.LinkedInApplication, query: str):
+    """
+    Searches for LinkedIn profiles.
+    """
+    # The python-linkedin library does not support people search.
+    # You would need to use a different library or a web scraper to implement this feature.
+    # For now, we'll just return an empty list.
+    return []

--- a/atomic-docker/project/functions/python_api_service/main_api_app.py
+++ b/atomic-docker/project/functions/python_api_service/main_api_app.py
@@ -25,6 +25,9 @@ from .personal_assistant_handler import personal_assistant_bp
 from .financial_analyst_handler import financial_analyst_bp
 from .marketing_manager_handler import marketing_manager_bp
 from .customer_support_manager_handler import customer_support_manager_bp
+from .recruiting_manager_handler import recruiting_manager_bp
+from .legal_handler import legal_bp
+from .it_manager_handler import it_manager_bp
 from .meeting_prep import meeting_prep_bp
 from .mcp_handler import mcp_bp
 
@@ -94,6 +97,12 @@ def create_app(db_pool=None):
     logger.info("Registered 'marketing_manager_bp' blueprint.")
     app.register_blueprint(customer_support_manager_bp)
     logger.info("Registered 'customer_support_manager_bp' blueprint.")
+    app.register_blueprint(recruiting_manager_bp)
+    logger.info("Registered 'recruiting_manager_bp' blueprint.")
+    app.register_blueprint(legal_bp)
+    logger.info("Registered 'legal_bp' blueprint.")
+    app.register_blueprint(it_manager_bp)
+    logger.info("Registered 'it_manager_bp' blueprint.")
     app.register_blueprint(mcp_bp)
     logger.info("Registered 'mcp_bp' blueprint.")
 

--- a/atomic-docker/project/functions/python_api_service/recruiting_manager_handler.py
+++ b/atomic-docker/project/functions/python_api_service/recruiting_manager_handler.py
@@ -1,0 +1,63 @@
+import logging
+from flask import Blueprint, request, jsonify, current_app
+from . import recruiting_manager_service
+
+logger = logging.getLogger(__name__)
+
+recruiting_manager_bp = Blueprint('recruiting_manager_bp', __name__)
+
+@recruiting_manager_bp.route('/api/recruiting/create-greenhouse-candidate-from-linkedin-profile', methods=['POST'])
+async def create_greenhouse_candidate_from_linkedin_profile():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    linkedin_profile_url = data.get('linkedin_profile_url')
+    if not all([user_id, linkedin_profile_url]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id and linkedin_profile_url are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await recruiting_manager_service.create_greenhouse_candidate_from_linkedin_profile(user_id, linkedin_profile_url, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating Greenhouse candidate from LinkedIn profile for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "CANDIDATE_CREATE_FAILED", "message": str(e)}}), 500
+
+@recruiting_manager_bp.route('/api/recruiting/greenhouse-candidate-summary/<candidate_id>', methods=['GET'])
+async def get_greenhouse_candidate_summary(candidate_id):
+    user_id = request.args.get('user_id')
+    if not user_id:
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id is required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await recruiting_manager_service.get_greenhouse_candidate_summary(user_id, candidate_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error getting Greenhouse candidate summary for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "SUMMARY_FETCH_FAILED", "message": str(e)}}), 500
+
+@recruiting_manager_bp.route('/api/recruiting/create-trello-card-from-greenhouse-candidate', methods=['POST'])
+async def create_trello_card_from_greenhouse_candidate():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    candidate_id = data.get('candidate_id')
+    trello_list_id = data.get('trello_list_id')
+    if not all([user_id, candidate_id, trello_list_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id, candidate_id, and trello_list_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await recruiting_manager_service.create_trello_card_from_greenhouse_candidate(user_id, candidate_id, trello_list_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating Trello card from Greenhouse candidate for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "CARD_CREATE_FAILED", "message": str(e)}}), 500

--- a/atomic-docker/project/functions/python_api_service/recruiting_manager_service.py
+++ b/atomic-docker/project/functions/python_api_service/recruiting_manager_service.py
@@ -1,0 +1,70 @@
+import logging
+from typing import Optional
+from . import linkedin_service
+from . import greenhouse_service # We need to create this
+from . import trello_service
+
+logger = logging.getLogger(__name__)
+
+async def create_greenhouse_candidate_from_linkedin_profile(user_id: str, linkedin_profile_url: Optional[str] = None, search_query: Optional[str] = None, db_conn_pool):
+    """
+    Creates a Greenhouse candidate from a LinkedIn profile.
+    """
+    linkedin_api = await linkedin_service.get_linkedin_api(user_id, db_conn_pool)
+    if not linkedin_api:
+        raise Exception("Could not get authenticated LinkedIn client.")
+
+    if not linkedin_profile_url and search_query:
+        profiles = await linkedin_service.search_linkedin_profiles(linkedin_api, search_query)
+        if not profiles:
+            raise Exception("No LinkedIn profiles found for the given search query.")
+        linkedin_profile_url = profiles[0]['public_profile_url']
+
+    # This is a simplified implementation. In a real application, you would use a web scraper
+    # to get the candidate's information from their LinkedIn profile.
+    # For now, we'll just use the profile URL as the candidate's name.
+    candidate_name = linkedin_profile_url.split('/')[-1]
+
+    greenhouse_client = await greenhouse_service.get_greenhouse_client(user_id, db_conn_pool)
+    if not greenhouse_client:
+        raise Exception("Could not get authenticated Greenhouse client.")
+
+    candidate_data = {
+        "first_name": candidate_name,
+        "last_name": "",
+        "external_id": linkedin_profile_url
+    }
+
+    candidate = await greenhouse_service.create_candidate(greenhouse_client, candidate_data)
+    return candidate
+
+async def get_greenhouse_candidate_summary(user_id: str, candidate_id: str, db_conn_pool):
+    """
+    Gets a summary of a Greenhouse candidate.
+    """
+    greenhouse_client = await greenhouse_service.get_greenhouse_client(user_id, db_conn_pool)
+    if not greenhouse_client:
+        raise Exception("Could not get authenticated Greenhouse client.")
+
+    candidate = await greenhouse_service.get_candidate(greenhouse_client, candidate_id)
+    return candidate
+
+async def create_trello_card_from_greenhouse_candidate(user_id: str, candidate_id: str, trello_list_id: str, db_conn_pool):
+    """
+    Creates a Trello card for a new Greenhouse candidate.
+    """
+    greenhouse_client = await greenhouse_service.get_greenhouse_client(user_id, db_conn_pool)
+    if not greenhouse_client:
+        raise Exception("Could not get authenticated Greenhouse client.")
+
+    candidate = await greenhouse_service.get_candidate(greenhouse_client, candidate_id)
+
+    trello_api_key, trello_token = await trello_service.get_trello_credentials(user_id, db_conn_pool)
+    if not trello_api_key or not trello_token:
+        raise Exception("Could not get Trello credentials.")
+
+    card_name = f"New Candidate: {candidate['first_name']} {candidate['last_name']}"
+    card_desc = f"**Candidate ID:** {candidate['id']}\n**Link:** {candidate['site_admin_url']}"
+
+    card = await trello_service.create_card(trello_api_key, trello_token, trello_list_id, card_name, card_desc)
+    return card

--- a/atomic-docker/project/functions/requirements.txt
+++ b/atomic-docker/project/functions/requirements.txt
@@ -20,3 +20,6 @@ newsapi-python
 quickbooks-python
 mailchimp-marketing
 zenpy
+greenhouse-python
+docusign-esign
+jira

--- a/src/skills/itManagerSkills.ts
+++ b/src/skills/itManagerSkills.ts
@@ -1,0 +1,98 @@
+import axios, { AxiosError } from 'axios';
+import {
+  SkillResponse,
+} from '../../atomic-docker/project/functions/atom-agent/types'; // Adjust path
+import { PYTHON_API_SERVICE_BASE_URL } from '../../atomic-docker/project/functions/atom-agent/_libs/constants';
+import { logger } from '../../atomic-docker/project/functions/_utils/logger';
+
+// Helper to handle Python API responses, can be centralized later
+function handlePythonApiResponse<T>(
+  response: any, // Adjust type as per actual Python API response structure
+  operationName: string
+): SkillResponse<T> {
+  if (response.data && response.data.ok && response.data.data) {
+    return { ok: true, data: response.data.data };
+  }
+  logger.warn(`[${operationName}] Failed API call.`, response.data?.error);
+  return {
+    ok: false,
+    error: {
+      code: response.data?.error?.code || 'PYTHON_API_ERROR',
+      message: response.data?.error?.message || `Failed to ${operationName}.`,
+      details: response.data?.error?.details,
+    },
+  };
+}
+
+// Helper to handle network/axios errors
+function handleAxiosError(error: AxiosError, operationName: string): SkillResponse<null> {
+    if (error.response) {
+      logger.error(`[${operationName}] Error: ${error.response.status}`, error.response.data);
+      const errData = error.response.data as any;
+      return { ok: false, error: { code: `HTTP_${error.response.status}`, message: errData?.error?.message || `Failed to ${operationName}.` } };
+    } else if (error.request) {
+      logger.error(`[${operationName}] Error: No response received`, error.request);
+      return { ok: false, error: { code: 'NETWORK_ERROR', message: `No response received for ${operationName}.` } };
+    }
+    logger.error(`[${operationName}] Error: ${error.message}`);
+    return { ok: false, error: { code: 'REQUEST_SETUP_ERROR', message: `Error setting up request for ${operationName}: ${error.message}` } };
+}
+
+export async function createJiraIssueFromSalesforceCase(
+  userId: string,
+  salesforceCaseId: string
+): Promise<SkillResponse<any>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+  }
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/it/create-jira-issue-from-salesforce-case`;
+
+  try {
+    const response = await axios.post(endpoint, {
+      user_id: userId,
+      salesforce_case_id: salesforceCaseId,
+    });
+    return handlePythonApiResponse(response, 'createJiraIssueFromSalesforceCase');
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'createJiraIssueFromSalesforceCase');
+  }
+}
+
+export async function getJiraIssueSummary(
+    userId: string,
+    issueId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/it/jira-issue-summary/${issueId}?user_id=${userId}`;
+
+    try {
+        const response = await axios.get(endpoint);
+        return handlePythonApiResponse(response, 'getJiraIssueSummary');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'getJiraIssueSummary');
+    }
+}
+
+export async function createTrelloCardFromJiraIssue(
+    userId: string,
+    issueId: string,
+    trelloListId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/it/create-trello-card-from-jira-issue`;
+
+    try {
+        const response = await axios.post(endpoint, {
+            user_id: userId,
+            issue_id: issueId,
+            trello_list_id: trelloListId,
+        });
+        return handlePythonApiResponse(response, 'createTrelloCardFromJiraIssue');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'createTrelloCardFromJiraIssue');
+    }
+}

--- a/src/skills/legalSkills.ts
+++ b/src/skills/legalSkills.ts
@@ -1,0 +1,98 @@
+import axios, { AxiosError } from 'axios';
+import {
+  SkillResponse,
+} from '../../atomic-docker/project/functions/atom-agent/types'; // Adjust path
+import { PYTHON_API_SERVICE_BASE_URL } from '../../atomic-docker/project/functions/atom-agent/_libs/constants';
+import { logger } from '../../atomic-docker/project/functions/_utils/logger';
+
+// Helper to handle Python API responses, can be centralized later
+function handlePythonApiResponse<T>(
+  response: any, // Adjust type as per actual Python API response structure
+  operationName: string
+): SkillResponse<T> {
+  if (response.data && response.data.ok && response.data.data) {
+    return { ok: true, data: response.data.data };
+  }
+  logger.warn(`[${operationName}] Failed API call.`, response.data?.error);
+  return {
+    ok: false,
+    error: {
+      code: response.data?.error?.code || 'PYTHON_API_ERROR',
+      message: response.data?.error?.message || `Failed to ${operationName}.`,
+      details: response.data?.error?.details,
+    },
+  };
+}
+
+// Helper to handle network/axios errors
+function handleAxiosError(error: AxiosError, operationName: string): SkillResponse<null> {
+    if (error.response) {
+      logger.error(`[${operationName}] Error: ${error.response.status}`, error.response.data);
+      const errData = error.response.data as any;
+      return { ok: false, error: { code: `HTTP_${error.response.status}`, message: errData?.error?.message || `Failed to ${operationName}.` } };
+    } else if (error.request) {
+      logger.error(`[${operationName}] Error: No response received`, error.request);
+      return { ok: false, error: { code: 'NETWORK_ERROR', message: `No response received for ${operationName}.` } };
+    }
+    logger.error(`[${operationName}] Error: ${error.message}`);
+    return { ok: false, error: { code: 'REQUEST_SETUP_ERROR', message: `Error setting up request for ${operationName}: ${error.message}` } };
+}
+
+export async function createDocusignEnvelopeFromSalesforceOpportunity(
+  userId: string,
+  salesforceOpportunityId: string
+): Promise<SkillResponse<any>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+  }
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/legal/create-docusign-envelope-from-salesforce-opportunity`;
+
+  try {
+    const response = await axios.post(endpoint, {
+      user_id: userId,
+      salesforce_opportunity_id: salesforceOpportunityId,
+    });
+    return handlePythonApiResponse(response, 'createDocusignEnvelopeFromSalesforceOpportunity');
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'createDocusignEnvelopeFromSalesforceOpportunity');
+  }
+}
+
+export async function getDocusignEnvelopeStatus(
+    userId: string,
+    envelopeId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/legal/docusign-envelope-status/${envelopeId}?user_id=${userId}`;
+
+    try {
+        const response = await axios.get(endpoint);
+        return handlePythonApiResponse(response, 'getDocusignEnvelopeStatus');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'getDocusignEnvelopeStatus');
+    }
+}
+
+export async function createTrelloCardFromDocusignEnvelope(
+    userId: string,
+    envelopeId: string,
+    trelloListId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/legal/create-trello-card-from-docusign-envelope`;
+
+    try {
+        const response = await axios.post(endpoint, {
+            user_id: userId,
+            envelope_id: envelopeId,
+            trello_list_id: trelloListId,
+        });
+        return handlePythonApiResponse(response, 'createTrelloCardFromDocusignEnvelope');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'createTrelloCardFromDocusignEnvelope');
+    }
+}

--- a/src/skills/recruitingManagerSkills.ts
+++ b/src/skills/recruitingManagerSkills.ts
@@ -1,0 +1,98 @@
+import axios, { AxiosError } from 'axios';
+import {
+  SkillResponse,
+} from '../../atomic-docker/project/functions/atom-agent/types'; // Adjust path
+import { PYTHON_API_SERVICE_BASE_URL } from '../../atomic-docker/project/functions/atom-agent/_libs/constants';
+import { logger } from '../../atomic-docker/project/functions/_utils/logger';
+
+// Helper to handle Python API responses, can be centralized later
+function handlePythonApiResponse<T>(
+  response: any, // Adjust type as per actual Python API response structure
+  operationName: string
+): SkillResponse<T> {
+  if (response.data && response.data.ok && response.data.data) {
+    return { ok: true, data: response.data.data };
+  }
+  logger.warn(`[${operationName}] Failed API call.`, response.data?.error);
+  return {
+    ok: false,
+    error: {
+      code: response.data?.error?.code || 'PYTHON_API_ERROR',
+      message: response.data?.error?.message || `Failed to ${operationName}.`,
+      details: response.data?.error?.details,
+    },
+  };
+}
+
+// Helper to handle network/axios errors
+function handleAxiosError(error: AxiosError, operationName: string): SkillResponse<null> {
+    if (error.response) {
+      logger.error(`[${operationName}] Error: ${error.response.status}`, error.response.data);
+      const errData = error.response.data as any;
+      return { ok: false, error: { code: `HTTP_${error.response.status}`, message: errData?.error?.message || `Failed to ${operationName}.` } };
+    } else if (error.request) {
+      logger.error(`[${operationName}] Error: No response received`, error.request);
+      return { ok: false, error: { code: 'NETWORK_ERROR', message: `No response received for ${operationName}.` } };
+    }
+    logger.error(`[${operationName}] Error: ${error.message}`);
+    return { ok: false, error: { code: 'REQUEST_SETUP_ERROR', message: `Error setting up request for ${operationName}: ${error.message}` } };
+}
+
+export async function createGreenhouseCandidateFromLinkedInProfile(
+  userId: string,
+  linkedInProfileUrl: string
+): Promise<SkillResponse<any>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+  }
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/recruiting/create-greenhouse-candidate-from-linkedin-profile`;
+
+  try {
+    const response = await axios.post(endpoint, {
+      user_id: userId,
+      linkedin_profile_url: linkedInProfileUrl,
+    });
+    return handlePythonApiResponse(response, 'createGreenhouseCandidateFromLinkedInProfile');
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'createGreenhouseCandidateFromLinkedInProfile');
+  }
+}
+
+export async function getGreenhouseCandidateSummary(
+    userId: string,
+    candidateId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/recruiting/greenhouse-candidate-summary/${candidateId}?user_id=${userId}`;
+
+    try {
+        const response = await axios.get(endpoint);
+        return handlePythonApiResponse(response, 'getGreenhouseCandidateSummary');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'getGreenhouseCandidateSummary');
+    }
+}
+
+export async function createTrelloCardFromGreenhouseCandidate(
+    userId: string,
+    candidateId: string,
+    trelloListId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/recruiting/create-trello-card-from-greenhouse-candidate`;
+
+    try {
+        const response = await axios.post(endpoint, {
+            user_id: userId,
+            candidate_id: candidateId,
+            trello_list_id: trelloListId,
+        });
+        return handlePythonApiResponse(response, 'createTrelloCardFromGreenhouseCandidate');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'createTrelloCardFromGreenhouseCandidate');
+    }
+}


### PR DESCRIPTION
This commit adds three new use cases to Atom, which combine multiple integrations to create powerful workflows.

Recruiting Manager:
- Create a new Greenhouse candidate from a LinkedIn profile.
- Get a summary of a candidate's profile from Greenhouse.
- Create a new Trello card for each new Greenhouse candidate.

Legal:
- Create a new Docusign envelope from a Salesforce opportunity.
- Get the status of a Docusign envelope.
- Create a new Trello card for each new Docusign envelope.

IT Manager:
- Create a new Jira issue from a Salesforce case.
- Get a summary of a Jira issue.
- Create a new Trello card for each new Jira issue.