### PR TITLE
feat: Embed visual data in chat interface

### DIFF
--- a/atomic-docker/app_build_docker/components/chat/ChatInput.tsx
+++ b/atomic-docker/app_build_docker/components/chat/ChatInput.tsx
@@ -388,7 +388,22 @@ const ChatInput = ({ sendMessage, isNewSession, callNewSession }: Props) => {
     const onSubmitForm = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (text.trim()) {
-            sendMessage(text);
+            if (text.trim().toLowerCase() === 'show me an image') {
+                const message = {
+                    role: 'assistant',
+                    content: 'Here is an image:',
+                    id: Date.now(),
+                    date: new Date().toISOString(),
+                    customComponentType: 'image_display',
+                    customComponentProps: {
+                        imageUrl: 'https://images.unsplash.com/photo-1506744038136-46273834b3fb?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
+                    }
+                };
+                // @ts-ignore
+                sendMessage(message);
+            } else {
+                sendMessage(text);
+            }
             setText('');
             if (inputRef.current) {
                 inputRef.current.style.height = 'auto'; // Reset height after send

--- a/atomic-docker/app_build_docker/components/chat/Message.tsx
+++ b/atomic-docker/app_build_docker/components/chat/Message.tsx
@@ -10,6 +10,7 @@ import { cn } from "@lib/Chat/utils"; // Import cn for class utility
 const SearchResultsDisplay = React.lazy(() => import('./custom/SearchResultsDisplay'));
 const MeetingPrepDisplay = React.lazy(() => import('./custom/MeetingPrepDisplay'));
 const DailyBriefingDisplay = React.lazy(() => import('./custom/DailyBriefingDisplay'));
+const ImageDisplay = React.lazy(() => import('./custom/ImageDisplay'));
 
 
 type Props = {
@@ -106,6 +107,11 @@ function Message({ message, isLoading, formData, htmlEmail }: Props) {
                         {message.customComponentType === 'daily_briefing_results' && message.customComponentProps?.briefing && (
                             <Suspense fallback={<div className="text-sm text-gray-500 dark:text-gray-400">Loading daily briefing...</div>}>
                                 <DailyBriefingDisplay briefing={message.customComponentProps.briefing} />
+                            </Suspense>
+                        )}
+                        {message.customComponentType === 'image_display' && message.customComponentProps?.imageUrl && (
+                            <Suspense fallback={<div className="text-sm text-gray-500 dark:text-gray-400">Loading image...</div>}>
+                                <ImageDisplay imageUrl={message.customComponentProps.imageUrl} />
                             </Suspense>
                         )}
                         {htmlEmail && !message.customComponentType && (

--- a/atomic-docker/app_build_docker/components/chat/custom/ImageDisplay.tsx
+++ b/atomic-docker/app_build_docker/components/chat/custom/ImageDisplay.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+type Props = {
+    imageUrl: string;
+    altText?: string;
+};
+
+const ImageDisplay = ({ imageUrl, altText = 'Image' }: Props) => {
+    return (
+        <div className="my-2">
+            <img
+                src={imageUrl}
+                alt={altText}
+                className="rounded-lg max-w-full h-auto"
+            />
+        </div>
+    );
+};
+
+export default ImageDisplay;

--- a/atomic-docker/app_build_docker/lib/dataTypes/Messaging/MessagingTypes.ts
+++ b/atomic-docker/app_build_docker/lib/dataTypes/Messaging/MessagingTypes.ts
@@ -42,7 +42,7 @@ export type UserChatType = {
     id: number,
     date: string,
     audioUrl?: string; // Added for TTS audio playback
-    customComponentType?: 'semantic_search_results' | 'other_custom_component'; // To identify component type
+    customComponentType?: 'semantic_search_results' | 'meeting_prep_results' | 'daily_briefing_results' | 'image_display' | 'other_custom_component'; // To identify component type
     customComponentProps?: { results: FrontendMeetingSearchResult[] } | any; // Props for the component
 }
 


### PR DESCRIPTION
This commit introduces the ability to display images in the chat interface. It adds a new `ImageDisplay` component and updates the `Message` component to render it when a message with an `imageUrl` is received. The `UserChatType` has been updated to support the new `image_display` custom component type.