### PR TITLE
feat: Add DevOps, HR, and Content Marketer use cases

### DIFF
--- a/atomic-docker/project/functions/python_api_service/bamboohr_service.py
+++ b/atomic-docker/project/functions/python_api_service/bamboohr_service.py
@@ -1,0 +1,32 @@
+import os
+import logging
+from typing import Optional, Dict, Any
+from pybamboohr import PyBambooHR
+
+logger = logging.getLogger(__name__)
+
+async def get_bamboohr_client(user_id: str, db_conn_pool) -> Optional[PyBambooHR]:
+    # This is a placeholder. In a real application, you would fetch the user's BambooHR credentials
+    # from a secure database. For now, we'll use environment variables.
+    # You'll need to create a table to store these credentials, similar to the Dropbox and Google Drive implementations.
+    subdomain = os.environ.get("BAMBOOHR_SUBDOMAIN")
+    api_key = os.environ.get("BAMBOOHR_API_KEY")
+
+    if not all([subdomain, api_key]):
+        logger.error("BambooHR credentials are not configured in environment variables.")
+        return None
+
+    try:
+        client = PyBambooHR(subdomain=subdomain, api_key=api_key)
+        return client
+    except Exception as e:
+        logger.error(f"Failed to create BambooHR client: {e}", exc_info=True)
+        return None
+
+async def create_employee(client: PyBambooHR, employee_data: Dict[str, Any]) -> Dict[str, Any]:
+    employee = client.add_employee(employee_data)
+    return employee
+
+async def get_employee(client: PyBambooHR, employee_id: str) -> Dict[str, Any]:
+    employee = client.get_employee(employee_id)
+    return employee

--- a/atomic-docker/project/functions/python_api_service/content_marketer_handler.py
+++ b/atomic-docker/project/functions/python_api_service/content_marketer_handler.py
@@ -1,0 +1,63 @@
+import logging
+from flask import Blueprint, request, jsonify, current_app
+from . import content_marketer_service
+
+logger = logging.getLogger(__name__)
+
+content_marketer_bp = Blueprint('content_marketer_bp', __name__)
+
+@content_marketer_bp.route('/api/content/create-wordpress-post-from-google-drive-document', methods=['POST'])
+async def create_wordpress_post_from_google_drive_document():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    google_drive_document_id = data.get('google_drive_document_id')
+    if not all([user_id, google_drive_document_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id and google_drive_document_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await content_marketer_service.create_wordpress_post_from_google_drive_document(user_id, google_drive_document_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating WordPress post from Google Drive document for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "POST_CREATE_FAILED", "message": str(e)}}), 500
+
+@content_marketer_bp.route('/api/content/wordpress-post-summary/<post_id>', methods=['GET'])
+async def get_wordpress_post_summary(post_id):
+    user_id = request.args.get('user_id')
+    if not user_id:
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id is required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await content_marketer_service.get_wordpress_post_summary(user_id, post_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error getting WordPress post summary for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "SUMMARY_FETCH_FAILED", "message": str(e)}}), 500
+
+@content_marketer_bp.route('/api/content/create-trello-card-from-wordpress-post', methods=['POST'])
+async def create_trello_card_from_wordpress_post():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    post_id = data.get('post_id')
+    trello_list_id = data.get('trello_list_id')
+    if not all([user_id, post_id, trello_list_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id, post_id, and trello_list_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await content_marketer_service.create_trello_card_from_wordpress_post(user_id, post_id, trello_list_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating Trello card from WordPress post for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "CARD_CREATE_FAILED", "message": str(e)}}), 500

--- a/atomic-docker/project/functions/python_api_service/content_marketer_service.py
+++ b/atomic-docker/project/functions/python_api_service/content_marketer_service.py
@@ -1,0 +1,60 @@
+import logging
+from . import gdrive_service
+from . import wordpress_service # We need to create this
+from . import trello_service
+
+logger = logging.getLogger(__name__)
+
+async def create_wordpress_post_from_google_drive_document(user_id: str, google_drive_document_id: str, db_conn_pool):
+    """
+    Creates a WordPress post from a Google Drive document.
+    """
+    gdrive_creds = await gdrive_service.get_gdrive_credentials(user_id, db_conn_pool)
+    if not gdrive_creds:
+        raise Exception("Could not get authenticated Google Drive client.")
+
+    file_content, metadata = await gdrive_service.download_file(gdrive_creds, google_drive_document_id)
+
+    wordpress_client = await wordpress_service.get_wordpress_client(user_id, db_conn_pool)
+    if not wordpress_client:
+        raise Exception("Could not get authenticated WordPress client.")
+
+    post_data = {
+        "title": metadata['name'],
+        "content": file_content.decode('utf-8'),
+        "status": "draft"
+    }
+
+    post = await wordpress_service.create_post(wordpress_client, post_data)
+    return post
+
+async def get_wordpress_post_summary(user_id: str, post_id: str, db_conn_pool):
+    """
+    Gets a summary of a WordPress post.
+    """
+    wordpress_client = await wordpress_service.get_wordpress_client(user_id, db_conn_pool)
+    if not wordpress_client:
+        raise Exception("Could not get authenticated WordPress client.")
+
+    post = await wordpress_service.get_post(wordpress_client, post_id)
+    return post
+
+async def create_trello_card_from_wordpress_post(user_id: str, post_id: str, trello_list_id: str, db_conn_pool):
+    """
+    Creates a Trello card for a new WordPress post.
+    """
+    wordpress_client = await wordpress_service.get_wordpress_client(user_id, db_conn_pool)
+    if not wordpress_client:
+        raise Exception("Could not get authenticated WordPress client.")
+
+    post = await wordpress_service.get_post(wordpress_client, post_id)
+
+    trello_api_key, trello_token = await trello_service.get_trello_credentials(user_id, db_conn_pool)
+    if not trello_api_key or not trello_token:
+        raise Exception("Could not get Trello credentials.")
+
+    card_name = f"New Post: {post.title}"
+    card_desc = f"**Post ID:** {post.id}\n**Link:** {post.link}"
+
+    card = await trello_service.create_card(trello_api_key, trello_token, trello_list_id, card_name, card_desc)
+    return card

--- a/atomic-docker/project/functions/python_api_service/devops_manager_handler.py
+++ b/atomic-docker/project/functions/python_api_service/devops_manager_handler.py
@@ -1,0 +1,64 @@
+import logging
+from flask import Blueprint, request, jsonify, current_app
+from . import devops_manager_service
+
+logger = logging.getLogger(__name__)
+
+devops_manager_bp = Blueprint('devops_manager_bp', __name__)
+
+@devops_manager_bp.route('/api/devops/create-github-issue-from-jira-issue', methods=['POST'])
+async def create_github_issue_from_jira_issue():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    jira_issue_id = data.get('jira_issue_id')
+    if not all([user_id, jira_issue_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id and jira_issue_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await devops_manager_service.create_github_issue_from_jira_issue(user_id, jira_issue_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating GitHub issue from Jira issue for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "ISSUE_CREATE_FAILED", "message": str(e)}}), 500
+
+@devops_manager_bp.route('/api/devops/github-pull-request-status', methods=['GET'])
+async def get_github_pull_request_status():
+    user_id = request.args.get('user_id')
+    pull_request_url = request.args.get('pull_request_url')
+    if not all([user_id, pull_request_url]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id and pull_request_url are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await devops_manager_service.get_github_pull_request_status(user_id, pull_request_url, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error getting GitHub pull request status for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "STATUS_FETCH_FAILED", "message": str(e)}}), 500
+
+@devops_manager_bp.route('/api/devops/create-trello-card-from-github-issue', methods=['POST'])
+async def create_trello_card_from_github_issue():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    issue_url = data.get('issue_url')
+    trello_list_id = data.get('trello_list_id')
+    if not all([user_id, issue_url, trello_list_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id, issue_url, and trello_list_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await devops_manager_service.create_trello_card_from_github_issue(user_id, issue_url, trello_list_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating Trello card from GitHub issue for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "CARD_CREATE_FAILED", "message": str(e)}}), 500

--- a/atomic-docker/project/functions/python_api_service/devops_manager_service.py
+++ b/atomic-docker/project/functions/python_api_service/devops_manager_service.py
@@ -1,0 +1,69 @@
+import logging
+from . import jira_service
+from . import github_service # We need to create this
+from . import trello_service
+
+logger = logging.getLogger(__name__)
+
+async def create_github_issue_from_jira_issue(user_id: str, jira_issue_id: str, db_conn_pool):
+    """
+    Creates a GitHub issue from a Jira issue.
+    """
+    jira_client = await jira_service.get_jira_client(user_id, db_conn_pool)
+    if not jira_client:
+        raise Exception("Could not get authenticated Jira client.")
+
+    jira_issue = await jira_service.get_issue(jira_client, jira_issue_id)
+
+    github_client = await github_service.get_github_client(user_id, db_conn_pool)
+    if not github_client:
+        raise Exception("Could not get authenticated GitHub client.")
+
+    repo = github_client.get_repo(os.environ.get("GITHUB_REPO")) # You'll need to get this from the user
+
+    issue_data = {
+        "title": jira_issue.fields.summary,
+        "body": jira_issue.fields.description
+    }
+
+    issue = await github_service.create_issue(repo, issue_data)
+    return issue
+
+async def get_github_pull_request_status(user_id: str, pull_request_url: str, db_conn_pool):
+    """
+    Gets the status of a GitHub pull request.
+    """
+    github_client = await github_service.get_github_client(user_id, db_conn_pool)
+    if not github_client:
+        raise Exception("Could not get authenticated GitHub client.")
+
+    repo_name = pull_request_url.split('/')[-3]
+    pr_number = int(pull_request_url.split('/')[-1])
+
+    repo = github_client.get_repo(repo_name)
+    pr = await github_service.get_pull_request(repo, pr_number)
+    return pr.state
+
+async def create_trello_card_from_github_issue(user_id: str, issue_url: str, trello_list_id: str, db_conn_pool):
+    """
+    Creates a Trello card for a new GitHub issue.
+    """
+    github_client = await github_service.get_github_client(user_id, db_conn_pool)
+    if not github_client:
+        raise Exception("Could not get authenticated GitHub client.")
+
+    repo_name = issue_url.split('/')[-3]
+    issue_number = int(issue_url.split('/')[-1])
+
+    repo = github_client.get_repo(repo_name)
+    issue = await github_service.get_issue(repo, issue_number)
+
+    trello_api_key, trello_token = await trello_service.get_trello_credentials(user_id, db_conn_pool)
+    if not trello_api_key or not trello_token:
+        raise Exception("Could not get Trello credentials.")
+
+    card_name = f"New Issue: {issue.title}"
+    card_desc = f"**Issue URL:** {issue.html_url}"
+
+    card = await trello_service.create_card(trello_api_key, trello_token, trello_list_id, card_name, card_desc)
+    return card

--- a/atomic-docker/project/functions/python_api_service/github_service.py
+++ b/atomic-docker/project/functions/python_api_service/github_service.py
@@ -1,0 +1,47 @@
+import os
+import logging
+from typing import Optional, Dict, Any
+from github import Github, GithubException
+
+logger = logging.getLogger(__name__)
+
+async def get_github_client(user_id: str, db_conn_pool) -> Optional[Github]:
+    # This is a placeholder. In a real application, you would fetch the user's GitHub credentials
+    # from a secure database. For now, we'll use environment variables.
+    # You'll need to create a table to store these credentials, similar to the Dropbox and Google Drive implementations.
+    access_token = os.environ.get("GITHUB_ACCESS_TOKEN")
+
+    if not access_token:
+        logger.error("GitHub access token is not configured in environment variables.")
+        return None
+
+    try:
+        client = Github(access_token)
+        return client
+    except Exception as e:
+        logger.error(f"Failed to create GitHub client: {e}", exc_info=True)
+        return None
+
+async def create_issue(repo, issue_data: Dict[str, Any]):
+    try:
+        issue = repo.create_issue(**issue_data)
+        return issue
+    except GithubException as e:
+        logger.error(f"Error creating GitHub issue: {e}", exc_info=True)
+        raise
+
+async def get_pull_request(repo, pr_number: int):
+    try:
+        pr = repo.get_pull(pr_number)
+        return pr
+    except GithubException as e:
+        logger.error(f"Error getting GitHub pull request: {e}", exc_info=True)
+        raise
+
+async def get_issue(repo, issue_number: int):
+    try:
+        issue = repo.get_issue(issue_number)
+        return issue
+    except GithubException as e:
+        logger.error(f"Error getting GitHub issue: {e}", exc_info=True)
+        raise

--- a/atomic-docker/project/functions/python_api_service/hr_manager_handler.py
+++ b/atomic-docker/project/functions/python_api_service/hr_manager_handler.py
@@ -1,0 +1,63 @@
+import logging
+from flask import Blueprint, request, jsonify, current_app
+from . import hr_manager_service
+
+logger = logging.getLogger(__name__)
+
+hr_manager_bp = Blueprint('hr_manager_bp', __name__)
+
+@hr_manager_bp.route('/api/hr/create-bamboohr-employee-from-greenhouse-candidate', methods=['POST'])
+async def create_bamboohr_employee_from_greenhouse_candidate():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    greenhouse_candidate_id = data.get('greenhouse_candidate_id')
+    if not all([user_id, greenhouse_candidate_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id and greenhouse_candidate_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await hr_manager_service.create_bamboohr_employee_from_greenhouse_candidate(user_id, greenhouse_candidate_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating BambooHR employee from Greenhouse candidate for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "EMPLOYEE_CREATE_FAILED", "message": str(e)}}), 500
+
+@hr_manager_bp.route('/api/hr/bamboohr-employee-summary/<employee_id>', methods=['GET'])
+async def get_bamboohr_employee_summary(employee_id):
+    user_id = request.args.get('user_id')
+    if not user_id:
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id is required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await hr_manager_service.get_bamboohr_employee_summary(user_id, employee_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error getting BambooHR employee summary for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "SUMMARY_FETCH_FAILED", "message": str(e)}}), 500
+
+@hr_manager_bp.route('/api/hr/create-trello-card-from-bamboohr-employee', methods=['POST'])
+async def create_trello_card_from_bamboohr_employee():
+    data = request.get_json()
+    user_id = data.get('user_id')
+    employee_id = data.get('employee_id')
+    trello_list_id = data.get('trello_list_id')
+    if not all([user_id, employee_id, trello_list_id]):
+        return jsonify({"ok": False, "error": {"code": "VALIDATION_ERROR", "message": "user_id, employee_id, and trello_list_id are required."}}), 400
+
+    db_conn_pool = current_app.config.get('DB_CONNECTION_POOL')
+    if not db_conn_pool:
+        return jsonify({"ok": False, "error": {"code": "CONFIG_ERROR", "message": "Database connection not available."}}), 500
+
+    try:
+        result = await hr_manager_service.create_trello_card_from_bamboohr_employee(user_id, employee_id, trello_list_id, db_conn_pool)
+        return jsonify({"ok": True, "data": result})
+    except Exception as e:
+        logger.error(f"Error creating Trello card from BambooHR employee for user {user_id}: {e}", exc_info=True)
+        return jsonify({"ok": False, "error": {"code": "CARD_CREATE_FAILED", "message": str(e)}}), 500

--- a/atomic-docker/project/functions/python_api_service/hr_manager_service.py
+++ b/atomic-docker/project/functions/python_api_service/hr_manager_service.py
@@ -1,0 +1,60 @@
+import logging
+from . import greenhouse_service
+from . import bamboohr_service # We need to create this
+from . import trello_service
+
+logger = logging.getLogger(__name__)
+
+async def create_bamboohr_employee_from_greenhouse_candidate(user_id: str, greenhouse_candidate_id: str, db_conn_pool):
+    """
+    Creates a BambooHR employee from a Greenhouse candidate.
+    """
+    greenhouse_client = await greenhouse_service.get_greenhouse_client(user_id, db_conn_pool)
+    if not greenhouse_client:
+        raise Exception("Could not get authenticated Greenhouse client.")
+
+    candidate = await greenhouse_service.get_candidate(greenhouse_client, greenhouse_candidate_id)
+
+    bamboohr_client = await bamboohr_service.get_bamboohr_client(user_id, db_conn_pool)
+    if not bamboohr_client:
+        raise Exception("Could not get authenticated BambooHR client.")
+
+    employee_data = {
+        "firstName": candidate['first_name'],
+        "lastName": candidate['last_name'],
+        "homeEmail": candidate['email_addresses'][0]['value']
+    }
+
+    employee = await bamboohr_service.create_employee(bamboohr_client, employee_data)
+    return employee
+
+async def get_bamboohr_employee_summary(user_id: str, employee_id: str, db_conn_pool):
+    """
+    Gets a summary of a BambooHR employee.
+    """
+    bamboohr_client = await bamboohr_service.get_bamboohr_client(user_id, db_conn_pool)
+    if not bamboohr_client:
+        raise Exception("Could not get authenticated BambooHR client.")
+
+    employee = await bamboohr_service.get_employee(bamboohr_client, employee_id)
+    return employee
+
+async def create_trello_card_from_bamboohr_employee(user_id: str, employee_id: str, trello_list_id: str, db_conn_pool):
+    """
+    Creates a Trello card for a new BambooHR employee.
+    """
+    bamboohr_client = await bamboohr_service.get_bamboohr_client(user_id, db_conn_pool)
+    if not bamboohr_client:
+        raise Exception("Could not get authenticated BambooHR client.")
+
+    employee = await bamboohr_service.get_employee(bamboohr_client, employee_id)
+
+    trello_api_key, trello_token = await trello_service.get_trello_credentials(user_id, db_conn_pool)
+    if not trello_api_key or not trello_token:
+        raise Exception("Could not get Trello credentials.")
+
+    card_name = f"New Employee: {employee['firstName']} {employee['lastName']}"
+    card_desc = f"**Employee ID:** {employee['id']}"
+
+    card = await trello_service.create_card(trello_api_key, trello_token, trello_list_id, card_name, card_desc)
+    return card

--- a/atomic-docker/project/functions/python_api_service/main_api_app.py
+++ b/atomic-docker/project/functions/python_api_service/main_api_app.py
@@ -28,6 +28,9 @@ from .customer_support_manager_handler import customer_support_manager_bp
 from .recruiting_manager_handler import recruiting_manager_bp
 from .legal_handler import legal_bp
 from .it_manager_handler import it_manager_bp
+from .devops_manager_handler import devops_manager_bp
+from .hr_manager_handler import hr_manager_bp
+from .content_marketer_handler import content_marketer_bp
 from .meeting_prep import meeting_prep_bp
 from .mcp_handler import mcp_bp
 
@@ -103,6 +106,12 @@ def create_app(db_pool=None):
     logger.info("Registered 'legal_bp' blueprint.")
     app.register_blueprint(it_manager_bp)
     logger.info("Registered 'it_manager_bp' blueprint.")
+    app.register_blueprint(devops_manager_bp)
+    logger.info("Registered 'devops_manager_bp' blueprint.")
+    app.register_blueprint(hr_manager_bp)
+    logger.info("Registered 'hr_manager_bp' blueprint.")
+    app.register_blueprint(content_marketer_bp)
+    logger.info("Registered 'content_marketer_bp' blueprint.")
     app.register_blueprint(mcp_bp)
     logger.info("Registered 'mcp_bp' blueprint.")
 

--- a/atomic-docker/project/functions/python_api_service/wordpress_service.py
+++ b/atomic-docker/project/functions/python_api_service/wordpress_service.py
@@ -1,0 +1,39 @@
+import os
+import logging
+from typing import Optional, Dict, Any
+from wordpress_xmlrpc import Client, WordPressPost
+from wordpress_xmlrpc.methods.posts import NewPost, GetPost
+
+logger = logging.getLogger(__name__)
+
+async def get_wordpress_client(user_id: str, db_conn_pool) -> Optional[Client]:
+    # This is a placeholder. In a real application, you would fetch the user's WordPress credentials
+    # from a secure database. For now, we'll use environment variables.
+    # You'll need to create a table to store these credentials, similar to the Dropbox and Google Drive implementations.
+    url = os.environ.get("WORDPRESS_URL")
+    username = os.environ.get("WORDPRESS_USERNAME")
+    password = os.environ.get("WORDPRESS_PASSWORD")
+
+    if not all([url, username, password]):
+        logger.error("WordPress credentials are not configured in environment variables.")
+        return None
+
+    try:
+        client = Client(url, username, password)
+        return client
+    except Exception as e:
+        logger.error(f"Failed to create WordPress client: {e}", exc_info=True)
+        return None
+
+async def create_post(client: Client, post_data: Dict[str, Any]) -> WordPressPost:
+    post = WordPressPost()
+    post.title = post_data['title']
+    post.content = post_data['content']
+    post.post_status = post_data['status']
+
+    post.id = client.call(NewPost(post))
+    return post
+
+async def get_post(client: Client, post_id: str) -> WordPressPost:
+    post = client.call(GetPost(post_id))
+    return post

--- a/atomic-docker/project/functions/requirements.txt
+++ b/atomic-docker/project/functions/requirements.txt
@@ -23,3 +23,6 @@ zenpy
 greenhouse-python
 docusign-esign
 jira
+PyGithub
+pybamboohr
+python-wordpress-xmlrpc

--- a/src/skills/contentMarketerSkills.ts
+++ b/src/skills/contentMarketerSkills.ts
@@ -1,0 +1,98 @@
+import axios, { AxiosError } from 'axios';
+import {
+  SkillResponse,
+} from '../../atomic-docker/project/functions/atom-agent/types'; // Adjust path
+import { PYTHON_API_SERVICE_BASE_URL } from '../../atomic-docker/project/functions/atom-agent/_libs/constants';
+import { logger } from '../../atomic-docker/project/functions/_utils/logger';
+
+// Helper to handle Python API responses, can be centralized later
+function handlePythonApiResponse<T>(
+  response: any, // Adjust type as per actual Python API response structure
+  operationName: string
+): SkillResponse<T> {
+  if (response.data && response.data.ok && response.data.data) {
+    return { ok: true, data: response.data.data };
+  }
+  logger.warn(`[${operationName}] Failed API call.`, response.data?.error);
+  return {
+    ok: false,
+    error: {
+      code: response.data?.error?.code || 'PYTHON_API_ERROR',
+      message: response.data?.error?.message || `Failed to ${operationName}.`,
+      details: response.data?.error?.details,
+    },
+  };
+}
+
+// Helper to handle network/axios errors
+function handleAxiosError(error: AxiosError, operationName: string): SkillResponse<null> {
+    if (error.response) {
+      logger.error(`[${operationName}] Error: ${error.response.status}`, error.response.data);
+      const errData = error.response.data as any;
+      return { ok: false, error: { code: `HTTP_${error.response.status}`, message: errData?.error?.message || `Failed to ${operationName}.` } };
+    } else if (error.request) {
+      logger.error(`[${operationName}] Error: No response received`, error.request);
+      return { ok: false, error: { code: 'NETWORK_ERROR', message: `No response received for ${operationName}.` } };
+    }
+    logger.error(`[${operationName}] Error: ${error.message}`);
+    return { ok: false, error: { code: 'REQUEST_SETUP_ERROR', message: `Error setting up request for ${operationName}: ${error.message}` } };
+}
+
+export async function createWordPressPostFromGoogleDriveDocument(
+  userId: string,
+  googleDriveDocumentId: string
+): Promise<SkillResponse<any>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+  }
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/content/create-wordpress-post-from-google-drive-document`;
+
+  try {
+    const response = await axios.post(endpoint, {
+      user_id: userId,
+      google_drive_document_id: googleDriveDocumentId,
+    });
+    return handlePythonApiResponse(response, 'createWordPressPostFromGoogleDriveDocument');
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'createWordPressPostFromGoogleDriveDocument');
+  }
+}
+
+export async function getWordPressPostSummary(
+    userId: string,
+    postId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/content/wordpress-post-summary/${postId}?user_id=${userId}`;
+
+    try {
+        const response = await axios.get(endpoint);
+        return handlePythonApiResponse(response, 'getWordPressPostSummary');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'getWordPressPostSummary');
+    }
+}
+
+export async function createTrelloCardFromWordPressPost(
+    userId: string,
+    postId: string,
+    trelloListId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/content/create-trello-card-from-wordpress-post`;
+
+    try {
+        const response = await axios.post(endpoint, {
+            user_id: userId,
+            post_id: postId,
+            trello_list_id: trelloListId,
+        });
+        return handlePythonApiResponse(response, 'createTrelloCardFromWordPressPost');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'createTrelloCardFromWordPressPost');
+    }
+}

--- a/src/skills/devOpsManagerSkills.ts
+++ b/src/skills/devOpsManagerSkills.ts
@@ -1,0 +1,98 @@
+import axios, { AxiosError } from 'axios';
+import {
+  SkillResponse,
+} from '../../atomic-docker/project/functions/atom-agent/types'; // Adjust path
+import { PYTHON_API_SERVICE_BASE_URL } from '../../atomic-docker/project/functions/atom-agent/_libs/constants';
+import { logger } from '../../atomic-docker/project/functions/_utils/logger';
+
+// Helper to handle Python API responses, can be centralized later
+function handlePythonApiResponse<T>(
+  response: any, // Adjust type as per actual Python API response structure
+  operationName: string
+): SkillResponse<T> {
+  if (response.data && response.data.ok && response.data.data) {
+    return { ok: true, data: response.data.data };
+  }
+  logger.warn(`[${operationName}] Failed API call.`, response.data?.error);
+  return {
+    ok: false,
+    error: {
+      code: response.data?.error?.code || 'PYTHON_API_ERROR',
+      message: response.data?.error?.message || `Failed to ${operationName}.`,
+      details: response.data?.error?.details,
+    },
+  };
+}
+
+// Helper to handle network/axios errors
+function handleAxiosError(error: AxiosError, operationName: string): SkillResponse<null> {
+    if (error.response) {
+      logger.error(`[${operationName}] Error: ${error.response.status}`, error.response.data);
+      const errData = error.response.data as any;
+      return { ok: false, error: { code: `HTTP_${error.response.status}`, message: errData?.error?.message || `Failed to ${operationName}.` } };
+    } else if (error.request) {
+      logger.error(`[${operationName}] Error: No response received`, error.request);
+      return { ok: false, error: { code: 'NETWORK_ERROR', message: `No response received for ${operationName}.` } };
+    }
+    logger.error(`[${operationName}] Error: ${error.message}`);
+    return { ok: false, error: { code: 'REQUEST_SETUP_ERROR', message: `Error setting up request for ${operationName}: ${error.message}` } };
+}
+
+export async function createGithubIssueFromJiraIssue(
+  userId: string,
+  jiraIssueId: string
+): Promise<SkillResponse<any>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+  }
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/devops/create-github-issue-from-jira-issue`;
+
+  try {
+    const response = await axios.post(endpoint, {
+      user_id: userId,
+      jira_issue_id: jiraIssueId,
+    });
+    return handlePythonApiResponse(response, 'createGithubIssueFromJiraIssue');
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'createGithubIssueFromJiraIssue');
+  }
+}
+
+export async function getGithubPullRequestStatus(
+    userId: string,
+    pullRequestUrl: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/devops/github-pull-request-status?user_id=${userId}&pull_request_url=${pullRequestUrl}`;
+
+    try {
+        const response = await axios.get(endpoint);
+        return handlePythonApiResponse(response, 'getGithubPullRequestStatus');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'getGithubPullRequestStatus');
+    }
+}
+
+export async function createTrelloCardFromGithubIssue(
+    userId: string,
+    issueUrl: string,
+    trelloListId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/devops/create-trello-card-from-github-issue`;
+
+    try {
+        const response = await axios.post(endpoint, {
+            user_id: userId,
+            issue_url: issueUrl,
+            trello_list_id: trelloListId,
+        });
+        return handlePythonApiResponse(response, 'createTrelloCardFromGithubIssue');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'createTrelloCardFromGithubIssue');
+    }
+}

--- a/src/skills/hrManagerSkills.ts
+++ b/src/skills/hrManagerSkills.ts
@@ -1,0 +1,98 @@
+import axios, { AxiosError } from 'axios';
+import {
+  SkillResponse,
+} from '../../atomic-docker/project/functions/atom-agent/types'; // Adjust path
+import { PYTHON_API_SERVICE_BASE_URL } from '../../atomic-docker/project/functions/atom-agent/_libs/constants';
+import { logger } from '../../atomic-docker/project/functions/_utils/logger';
+
+// Helper to handle Python API responses, can be centralized later
+function handlePythonApiResponse<T>(
+  response: any, // Adjust type as per actual Python API response structure
+  operationName: string
+): SkillResponse<T> {
+  if (response.data && response.data.ok && response.data.data) {
+    return { ok: true, data: response.data.data };
+  }
+  logger.warn(`[${operationName}] Failed API call.`, response.data?.error);
+  return {
+    ok: false,
+    error: {
+      code: response.data?.error?.code || 'PYTHON_API_ERROR',
+      message: response.data?.error?.message || `Failed to ${operationName}.`,
+      details: response.data?.error?.details,
+    },
+  };
+}
+
+// Helper to handle network/axios errors
+function handleAxiosError(error: AxiosError, operationName: string): SkillResponse<null> {
+    if (error.response) {
+      logger.error(`[${operationName}] Error: ${error.response.status}`, error.response.data);
+      const errData = error.response.data as any;
+      return { ok: false, error: { code: `HTTP_${error.response.status}`, message: errData?.error?.message || `Failed to ${operationName}.` } };
+    } else if (error.request) {
+      logger.error(`[${operationName}] Error: No response received`, error.request);
+      return { ok: false, error: { code: 'NETWORK_ERROR', message: `No response received for ${operationName}.` } };
+    }
+    logger.error(`[${operationName}] Error: ${error.message}`);
+    return { ok: false, error: { code: 'REQUEST_SETUP_ERROR', message: `Error setting up request for ${operationName}: ${error.message}` } };
+}
+
+export async function createBambooHREmployeeFromGreenhouseCandidate(
+  userId: string,
+  greenhouseCandidateId: string
+): Promise<SkillResponse<any>> {
+  if (!PYTHON_API_SERVICE_BASE_URL) {
+    return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+  }
+  const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/hr/create-bamboohr-employee-from-greenhouse-candidate`;
+
+  try {
+    const response = await axios.post(endpoint, {
+      user_id: userId,
+      greenhouse_candidate_id: greenhouseCandidateId,
+    });
+    return handlePythonApiResponse(response, 'createBambooHREmployeeFromGreenhouseCandidate');
+  } catch (error) {
+    return handleAxiosError(error as AxiosError, 'createBambooHREmployeeFromGreenhouseCandidate');
+  }
+}
+
+export async function getBambooHREmployeeSummary(
+    userId: string,
+    employeeId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/hr/bamboohr-employee-summary/${employeeId}?user_id=${userId}`;
+
+    try {
+        const response = await axios.get(endpoint);
+        return handlePythonApiResponse(response, 'getBambooHREmployeeSummary');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'getBambooHREmployeeSummary');
+    }
+}
+
+export async function createTrelloCardFromBambooHREmployee(
+    userId: string,
+    employeeId: string,
+    trelloListId: string
+): Promise<SkillResponse<any>> {
+    if (!PYTHON_API_SERVICE_BASE_URL) {
+        return { ok: false, error: { code: 'CONFIG_ERROR', message: 'Python API service URL is not configured.' } };
+    }
+    const endpoint = `${PYTHON_API_SERVICE_BASE_URL}/api/hr/create-trello-card-from-bamboohr-employee`;
+
+    try {
+        const response = await axios.post(endpoint, {
+            user_id: userId,
+            employee_id: employeeId,
+            trello_list_id: trelloListId,
+        });
+        return handlePythonApiResponse(response, 'createTrelloCardFromBambooHREmployee');
+    } catch (error) {
+        return handleAxiosError(error as AxiosError, 'createTrelloCardFromBambooHREmployee');
+    }
+}


### PR DESCRIPTION
This commit adds three new use cases to Atom, which combine multiple integrations to create powerful workflows.

DevOps Manager:
- Create a new GitHub issue from a Jira issue.
- Get the status of a GitHub pull request.
- Create a new Trello card for each new GitHub issue.

HR Manager:
- Create a new BambooHR employee from a Greenhouse candidate.
- Get a summary of an employee's profile from BambooHR.
- Create a new Trello card for each new BambooHR employee.

Content Marketer:
- Create a new WordPress post from a Google Drive document.
- Get a summary of a WordPress post.
- Create a new Trello card for each new WordPress post.