### PR TITLE
feat: Allow atom agent to schedule activation of skills via tasks

### DIFF
--- a/atomic-docker/project/functions/atom-agent/handler.ts
+++ b/atomic-docker/project/functions/atom-agent/handler.ts
@@ -163,7 +163,8 @@ import {
     NLUScheduleTeamMeetingEntities,
     SchedulingResponse,
     ScheduleTaskParams, // Added for scheduleTask
-    scheduleTask // Added for scheduleTask
+    scheduleTask, // Added for scheduleTask
+    handleScheduleSkillActivation
 } from './skills/schedulingSkills';
 import { understandMessage } from './skills/nluService';
 import {
@@ -1297,6 +1298,20 @@ async function _internalHandleMessage(
         break;
 
     // START_IN_PERSON_AUDIO_NOTE and related intents will be handled here
+      case "ScheduleSkillActivation":
+        try {
+            const scheduleEntities = nluResponse.entities as import('../types').ScheduleSkillActivationEntities;
+            if (!scheduleEntities.skill_to_schedule || !scheduleEntities.activation_time) {
+                textResponse = "To schedule a skill, please provide the skill name and the activation time.";
+            } else {
+                textResponse = await handleScheduleSkillActivation(userId, scheduleEntities);
+            }
+        } catch (error: any) {
+            console.error(`[Handler][${interfaceType}] Error in NLU Intent "ScheduleSkillActivation":`, error.message, error.stack);
+            textResponse = "Sorry, an unexpected error occurred while scheduling the skill.";
+        }
+        break;
+
       case "START_IN_PERSON_AUDIO_NOTE":
       case "STOP_IN_PERSON_AUDIO_NOTE":
       case "CANCEL_IN_PERSON_AUDIO_NOTE":

--- a/atomic-docker/project/functions/atom-agent/skills/nluService.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/nluService.ts
@@ -445,6 +445,39 @@ New Intent for Scheduling from Email Content:
               "target_task_list_or_project": "Support Tickets"
             }
           }
+
+39. Intent: "ScheduleSkillActivation"
+    - Purpose: To schedule a skill to be activated at a later time.
+    - Entities:
+        - "skill_to_schedule": {
+            "description": "The name of the skill to schedule.",
+            "type": "string",
+            "required": true
+        },
+        - "activation_time": {
+            "description": "The time at which to activate the skill.",
+            "type": "string",
+            "required": true
+        },
+        - "skill_entities": {
+            "description": "The entities to pass to the skill when it is activated.",
+            "type": "object",
+            "optional": true
+        }
+    - Examples:
+        - User: "Schedule the SendEmail skill to run tomorrow at 9am with entities {'to': 'test@example.com', 'subject': 'Test', 'body': 'This is a test'}."
+          Response: {
+            "intent": "ScheduleSkillActivation",
+            "entities": {
+              "skill_to_schedule": "SendEmail",
+              "activation_time": "tomorrow at 9am",
+              "skill_entities": {
+                "to": "test@example.com",
+                "subject": "Test",
+                "body": "This is a test"
+              }
+            }
+          }
         - User: "Make a task from Bob's Teams message: https://teams.microsoft.com/l/message/channel_id/message_id. Call it 'Review proposal' and assign it to me for tomorrow."
           Response: {
             "intent": "CreateTaskFromChatMessage",

--- a/atomic-docker/project/functions/atom-agent/skills/scheduleSkillActivation.test.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/scheduleSkillActivation.test.ts
@@ -1,0 +1,28 @@
+import { handleScheduleSkillActivation } from './schedulingSkills';
+import { scheduleTask } from './schedulingSkills';
+
+jest.mock('@/agendaService', () => ({
+    agenda: {
+        schedule: jest.fn(),
+        every: jest.fn(),
+    },
+}));
+
+describe('handleScheduleSkillActivation', () => {
+    it('should call scheduleTask with the correct parameters', async () => {
+        const userId = 'test-user';
+        const entities = {
+            skill_to_schedule: 'SendEmail',
+            activation_time: 'tomorrow at 9am',
+            skill_entities: {
+                to: 'test@example.com',
+                subject: 'Test',
+                body: 'This is a test',
+            },
+        };
+
+        const result = await handleScheduleSkillActivation(userId, entities);
+
+        expect(result).toEqual('Task "SendEmail" has been scheduled for tomorrow at 9am.');
+    });
+});

--- a/atomic-docker/project/functions/atom-agent/skills/schedulingSkills.ts
+++ b/atomic-docker/project/functions/atom-agent/skills/schedulingSkills.ts
@@ -1,4 +1,4 @@
-import { agenda, ScheduledAgentTaskData } from '../../../agendaService'; // Adjusted path
+import { agenda, ScheduledAgentTaskData } from '@/agendaService'; // Adjusted path
 
 // New ScheduleTaskParams interface for Agenda-based scheduling
 export interface ScheduleTaskParams {
@@ -247,6 +247,23 @@ export async function getUsersAvailability(
 
 // TODO: Implement these functions based on NLU intents if they are still needed
 // For now, they are placeholders as the primary focus is on the new email scheduling flow.
+export async function handleScheduleSkillActivation(userId: string, entities: any): Promise<string> {
+    const { skill_to_schedule, activation_time, skill_entities } = entities;
+
+    if (!skill_to_schedule || !activation_time) {
+        return "I need to know which skill to schedule and when to schedule it.";
+    }
+
+    const params: ScheduleTaskParams = {
+        when: activation_time,
+        originalUserIntent: skill_to_schedule,
+        entities: skill_entities,
+        userId: userId,
+    };
+
+    return scheduleTask(params);
+}
+
 export async function createSchedulingRule(userId: string, ruleDetails: NLUCreateTimePreferenceRuleEntities): Promise<SchedulingResponse> {
     console.log("createSchedulingRule called with:", userId, ruleDetails);
     // Placeholder

--- a/atomic-docker/project/functions/atom-agent/types.ts
+++ b/atomic-docker/project/functions/atom-agent/types.ts
@@ -1445,3 +1445,10 @@ export interface Tweet {
   };
   created_at: string;
 }
+
+// --- Schedule Skill Activation Types ---
+export interface ScheduleSkillActivationEntities {
+    skill_to_schedule: string;
+    activation_time: string;
+    skill_entities: Record<string, any>;
+}

--- a/atomic-docker/project/functions/jest.config.cjs
+++ b/atomic-docker/project/functions/jest.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+    '^@utils/(.*)$': '<rootDir>/_utils/$1'
+  }
+};

--- a/atomic-docker/project/functions/package.json
+++ b/atomic-docker/project/functions/package.json
@@ -83,5 +83,10 @@
     "pnpm": "^7.32.4",
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/atomic-docker/project/functions/ses-notification-lambda/package.json
+++ b/atomic-docker/project/functions/ses-notification-lambda/package.json
@@ -1,11 +1,8 @@
 {
   "name": "ses-notification-lambda",
   "version": "1.0.0",
-  "description": "AWS Lambda function to send scheduling result notifications via SES, triggered by Hasura.",
-  "name": "ses-notification-lambda",
-  "version": "1.0.0",
   "description": "AWS Lambda function to send scheduling result notifications via SES, triggered by Hasura and managed by Serverless Framework.",
-  "main": ".esbuild/.build/src/index.js", // Default output for serverless-esbuild, or adjust
+  "main": ".esbuild/.build/src/index.js",
   "scripts": {
     "clean": "rm -rf .esbuild .serverless dist deployment-package.zip",
     "build:local": "esbuild src/index.ts --bundle --minify --sourcemap --platform=node --target=node18 --outfile=dist/local-build/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3751,6 +3751,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4127,6 +4128,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }


### PR DESCRIPTION
This change introduces the ability for the Atom agent to schedule the activation of skills via tasks.

A new `ScheduleSkillActivation` intent has been created, which can be used to schedule the activation of other skills. This intent has entities for the `skill_to_schedule`, `activation_time`, and `skill_entities`.

A new `handleScheduleSkillActivation` function has been created in `schedulingSkills.ts` to handle this intent. This function is responsible for creating the `agenda` job.

The `handler.ts` file has been updated to call the `handleScheduleSkillActivation` function when the `ScheduleSkillActivation` intent is detected.

The `types.ts` file has been updated to include the new intent and entities.

A new test file has been created to test the `ScheduleSkillActivation` intent.