### PR TITLE
fix: correct syntax error in mcp_service.py

### DIFF
--- a/backend/integrations/mcp_service.py
+++ b/backend/integrations/mcp_service.py
@@ -225,7 +225,7 @@ class MCPService:
                 {
                     "name": "search_formulas",
                     "description": "Search for business logic, math definitions, and extracted Excel formulas in Atom's memory",
-                    }
+                    "parameters": {"query": "string"}
                 },
                 {
                     "name": "canvas_tool",


### PR DESCRIPTION
Fixed missing parameters dict in search_formulas tool definition. This was blocking the CI pipeline from running successfully.