### PR TITLE
feat: Integrate MeiliSearch into the ingestion pipeline

### DIFF
--- a/atomic-docker/python-api/ingestion_pipeline/meilisearch_handler.py
+++ b/atomic-docker/python-api/ingestion_pipeline/meilisearch_handler.py
@@ -64,13 +64,13 @@ async def get_or_create_index(index_name: str, primary_key: Optional[str] = None
         logger.error(f"Error getting or creating index '{index_name}': {e}", exc_info=True)
         return None
 
-async def add_documents_to_index(index_name: str, documents: List[Dict[str, Any]], primary_key_on_add: Optional[str] = None) -> Dict[str, Any]:
+async def add_documents_to_index(index_name: str, documents: List[Dict[str, Any]], primary_key: Optional[str] = None) -> Dict[str, Any]:
     """
     Adds a list of documents to the specified index.
-    'primary_key_on_add' can be specified if adding docs to a new index where Meili should infer it,
+    'primary_key' can be specified if adding docs to a new index where Meili should infer it,
     or if you want to ensure it during the add operation (though usually set at index creation).
     """
-    index = await get_or_create_index(index_name, primary_key=primary_key_on_add if not primary_key_on_add else None) # Only pass pk if index might be new
+    index = await get_or_create_index(index_name, primary_key=primary_key)
     if not index:
         return {"status": "error", "message": f"Failed to get or create index '{index_name}'."}
 
@@ -80,7 +80,7 @@ async def add_documents_to_index(index_name: str, documents: List[Dict[str, Any]
 
     try:
         logger.info(f"Adding {len(documents)} documents to index '{index_name}'. First doc keys: {documents[0].keys() if documents else 'N/A'}")
-        task_info = index.add_documents(documents, primary_key=primary_key_on_add)
+        task_info = index.add_documents(documents, primary_key=primary_key)
         # Asynchronous operation, client can wait for task completion
         # For critical ops, waiting is good. For bulk, maybe not always.
         client = get_meilisearch_client()

--- a/atomic-docker/python-api/ingestion_pipeline/pipeline_orchestrator.py
+++ b/atomic-docker/python-api/ingestion_pipeline/pipeline_orchestrator.py
@@ -18,6 +18,7 @@ try:
         TABLE_NAME as lancedb_default_table_name, # Use the default table name from handler
         TranscriptChunk # Schema for type checking if needed, though not directly used here
     )
+    from .meilisearch_handler import add_documents_to_index
 except ImportError: # Fallback for direct script execution if . is not recognized
     from notion_extractor import extract_structured_data_from_db, get_notion_client as get_notion_ext_client
     from gdrive_extractor import extract_data_from_gdrive
@@ -29,6 +30,7 @@ except ImportError: # Fallback for direct script execution if . is not recognize
         TABLE_NAME as lancedb_default_table_name,
         TranscriptChunk
     )
+    from meilisearch_handler import add_documents_to_index
 
 
 # Configure logging
@@ -222,6 +224,14 @@ async def run_ingestion_pipeline():
             logger.error(f"Failed to store embeddings for item: '{item_title}' (ID: {item_id}) in LanceDB.")
             failed_pages_count += 1
 
+    # Add all documents to MeiliSearch
+    if all_data:
+        logger.info("Adding all documents to MeiliSearch.")
+        # Determine primary key, assuming 'document_id' or 'notion_page_id'
+        primary_key = "document_id" if "document_id" in all_data[0] else "notion_page_id"
+        await add_documents_to_index("documents", all_data, primary_key=primary_key)
+
+
     logger.info(f"Ingestion pipeline finished. Successfully processed items: {processed_pages_count}. Skipped/up-to-date items: {skipped_pages_count}. Failed items: {failed_pages_count}.")
 
 
@@ -243,7 +253,7 @@ async def main():
         logger.info("python-dotenv not installed, .env file will not be loaded. Relying on external environment variables.")
 
     # Check for required environment variables before running
-    required_vars = ["OPENAI_API_KEY", "LANCEDB_URI"]
+    required_vars = ["OPENAI_API_KEY", "LANCEDB_URI", "MEILI_MASTER_KEY"]
     if os.getenv("NOTION_API_KEY"):
         required_vars.append("NOTION_TRANSCRIPTS_DATABASE_ID")
 


### PR DESCRIPTION
This commit integrates MeiliSearch into the ingestion pipeline, allowing all ingested documents to be indexed and made searchable.

- Updates `meilisearch_handler.py` to be more flexible with primary keys.
- Updates `pipeline_orchestrator.py` to call the MeiliSearch handler and index all documents.
- Adds environment variable checks for `MEILI_MASTER_KEY`.