### PR TITLE
feat: Add file type handling to the ingestion pipeline

### DIFF
--- a/atomic-docker/python-api/ingestion_pipeline/gdrive_extractor.py
+++ b/atomic-docker/python-api/ingestion_pipeline/gdrive_extractor.py
@@ -1,26 +1,74 @@
 import os
 import logging
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Any
+import io
+from googleapiclient.discovery import build
+from google.oauth2.credentials import Credentials
+import docx
+import PyPDF2
 
 # Configure logging
 logger = logging.getLogger(__name__)
 if not logger.hasHandlers():
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-# Mock functions for now
-async def extract_data_from_gdrive(user_id: str) -> List[Dict[str, Any]]:
+def get_gdrive_service(credentials: Credentials):
+    return build('drive', 'v3', credentials=credentials)
+
+def extract_text_from_docx(content: bytes) -> str:
+    doc = docx.Document(io.BytesIO(content))
+    return "\n".join([paragraph.text for paragraph in doc.paragraphs])
+
+def extract_text_from_pdf(content: bytes) -> str:
+    reader = PyPDF2.PdfReader(io.BytesIO(content))
+    text = []
+    for page in reader.pages:
+        text.append(page.extract_text())
+    return "\n".join(text)
+
+async def extract_data_from_gdrive(user_id: str, credentials_json: str) -> List[Dict[str, Any]]:
     logger.info(f"Extracting data from Google Drive for user {user_id}")
-    # In a real implementation, this would use the Google Drive API
-    # to find relevant files, download them, and extract their content.
-    return [
-        {
-            "source": "gdrive",
-            "document_id": "gdrive_doc_123",
-            "document_title": "Project Proposal",
-            "full_text": "This is the content of the project proposal document from Google Drive.",
-            "user_id": user_id,
-            "created_at": "2023-01-10T10:00:00Z",
-            "last_edited_at": "2023-01-11T12:00:00Z",
-            "url": "https://docs.google.com/document/d/gdrive_doc_123"
-        }
-    ]
+    credentials = Credentials.from_authorized_user_info(info=json.loads(credentials_json))
+    service = get_gdrive_service(credentials)
+
+    extracted_data = []
+
+    results = service.files().list(pageSize=10, fields="nextPageToken, files(id, name, mimeType, createdTime, modifiedTime, webViewLink)").execute()
+    items = results.get('files', [])
+
+    for item in items:
+        file_id = item['id']
+        file_name = item['name']
+        mime_type = item['mimeType']
+        text = ""
+        try:
+            if mime_type == 'application/vnd.google-apps.document':
+                request = service.files().export_media(fileId=file_id, mimeType='application/vnd.openxmlformats-officedocument.wordprocessingml.document')
+                content = request.execute()
+                text = extract_text_from_docx(content)
+            elif mime_type == 'application/pdf':
+                request = service.files().get_media(fileId=file_id)
+                content = request.execute()
+                text = extract_text_from_pdf(content)
+            elif mime_type == 'text/plain':
+                request = service.files().get_media(fileId=file_id)
+                content = request.execute()
+                text = content.decode('utf-8')
+            else:
+                logger.warning(f"Unsupported MIME type: {mime_type}. Skipping file: {file_name}")
+                continue
+
+            extracted_data.append({
+                "source": "gdrive",
+                "document_id": f"gdrive_{file_id}",
+                "document_title": file_name,
+                "full_text": text,
+                "user_id": user_id,
+                "created_at": item['createdTime'],
+                "last_edited_at": item['modifiedTime'],
+                "url": item['webViewLink']
+            })
+        except Exception as e:
+            logger.error(f"Error processing file {file_name} from Google Drive: {e}")
+
+    return extracted_data

--- a/atomic-docker/python-api/ingestion_pipeline/local_storage_extractor.py
+++ b/atomic-docker/python-api/ingestion_pipeline/local_storage_extractor.py
@@ -1,26 +1,64 @@
 import os
 import logging
 from typing import List, Dict, Any
+import docx
+import PyPDF2
+from datetime import datetime, timezone
 
 # Configure logging
 logger = logging.getLogger(__name__)
 if not logger.hasHandlers():
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-# Mock functions for now
+def extract_text_from_docx(file_path: str) -> str:
+    doc = docx.Document(file_path)
+    return "\n".join([paragraph.text for paragraph in doc.paragraphs])
+
+def extract_text_from_pdf(file_path: str) -> str:
+    with open(file_path, 'rb') as f:
+        reader = PyPDF2.PdfReader(f)
+        text = []
+        for page in reader.pages:
+            text.append(page.extract_text())
+        return "\n".join(text)
+
+def extract_text_from_txt(file_path: str) -> str:
+    with open(file_path, 'r') as f:
+        return f.read()
+
 async def extract_data_from_local_storage(user_id: str, path: str) -> List[Dict[str, Any]]:
     logger.info(f"Extracting data from local storage for user {user_id} at path {path}")
-    # In a real implementation, this would scan the local path for files,
-    # read them, and extract their content.
-    return [
-        {
-            "source": "local_storage",
-            "document_id": "local_file_abc",
-            "document_title": "My Local Document",
-            "full_text": "This is a document stored on the local file system.",
-            "user_id": user_id,
-            "created_at": "2023-02-15T09:00:00Z",
-            "last_edited_at": "2023-02-15T09:00:00Z",
-            "url": f"file://{path}/my_local_document.txt"
-        }
-    ]
+    extracted_data = []
+    for root, _, files in os.walk(path):
+        for file in files:
+            file_path = os.path.join(root, file)
+            file_ext = os.path.splitext(file)[1].lower()
+            text = ""
+            try:
+                if file_ext == '.docx':
+                    text = extract_text_from_docx(file_path)
+                elif file_ext == '.pdf':
+                    text = extract_text_from_pdf(file_path)
+                elif file_ext == '.txt':
+                    text = extract_text_from_txt(file_path)
+                else:
+                    logger.warning(f"Unsupported file type: {file_ext}. Skipping file: {file_path}")
+                    continue
+
+                stat = os.stat(file_path)
+                created_at = datetime.fromtimestamp(stat.st_ctime, tz=timezone.utc).isoformat()
+                last_edited_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+
+                extracted_data.append({
+                    "source": "local_storage",
+                    "document_id": f"local_{stat.st_ino}",
+                    "document_title": file,
+                    "full_text": text,
+                    "user_id": user_id,
+                    "created_at": created_at,
+                    "last_edited_at": last_edited_at,
+                    "url": f"file://{file_path}"
+                })
+            except Exception as e:
+                logger.error(f"Error processing file {file_path}: {e}")
+    return extracted_data

--- a/atomic-docker/python-api/ingestion_pipeline/pipeline_orchestrator.py
+++ b/atomic-docker/python-api/ingestion_pipeline/pipeline_orchestrator.py
@@ -136,8 +136,10 @@ async def run_ingestion_pipeline():
             logger.error("Notion client not initialized. Skipping Notion data extraction.")
 
     # Google Drive
-    gdrive_data = await extract_data_from_gdrive(ATOM_USER_ID_FOR_INGESTION)
-    all_data.extend(gdrive_data)
+    gdrive_credentials = os.getenv("GDRIVE_CREDENTIALS")
+    if gdrive_credentials:
+        gdrive_data = await extract_data_from_gdrive(ATOM_USER_ID_FOR_INGESTION, gdrive_credentials)
+        all_data.extend(gdrive_data)
 
     # Local Storage
     local_storage_path = os.getenv("LOCAL_STORAGE_PATH")

--- a/atomic-docker/python-api/ingestion_pipeline/requirements.txt
+++ b/atomic-docker/python-api/ingestion_pipeline/requirements.txt
@@ -17,9 +17,12 @@ meilisearch>=0.36.0,<1.0.0
 
 # For Cloud Integrations
 dropbox>=11.36.0
+google-api-python-client
+google-auth-oauthlib
 
 # For HTML/DOCX parsing
 python-docx>=0.8.11
+PyPDF2
 beautifulsoup4>=4.12.0
 lxml>=4.9.0
 


### PR DESCRIPTION
This commit adds the ability to handle different file types (.docx, .pdf, .txt) in the ingestion pipeline.

- Updates `local_storage_extractor.py` to identify file types and extract text accordingly.
- Updates `gdrive_extractor.py` to handle different MIME types and extract text accordingly.
- Updates `requirements.txt` to include new dependencies for file parsing.
- Updates `pipeline_orchestrator.py` to handle the new data structures.