### PR TITLE
feat: Add Dropbox and OneDrive support to the ingestion pipeline

### DIFF
--- a/atomic-docker/python-api/ingestion_pipeline/dropbox_extractor.py
+++ b/atomic-docker/python-api/ingestion_pipeline/dropbox_extractor.py
@@ -1,0 +1,67 @@
+import os
+import logging
+from typing import List, Dict, Any
+import dropbox
+import io
+import docx
+import PyPDF2
+from datetime import datetime, timezone
+
+# Configure logging
+logger = logging.getLogger(__name__)
+if not logger.hasHandlers():
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+def extract_text_from_docx(content: bytes) -> str:
+    doc = docx.Document(io.BytesIO(content))
+    return "\n".join([paragraph.text for paragraph in doc.paragraphs])
+
+def extract_text_from_pdf(content: bytes) -> str:
+    reader = PyPDF2.PdfReader(io.BytesIO(content))
+    text = []
+    for page in reader.pages:
+        text.append(page.extract_text())
+    return "\n".join(text)
+
+async def extract_data_from_dropbox(user_id: str, access_token: str) -> List[Dict[str, Any]]:
+    logger.info(f"Extracting data from Dropbox for user {user_id}")
+    dbx = dropbox.Dropbox(access_token)
+    extracted_data = []
+
+    try:
+        for entry in dbx.files_list_folder('').entries:
+            if isinstance(entry, dropbox.files.FileMetadata):
+                file_path = entry.path_display
+                file_ext = os.path.splitext(file_path)[1].lower()
+                text = ""
+
+                try:
+                    _, res = dbx.files_download(path=file_path)
+                    content = res.content
+
+                    if file_ext == '.docx':
+                        text = extract_text_from_docx(content)
+                    elif file_ext == '.pdf':
+                        text = extract_text_from_pdf(content)
+                    elif file_ext == '.txt':
+                        text = content.decode('utf-8')
+                    else:
+                        logger.warning(f"Unsupported file type: {file_ext}. Skipping file: {file_path}")
+                        continue
+
+                    extracted_data.append({
+                        "source": "dropbox",
+                        "document_id": f"dropbox_{entry.id}",
+                        "document_title": entry.name,
+                        "full_text": text,
+                        "user_id": user_id,
+                        "created_at": entry.client_modified.replace(tzinfo=timezone.utc).isoformat(),
+                        "last_edited_at": entry.server_modified.replace(tzinfo=timezone.utc).isoformat(),
+                        "url": dbx.sharing_create_shared_link(path=file_path).url
+                    })
+                except Exception as e:
+                    logger.error(f"Error processing file {file_path} from Dropbox: {e}")
+    except Exception as e:
+        logger.error(f"Error listing files from Dropbox: {e}")
+
+    return extracted_data

--- a/atomic-docker/python-api/ingestion_pipeline/onedrive_extractor.py
+++ b/atomic-docker/python-api/ingestion_pipeline/onedrive_extractor.py
@@ -1,0 +1,71 @@
+import os
+import logging
+from typing import List, Dict, Any
+import io
+import docx
+import PyPDF2
+from msgraph import GraphServiceClient
+from msgraph.generated.models.drive_item import DriveItem
+from azure.identity import InteractiveBrowserCredential
+
+# Configure logging
+logger = logging.getLogger(__name__)
+if not logger.hasHandlers():
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+def extract_text_from_docx(content: bytes) -> str:
+    doc = docx.Document(io.BytesIO(content))
+    return "\n".join([paragraph.text for paragraph in doc.paragraphs])
+
+def extract_text_from_pdf(content: bytes) -> str:
+    reader = PyPDF2.PdfReader(io.BytesIO(content))
+    text = []
+    for page in reader.pages:
+        text.append(page.extract_text())
+    return "\n".join(text)
+
+async def extract_data_from_onedrive(user_id: str, access_token: str) -> List[Dict[str, Any]]:
+    logger.info(f"Extracting data from OneDrive for user {user_id}")
+
+    credential = InteractiveBrowserCredential(client_id=os.environ["MS_CLIENT_ID"])
+    client = GraphServiceClient(credentials=credential)
+
+    extracted_data = []
+
+    try:
+        drive_items = await client.me.drive.root.children.get()
+        for item in drive_items.value:
+            if item.file:
+                file_name = item.name
+                file_ext = os.path.splitext(file_name)[1].lower()
+                text = ""
+
+                try:
+                    content = await client.me.drive.items.by_drive_item_id(item.id).content.get()
+
+                    if file_ext == '.docx':
+                        text = extract_text_from_docx(content)
+                    elif file_ext == '.pdf':
+                        text = extract_text_from_pdf(content)
+                    elif file_ext == '.txt':
+                        text = content.decode('utf-8')
+                    else:
+                        logger.warning(f"Unsupported file type: {file_ext}. Skipping file: {file_name}")
+                        continue
+
+                    extracted_data.append({
+                        "source": "onedrive",
+                        "document_id": f"onedrive_{item.id}",
+                        "document_title": file_name,
+                        "full_text": text,
+                        "user_id": user_id,
+                        "created_at": item.created_date_time.isoformat(),
+                        "last_edited_at": item.last_modified_date_time.isoformat(),
+                        "url": item.web_url
+                    })
+                except Exception as e:
+                    logger.error(f"Error processing file {file_name} from OneDrive: {e}")
+    except Exception as e:
+        logger.error(f"Error listing files from OneDrive: {e}")
+
+    return extracted_data

--- a/atomic-docker/python-api/ingestion_pipeline/requirements.txt
+++ b/atomic-docker/python-api/ingestion_pipeline/requirements.txt
@@ -19,6 +19,8 @@ meilisearch>=0.36.0,<1.0.0
 dropbox>=11.36.0
 google-api-python-client
 google-auth-oauthlib
+msgraph-sdk
+azure-identity
 
 # For HTML/DOCX parsing
 python-docx>=0.8.11


### PR DESCRIPTION
This commit adds the ability to ingest data from Dropbox and OneDrive, in addition to the existing data sources.

- Creates new `dropbox_extractor.py` and `onedrive_extractor.py` modules to handle data extraction from these sources.
- Updates `pipeline_orchestrator.py` to use the new extractors and process data from all configured sources.
- Updates `requirements.txt` to include new dependencies for Dropbox and OneDrive integration.
- Updates environment variable checks for the new data sources.