### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/backend/core/benchmarks.py
+++ b/backend/core/benchmarks.py
@@ -46,9 +46,11 @@ MODEL_QUALITY_SCORES = {
     "gpt-4o-mini": 85,
     "gemini-2.0-flash": 86,
     "gemini-1.5-flash": 84,
-    "minimax-m2.5": 88,  # Standard tier, between gemini-2.0-flash and deepseek-chat
-    "MiniMax-M2.7": 90,  # Latest flagship model, 204K context
-    "MiniMax-M2.7-highspeed": 89,  # Low-latency variant, 204K context
+    "minimax-m2.5": 88,  # Standard tier, between gemini-2.0-flash and deepseek-chat (legacy)
+    "MiniMax-M3": 92,  # Latest flagship model, 512K context, image input
+    "MiniMax-M3-highspeed": 91,  # Low-latency variant, 512K context
+    "MiniMax-M2.7": 90,  # Previous flagship model, 204K context
+    "MiniMax-M2.7-highspeed": 89,  # Previous low-latency variant, 204K context
     "lux-1.0": 88,  # LUX Computer Use (Claude 3.5 Sonnet based) - Phase 226.2-01
 
     # Efficiency / Simple

--- a/backend/core/byok_endpoints.py
+++ b/backend/core/byok_endpoints.py
@@ -380,14 +380,14 @@ class BYOKManager:
                 reasoning_level=4
             ),
             AIProviderConfig(
-                id="minimax_2_5",
-                name="MiniMax 2.5",
-                description="MiniMax M2.5 Fast Inference",
+                id="minimax_m3",
+                name="MiniMax M3",
+                description="MiniMax M3 Flagship (512K context, image input)",
                 api_key_env_var="MINIMAX_API_KEY",
                 base_url="https://api.minimax.io/v1",
                 supported_tasks=["general", "chat", "code"],
                 cost_per_token=0.00000075,
-                model="minimax-m2.5",
+                model="MiniMax-M3",
                 reasoning_level=3
             ),
             AIProviderConfig(
@@ -790,7 +790,7 @@ async def store_api_key(
             detail="Invalid API key: must be at least 10 characters"
         )
 
-    valid_providers = ["openai", "anthropic", "deepseek", "gemini", "moonshot", "minimax", "qwen", "lux", "groq", "google", "google_flash", "google_flash_3_5", "gemini_flash_3_5", "mistral", "glm", "glm_5", "deepinfra", "tavily", "minimax_2_5", "anthropic_opus_4_6", "openai_5_3", "xiaomi"]
+    valid_providers = ["openai", "anthropic", "deepseek", "gemini", "moonshot", "minimax", "qwen", "lux", "groq", "google", "google_flash", "google_flash_3_5", "gemini_flash_3_5", "mistral", "glm", "glm_5", "deepinfra", "tavily", "minimax_m3", "anthropic_opus_4_6", "openai_5_3", "xiaomi"]
     if provider_id not in valid_providers:
         raise HTTPException(
             status_code=400,

--- a/backend/core/dynamic_pricing_fetcher.py
+++ b/backend/core/dynamic_pricing_fetcher.py
@@ -99,16 +99,17 @@ class DynamicPricingFetcher:
                         }
 
                 # Add MiniMax models fallback if not in LiteLLM yet
-                if "minimax-m2.5" not in pricing:
-                    pricing["minimax-m2.5"] = {
-                        "input_cost_per_token": 0.000001,  # $1/M estimated
-                        "output_cost_per_token": 0.000001,
-                        "max_tokens": 204000,
-                        "litellm_provider": "minimax",
-                        "mode": "chat",
-                        "source": "estimated",
-                        "supports_cache": False,
-                    }
+                for _m3 in ("MiniMax-M3", "MiniMax-M3-highspeed"):
+                    if _m3 not in pricing:
+                        pricing[_m3] = {
+                            "input_cost_per_token": 0.000001,
+                            "output_cost_per_token": 0.000001,
+                            "max_tokens": 512000,
+                            "litellm_provider": "minimax",
+                            "mode": "chat",
+                            "source": "estimated",
+                            "supports_cache": False,
+                        }
                 for _m27 in ("MiniMax-M2.7", "MiniMax-M2.7-highspeed"):
                     if _m27 not in pricing:
                         pricing[_m27] = {
@@ -491,7 +492,7 @@ class DynamicPricingFetcher:
             True if pricing is estimated, False if from official source
 
         Examples:
-            >>> fetcher.is_pricing_estimated("minimax-m2.5")
+            >>> fetcher.is_pricing_estimated("MiniMax-M3")
             True  # Estimated until official pricing announced
             >>> fetcher.is_pricing_estimated("gpt-4o")
             False  # Official from LiteLLM

--- a/backend/core/llm/byok_handler.py
+++ b/backend/core/llm/byok_handler.py
@@ -103,10 +103,10 @@ COST_EFFICIENT_MODELS = {
         QueryComplexity.ADVANCED: "qwen-3-max",
     },
     "minimax": {
-        QueryComplexity.SIMPLE: "MiniMax-M2.7-highspeed",
-        QueryComplexity.MODERATE: "MiniMax-M2.7-highspeed",
-        QueryComplexity.COMPLEX: "MiniMax-M2.7",
-        QueryComplexity.ADVANCED: "MiniMax-M2.7",
+        QueryComplexity.SIMPLE: "MiniMax-M3-highspeed",
+        QueryComplexity.MODERATE: "MiniMax-M3-highspeed",
+        QueryComplexity.COMPLEX: "MiniMax-M3",
+        QueryComplexity.ADVANCED: "MiniMax-M3",
     },
     "lux": {  # LUX Computer Use (Claude 3.5 Sonnet based)
         QueryComplexity.SIMPLE: "lux-1.0",
@@ -156,7 +156,7 @@ REASONING_MODELS_WITHOUT_VISION = {
     "o3",
     "o3-mini",
     "deepseek-chat",
-    "MiniMax-M2.7"
+    "MiniMax-M3"
 }
 
 VISION_ONLY_MODELS = {
@@ -170,10 +170,10 @@ class BYOKHandler:
     Handler for LLM interactions using BYOK system with intelligent cost optimization.
     Automatically routes queries to the most cost-effective provider based on complexity.
 
-    Phase 68-04: MiniMax M2.5 Integration
+    Phase 68-04: MiniMax M3 Integration
     - Positioned in STANDARD tier with estimated $1/M pricing
     - API access may be closed - graceful fallback to next provider
-    - Quality score 88 (between gemini-2.0-flash @ 86 and deepseek-chat @ 80)
+    - Quality score 92 (latest flagship, 512K context, image input)
     - Native agent support, no prompt caching
     """
     def __init__(
@@ -388,7 +388,7 @@ class BYOKHandler:
             "deepseek": {"base_url": "https://api.deepseek.com/v1"},
             "moonshot": {"base_url": "https://api.moonshot.cn/v1"},
             "deepinfra": {"base_url": "https://api.deepinfra.com/v1/openai"},
-            "minimax": {"base_url": "https://api.minimax.io/v1"},  # MiniMax M2.7 (OpenAI-compatible)
+            "minimax": {"base_url": "https://api.minimax.io/v1"},  # MiniMax M3 (OpenAI-compatible)
             "lux": {"base_url": None},  # Phase 226.2-01: LUX Computer Use (uses Anthropic API)
             "qwen": {"base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"},
             "gemini": {"base_url": "https://generativelanguage.googleapis.com/v1beta/openai/"},

--- a/backend/core/llm/minimax_integration.py
+++ b/backend/core/llm/minimax_integration.py
@@ -1,16 +1,18 @@
 """
-MiniMax M2.7 API Integration for BYOK Handler
+MiniMax M3 API Integration for BYOK Handler
 
 Provides cost-effective standard tier routing via OpenAI-compatible API.
-MiniMax M2.7 is the latest flagship model with 204K context window.
+MiniMax M3 is the latest flagship model with 512K context window and image input support.
 
 Available models:
-- MiniMax-M2.7: Latest flagship, 204K context
-- MiniMax-M2.7-highspeed: Optimized for lower latency, 204K context
+- MiniMax-M3: Latest flagship, 512K context, image input
+- MiniMax-M3-highspeed: Optimized for lower latency, 512K context
+- MiniMax-M2.7: Previous flagship, 204K context (retained for compatibility)
+- MiniMax-M2.7-highspeed: Previous low-latency variant, 204K context
 
 Integration:
-- Tier: STANDARD (quality score 90)
-- Vision: Not supported (text-only reasoning model)
+- Tier: STANDARD (quality score 92)
+- Vision: Supported on M3 (image input)
 - Tools: Native agent support via OpenAI-compatible function calling
 - Cache: No prompt caching
 - Pricing: Pay-as-you-go (no minimum commitment)
@@ -30,13 +32,13 @@ logger = logging.getLogger(__name__)
 
 # Available MiniMax models with context windows
 MINIMAX_MODELS = {
-    "MiniMax-M2.7": {"context_window": 204000, "description": "Latest flagship model"},
-    "MiniMax-M2.7-highspeed": {"context_window": 204000, "description": "Optimized for lower latency"},
-    "MiniMax-M2.5": {"context_window": 204000, "description": "Previous generation"},
-    "MiniMax-M2.5-highspeed": {"context_window": 204000, "description": "Previous generation, low latency"},
+    "MiniMax-M3": {"context_window": 512000, "description": "Latest flagship model with image input"},
+    "MiniMax-M3-highspeed": {"context_window": 512000, "description": "Latest flagship, low-latency variant"},
+    "MiniMax-M2.7": {"context_window": 204000, "description": "Previous flagship model"},
+    "MiniMax-M2.7-highspeed": {"context_window": 204000, "description": "Previous flagship, low-latency variant"},
 }
 
-DEFAULT_MODEL = "MiniMax-M2.7"
+DEFAULT_MODEL = "MiniMax-M3"
 
 
 def clamp_temperature(temperature: float) -> float:
@@ -57,16 +59,16 @@ class RateLimitedError(Exception):
 
 class MiniMaxIntegration:
     """
-    MiniMax M2.7 API wrapper for cost-effective standard tier routing.
+    MiniMax M3 API wrapper for cost-effective standard tier routing.
 
     Pricing:
     - Input: ~$1/M tokens
     - Output: ~$1/M tokens
-    - Context: 204K tokens (all models)
+    - Context: 512K tokens (M3), 204K tokens (M2.7)
 
     Capabilities:
-    - Quality Score: 90
-    - Vision: No (text-only reasoning)
+    - Quality Score: 92
+    - Vision: Yes on M3 (image input)
     - Tools: Yes (native agent / function calling support)
     - Cache: No
     """
@@ -76,12 +78,12 @@ class MiniMaxIntegration:
     ESTIMATED_PRICING = {
         "input_cost_per_token": 0.000001,   # ~$1/M tokens
         "output_cost_per_token": 0.000001,  # ~$1/M tokens
-        "max_tokens": 204000,
+        "max_tokens": 512000,
     }
 
     CAPABILITIES = {
-        "quality_score": 90,
-        "supports_vision": False,
+        "quality_score": 92,
+        "supports_vision": True,
         "supports_tools": True,
         "supports_cache": False,
         "tier": CognitiveTier.STANDARD,
@@ -93,7 +95,7 @@ class MiniMaxIntegration:
 
         Args:
             api_key: MiniMax API key (from MINIMAX_API_KEY env var or user config)
-            model: Model to use (default: MiniMax-M2.7)
+            model: Model to use (default: MiniMax-M3)
         """
         self.api_key = api_key
         self.model = model

--- a/backend/core/llm_service.py
+++ b/backend/core/llm_service.py
@@ -62,7 +62,11 @@ class LLMModel(str, Enum):
     GEMINI_3_5_FLASH = "gemini-3.5-flash"
 
     # MiniMax
-    MINIMAX_2_5 = "minimax-m2.5"
+    MINIMAX_M3 = "MiniMax-M3"
+    MINIMAX_M3_HIGHSPEED = "MiniMax-M3-highspeed"
+    MINIMAX_M27 = "MiniMax-M2.7"
+    MINIMAX_M27_HIGHSPEED = "MiniMax-M2.7-highspeed"
+    MINIMAX_2_5 = "minimax-m2.5"  # legacy
 
     # Xiaomi
     XIAOMI_MIMO_2_5_PRO = "xiaomi/mimo-v2.5-pro"

--- a/backend/independent_ai_validator/providers/minimax_provider.py
+++ b/backend/independent_ai_validator/providers/minimax_provider.py
@@ -2,8 +2,8 @@
 """
 MiniMax Provider Implementation for Independent AI Validator
 
-Uses MiniMax M2.7 via OpenAI-compatible API (https://api.minimax.io/v1).
-204K context window, temperature clamped to (0.0, 1.0].
+Uses MiniMax M3 via OpenAI-compatible API (https://api.minimax.io/v1).
+512K context window, temperature clamped to (0.0, 1.0].
 """
 
 import asyncio
@@ -28,17 +28,17 @@ def _clamp_temperature(temperature: float) -> float:
 
 class MiniMaxProvider(BaseLLMProvider):
     """
-    MiniMax M2.7 provider for marketing claim validation.
+    MiniMax M3 provider for marketing claim validation.
     Uses the OpenAI-compatible chat/completions endpoint.
     """
 
-    def __init__(self, api_key: str, weight: float = 1.0, model: str = "MiniMax-M2.7"):
+    def __init__(self, api_key: str, weight: float = 1.0, model: str = "MiniMax-M3"):
         super().__init__(api_key, "MiniMax", weight)
         self.base_url = "https://api.minimax.io/v1"
         self.model = model
 
     async def validate_claim(self, request: ValidationRequest) -> LLMResponse:
-        """Validate a marketing claim using MiniMax M2.7"""
+        """Validate a marketing claim using MiniMax M3"""
         start_time = time.time()
 
         try:
@@ -126,7 +126,7 @@ class MiniMaxProvider(BaseLLMProvider):
             )
 
     async def analyze_evidence(self, evidence: Dict[str, Any], claim: str) -> LLMResponse:
-        """Analyze evidence for a claim using MiniMax M2.7"""
+        """Analyze evidence for a claim using MiniMax M3"""
         evidence_json = json.dumps(evidence, indent=2)
         prompt = f"""
 You are an evidence analysis expert. Analyze the provided evidence for the following marketing claim.
@@ -201,7 +201,7 @@ Be thorough and objective in your analysis.
                     return LLMResponse(
                         content=content,
                         confidence=confidence,
-                        reasoning="Evidence analysis completed using MiniMax M2.7",
+                        reasoning="Evidence analysis completed using MiniMax M3",
                         metadata={"analysis_type": "evidence", "tokens_used": tokens_used},
                         provider=self.name,
                         model=self.model,
@@ -220,7 +220,7 @@ Be thorough and objective in your analysis.
             )
 
     async def check_bias(self, text: str) -> LLMResponse:
-        """Check for potential bias in the provided text using MiniMax M2.7"""
+        """Check for potential bias in the provided text using MiniMax M3"""
         prompt = f"""
 You are a bias detection expert. Analyze the following text for potential biases that could affect objective validation.
 
@@ -290,7 +290,7 @@ Be thorough and constructive in your analysis.
                     return LLMResponse(
                         content=content,
                         confidence=confidence,
-                        reasoning="Bias analysis completed using MiniMax M2.7",
+                        reasoning="Bias analysis completed using MiniMax M3",
                         metadata={"analysis_type": "bias", "tokens_used": tokens_used},
                         provider=self.name,
                         model=self.model,

--- a/backend/tests/core/test_dynamic_pricing_fetcher.py
+++ b/backend/tests/core/test_dynamic_pricing_fetcher.py
@@ -181,12 +181,13 @@ class TestLiteLLMFetch:
 
             result = await pricing_fetcher.fetch_litellm_pricing()
 
-            # 4 from mock + 3 MiniMax fallback models
-            assert len(result) == 7
+            # 4 from mock + 4 MiniMax fallback models (M3, M3-highspeed, M2.7, M2.7-highspeed)
+            assert len(result) == 8
             assert "gpt-4o" in result
             assert result["gpt-4o"]["input_cost_per_token"] == 0.000005
             assert result["gpt-4o"]["source"] == "litellm"
             # Check MiniMax fallback models added
+            assert "MiniMax-M3" in result
             assert "MiniMax-M2.7" in result
 
     @pytest.mark.asyncio

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -642,7 +642,7 @@ class TestLLMServiceBackwardCompatibility(TestLLMServiceProviderSelection):
         assert compat_service.get_provider("claude-3-5-sonnet").value == "anthropic"
         assert compat_service.get_provider("deepseek-chat").value == "deepseek"
         assert compat_service.get_provider("gemini-1.5-pro").value == "gemini"
-        assert compat_service.get_provider("minimax-m2.5").value == "minimax"
+        assert compat_service.get_provider("MiniMax-M3").value == "minimax"
         assert compat_service.get_provider("mistral-7b").value == "mistral"
         assert compat_service.get_provider("qwen-7b").value == "qwen"
 

--- a/backend/tests/test_minimax_integration.py
+++ b/backend/tests/test_minimax_integration.py
@@ -1,5 +1,5 @@
 """
-MiniMax M2.7 Integration Tests
+MiniMax M3 Integration Tests
 
 Comprehensive test suite for MiniMax API wrapper, pricing integration,
 BYOK handler integration, and independent AI validator provider.
@@ -55,15 +55,15 @@ class TestMiniMaxClientInitialization:
         client = MiniMaxIntegration("test-key")
         assert client.client.timeout == 30.0 or str(client.client.timeout) == "Timeout(timeout=30.0)"
 
-    def test_default_model_is_m27(self):
-        """Test default model is MiniMax-M2.7"""
+    def test_default_model_is_m3(self):
+        """Test default model is MiniMax-M3"""
         client = MiniMaxIntegration("test-key")
-        assert client.model == "MiniMax-M2.7"
+        assert client.model == "MiniMax-M3"
 
     def test_custom_model_selection(self):
         """Test custom model can be specified"""
-        client = MiniMaxIntegration("test-key", model="MiniMax-M2.7-highspeed")
-        assert client.model == "MiniMax-M2.7-highspeed"
+        client = MiniMaxIntegration("test-key", model="MiniMax-M3-highspeed")
+        assert client.model == "MiniMax-M3-highspeed"
 
 
 class TestTemperatureClamping:
@@ -157,7 +157,7 @@ class TestGenerateMethod:
             payload = call_args[1]["json"]
             assert payload["temperature"] == 0.01
             assert payload["max_tokens"] == 500
-            assert payload["model"] == "MiniMax-M2.7"
+            assert payload["model"] == "MiniMax-M3"
 
     @pytest.mark.asyncio
     async def test_model_override_in_generate(self):
@@ -172,35 +172,35 @@ class TestGenerateMethod:
         mock_response.raise_for_status = MagicMock()
 
         with patch.object(client.client, "post", return_value=mock_response) as mock_post:
-            await client.generate("Test", model="MiniMax-M2.7-highspeed")
+            await client.generate("Test", model="MiniMax-M3-highspeed")
 
             call_args = mock_post.call_args
             payload = call_args[1]["json"]
-            assert payload["model"] == "MiniMax-M2.7-highspeed"
+            assert payload["model"] == "MiniMax-M3-highspeed"
 
 
 class TestPricingAndCapabilities:
     """Test pricing and capabilities methods"""
 
-    def test_get_pricing_returns_204k_context(self):
-        """Test returns 204K context window"""
+    def test_get_pricing_returns_512k_context(self):
+        """Test returns 512K context window (M3 default)"""
         client = MiniMaxIntegration("test-key")
         pricing = client.get_pricing()
 
         assert pricing["input_cost_per_token"] == 0.000001  # $1/M
         assert pricing["output_cost_per_token"] == 0.000001  # $1/M
-        assert pricing["max_tokens"] == 204000
+        assert pricing["max_tokens"] == 512000
 
     def test_get_capabilities(self):
-        """Test returns correct tier (STANDARD) and quality_score (90)"""
+        """Test returns correct tier (STANDARD) and quality_score (92)"""
         from core.llm.cognitive_tier_system import CognitiveTier
 
         client = MiniMaxIntegration("test-key")
         capabilities = client.get_capabilities()
 
-        assert capabilities["quality_score"] == 90
+        assert capabilities["quality_score"] == 92
         assert capabilities["tier"] == CognitiveTier.STANDARD
-        assert capabilities["supports_vision"] is False
+        assert capabilities["supports_vision"] is True
         assert capabilities["supports_tools"] is True
         assert capabilities["supports_cache"] is False
 
@@ -210,11 +210,14 @@ class TestPricingAndCapabilities:
         capabilities = client.get_capabilities()
         assert capabilities["supports_tools"] is True
 
-    def test_available_models_includes_m27(self):
-        """Test available models list includes M2.7 variants"""
+    def test_available_models_includes_m3_and_m27(self):
+        """Test available models list includes M3 and retained M2.7 variants"""
         models = MiniMaxIntegration.get_available_models()
+        assert "MiniMax-M3" in models
+        assert "MiniMax-M3-highspeed" in models
         assert "MiniMax-M2.7" in models
         assert "MiniMax-M2.7-highspeed" in models
+        assert models["MiniMax-M3"]["context_window"] == 512000
         assert models["MiniMax-M2.7"]["context_window"] == 204000
 
 
@@ -225,8 +228,8 @@ class TestBYOKIntegration:
         """Test listed in providers_config"""
         assert "minimax" in COST_EFFICIENT_MODELS
 
-    def test_minimax_uses_m27_models(self):
-        """Test mapped to M2.7 models"""
+    def test_minimax_uses_m3_models(self):
+        """Test mapped to M3 models (M3 highspeed for fast paths, M3 for complex)"""
         from core.llm.byok_handler import QueryComplexity
 
         minimax_models = COST_EFFICIENT_MODELS.get("minimax", {})
@@ -236,11 +239,11 @@ class TestBYOKIntegration:
         assert QueryComplexity.COMPLEX in minimax_models
         assert QueryComplexity.ADVANCED in minimax_models
 
-        # Simple/Moderate -> highspeed, Complex/Advanced -> M2.7
-        assert minimax_models[QueryComplexity.SIMPLE] == "MiniMax-M2.7-highspeed"
-        assert minimax_models[QueryComplexity.MODERATE] == "MiniMax-M2.7-highspeed"
-        assert minimax_models[QueryComplexity.COMPLEX] == "MiniMax-M2.7"
-        assert minimax_models[QueryComplexity.ADVANCED] == "MiniMax-M2.7"
+        # Simple/Moderate -> highspeed, Complex/Advanced -> M3
+        assert minimax_models[QueryComplexity.SIMPLE] == "MiniMax-M3-highspeed"
+        assert minimax_models[QueryComplexity.MODERATE] == "MiniMax-M3-highspeed"
+        assert minimax_models[QueryComplexity.COMPLEX] == "MiniMax-M3"
+        assert minimax_models[QueryComplexity.ADVANCED] == "MiniMax-M3"
 
     def test_minimax_in_static_fallback(self):
         """Test appears in provider_priority"""
@@ -284,8 +287,18 @@ class TestFallbackBehavior:
 class TestBenchmarkIntegration:
     """Test MiniMax integration with benchmark system"""
 
+    def test_m3_quality_score_defined(self):
+        """Test get_quality_score('MiniMax-M3') returns 92"""
+        score = get_quality_score("MiniMax-M3")
+        assert score == 92
+
+    def test_m3_highspeed_quality_score_defined(self):
+        """Test get_quality_score('MiniMax-M3-highspeed') returns 91"""
+        score = get_quality_score("MiniMax-M3-highspeed")
+        assert score == 91
+
     def test_m27_quality_score_defined(self):
-        """Test get_quality_score('MiniMax-M2.7') returns 90"""
+        """Test get_quality_score('MiniMax-M2.7') returns 90 (retained for compatibility)"""
         score = get_quality_score("MiniMax-M2.7")
         assert score == 90
 
@@ -304,17 +317,27 @@ class TestModelConstants:
     """Test model constants and configuration"""
 
     def test_default_model_constant(self):
-        """Test DEFAULT_MODEL is MiniMax-M2.7"""
-        assert DEFAULT_MODEL == "MiniMax-M2.7"
+        """Test DEFAULT_MODEL is MiniMax-M3"""
+        assert DEFAULT_MODEL == "MiniMax-M3"
 
-    def test_minimax_models_all_204k(self):
-        """Test all models have 204K context window"""
-        for model_name, info in MINIMAX_MODELS.items():
-            assert info["context_window"] == 204000, f"{model_name} should have 204K context"
+    def test_m3_models_have_512k_context(self):
+        """Test M3 models have 512K context window"""
+        assert MINIMAX_MODELS["MiniMax-M3"]["context_window"] == 512000
+        assert MINIMAX_MODELS["MiniMax-M3-highspeed"]["context_window"] == 512000
+
+    def test_m27_models_have_204k_context(self):
+        """Test retained M2.7 models still report 204K context window"""
+        assert MINIMAX_MODELS["MiniMax-M2.7"]["context_window"] == 204000
+        assert MINIMAX_MODELS["MiniMax-M2.7-highspeed"]["context_window"] == 204000
 
     def test_minimax_models_includes_all_variants(self):
-        """Test model registry includes M2.5 and M2.7 variants"""
+        """Test model registry includes M3 (new default) and retained M2.7 variants"""
+        assert "MiniMax-M3" in MINIMAX_MODELS
+        assert "MiniMax-M3-highspeed" in MINIMAX_MODELS
         assert "MiniMax-M2.7" in MINIMAX_MODELS
         assert "MiniMax-M2.7-highspeed" in MINIMAX_MODELS
-        assert "MiniMax-M2.5" in MINIMAX_MODELS
-        assert "MiniMax-M2.5-highspeed" in MINIMAX_MODELS
+
+    def test_minimax_models_drops_legacy_m25(self):
+        """Test deprecated M2.5 variants are removed from the available model list"""
+        assert "MiniMax-M2.5" not in MINIMAX_MODELS
+        assert "MiniMax-M2.5-highspeed" not in MINIMAX_MODELS

--- a/backend/tests/test_minimax_m27_integration.py
+++ b/backend/tests/test_minimax_m27_integration.py
@@ -1,7 +1,7 @@
 """
-MiniMax M2.7 Integration Tests
+MiniMax M3 Integration Tests
 
-End-to-end integration tests verifying MiniMax M2.7 provider works
+End-to-end integration tests verifying MiniMax M3 provider works
 correctly across BYOK handler, validator engine, and pricing systems.
 
 These tests require MINIMAX_API_KEY to be set for live API calls.
@@ -34,16 +34,18 @@ class TestBYOKRoutingIntegration:
         handler = BYOKHandler()
         # MiniMax should be in the cost-efficient models
         assert "minimax" in COST_EFFICIENT_MODELS
-        # For simple queries, highspeed model should be selected
-        assert COST_EFFICIENT_MODELS["minimax"][QueryComplexity.SIMPLE] == "MiniMax-M2.7-highspeed"
+        # For simple queries, M3 highspeed model should be selected
+        assert COST_EFFICIENT_MODELS["minimax"][QueryComplexity.SIMPLE] == "MiniMax-M3-highspeed"
 
     def test_minimax_ranked_for_complex_queries(self):
-        """Test MiniMax uses full M2.7 for complex queries"""
-        assert COST_EFFICIENT_MODELS["minimax"][QueryComplexity.COMPLEX] == "MiniMax-M2.7"
-        assert COST_EFFICIENT_MODELS["minimax"][QueryComplexity.ADVANCED] == "MiniMax-M2.7"
+        """Test MiniMax uses full M3 for complex queries"""
+        assert COST_EFFICIENT_MODELS["minimax"][QueryComplexity.COMPLEX] == "MiniMax-M3"
+        assert COST_EFFICIENT_MODELS["minimax"][QueryComplexity.ADVANCED] == "MiniMax-M3"
 
     def test_minimax_quality_scores_in_benchmarks(self):
-        """Test all MiniMax models have quality scores"""
+        """Test all MiniMax models have quality scores (M3 + retained M2.7 + legacy)"""
+        assert get_quality_score("MiniMax-M3") == 92
+        assert get_quality_score("MiniMax-M3-highspeed") == 91
         assert get_quality_score("MiniMax-M2.7") == 90
         assert get_quality_score("MiniMax-M2.7-highspeed") == 89
         assert get_quality_score("minimax-m2.5") == 88
@@ -94,7 +96,7 @@ class TestValidatorProviderIntegration:
         assert result.provider == "MiniMax"
         assert result.confidence == 0.88
         assert result.tokens_used == 800
-        assert result.model == "MiniMax-M2.7"
+        assert result.model == "MiniMax-M3"
         assert "Reasoning" in (result.reasoning or "")
 
     @pytest.mark.asyncio
@@ -163,8 +165,8 @@ class TestValidatorProviderIntegration:
 class TestPricingPipelineIntegration:
     """Test MiniMax pricing flows through the full pipeline"""
 
-    def test_pricing_fetcher_includes_m27(self):
-        """Test DynamicPricingFetcher includes M2.7 pricing after refresh"""
+    def test_pricing_fetcher_includes_m3(self):
+        """Test DynamicPricingFetcher includes M3 pricing after refresh"""
         fetcher = get_pricing_fetcher()
 
         # Mock the HTTP calls to avoid network dependency
@@ -188,13 +190,13 @@ class TestPricingPipelineIntegration:
 
         asyncio.run(_mock_refresh())
 
-        pricing = fetcher.get_model_price("MiniMax-M2.7")
+        pricing = fetcher.get_model_price("MiniMax-M3")
         assert pricing is not None
-        assert pricing["max_tokens"] == 204000
+        assert pricing["max_tokens"] == 512000
         assert pricing["source"] == "estimated"
 
-    def test_pricing_fetcher_includes_m27_highspeed(self):
-        """Test DynamicPricingFetcher includes M2.7-highspeed pricing"""
+    def test_pricing_fetcher_includes_m3_highspeed(self):
+        """Test DynamicPricingFetcher includes M3-highspeed pricing"""
         fetcher = get_pricing_fetcher()
 
         import asyncio
@@ -215,12 +217,12 @@ class TestPricingPipelineIntegration:
 
         asyncio.run(_mock_refresh())
 
-        pricing = fetcher.get_model_price("MiniMax-M2.7-highspeed")
+        pricing = fetcher.get_model_price("MiniMax-M3-highspeed")
         assert pricing is not None
-        assert pricing["max_tokens"] == 204000
+        assert pricing["max_tokens"] == 512000
 
-    def test_m25_pricing_updated_to_204k(self):
-        """Test M2.5 pricing reflects 204K context (not 128K)"""
+    def test_pricing_fetcher_retains_m27(self):
+        """Test DynamicPricingFetcher still includes M2.7 pricing for compatibility"""
         fetcher = get_pricing_fetcher()
 
         import asyncio
@@ -241,6 +243,6 @@ class TestPricingPipelineIntegration:
 
         asyncio.run(_mock_refresh())
 
-        pricing = fetcher.get_model_price("minimax-m2.5")
+        pricing = fetcher.get_model_price("MiniMax-M2.7")
         assert pricing is not None
         assert pricing["max_tokens"] == 204000

--- a/backend/tests/test_minimax_validator_provider.py
+++ b/backend/tests/test_minimax_validator_provider.py
@@ -38,14 +38,14 @@ class TestMiniMaxProviderInit:
         assert provider.base_url == "https://api.minimax.io/v1"
 
     def test_default_model(self):
-        """Test default model is MiniMax-M2.7"""
+        """Test default model is MiniMax-M3"""
         provider = MiniMaxProvider("test-key")
-        assert provider.model == "MiniMax-M2.7"
+        assert provider.model == "MiniMax-M3"
 
     def test_custom_model(self):
         """Test custom model can be specified"""
-        provider = MiniMaxProvider("test-key", model="MiniMax-M2.7-highspeed")
-        assert provider.model == "MiniMax-M2.7-highspeed"
+        provider = MiniMaxProvider("test-key", model="MiniMax-M3-highspeed")
+        assert provider.model == "MiniMax-M3-highspeed"
 
 
 class TestClaimValidation:

--- a/backend/tests/unit/test_llm_service.py
+++ b/backend/tests/unit/test_llm_service.py
@@ -210,7 +210,7 @@ class TestProviderSelection:
 
     def test_get_provider_minimax(self, llm_service):
         """Test provider detection for MiniMax"""
-        provider = llm_service.get_provider("minimax-m2.5")
+        provider = llm_service.get_provider("MiniMax-M3")
         assert provider == LLMProvider.MINIMAX
 
     def test_get_provider_mistral(self, llm_service):
@@ -924,7 +924,7 @@ class TestIntegration:
             ("claude-3-5-sonnet", LLMProvider.ANTHROPIC),
             ("deepseek-chat", LLMProvider.DEEPSEEK),
             ("gemini-1.5-pro", LLMProvider.GEMINI),
-            ("minimax-m2.5", LLMProvider.MINIMAX)
+            ("MiniMax-M3", LLMProvider.MINIMAX)
         ]
 
         for model, expected_provider in test_cases:

--- a/docs/api/LLM_SERVICE_API.md
+++ b/docs/api/LLM_SERVICE_API.md
@@ -1327,7 +1327,7 @@ class LLMService:
 | Anthropic | `anthropic` | claude-3-5-sonnet, claude-3-opus, claude-3-haiku |
 | DeepSeek | `deepseek` | deepseek-chat, deepseek-reasoner |
 | Gemini | `gemini` | gemini-1.5-pro, gemini-1.5-flash |
-| MiniMax | `minimax` | minimax-m2.5 |
+| MiniMax | `minimax` | MiniMax-M3, MiniMax-M3-highspeed, MiniMax-M2.7, MiniMax-M2.7-highspeed |
 | Groq | `groq` | llama-3.1-70b-versatile |
 | Mistral | `mistral` | mistral-large, mistral-7b |
 | Qwen | `qwen` | qwen-plus, qwen-max |


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to add the new flagship M3 (512K context, image input) and route as the new default while retaining M2.7 for compatibility.

## Changes
- Add `MiniMax-M3` and `MiniMax-M3-highspeed` to the available model registry (`MINIMAX_MODELS`) with 512K context window and matching benchmark quality scores (92 / 91)
- Set `DEFAULT_MODEL` (BYOK) and `MiniMaxProvider` validator default to `MiniMax-M3`
- Route `BYOKHandler.COST_EFFICIENT_MODELS["minimax"]` to `MiniMax-M3-highspeed` for fast paths and `MiniMax-M3` for complex / advanced
- Replace the `byok_endpoints` `AIProviderConfig` `minimax_2_5` entry with `minimax_m3` (`MiniMax-M3`, 512K context, image input)
- Retain `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` in the model registry, benchmarks, and pricing fallback for backward compatibility
- Remove the deprecated `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` entries from `MINIMAX_MODELS` and the pricing fallback (legacy `minimax-m2.5` quality score is retained for backward score lookups)
- Add `LLMModel.MINIMAX_M3` / `MINIMAX_M3_HIGHSPEED` / `MINIMAX_M27` / `MINIMAX_M27_HIGHSPEED` enum entries (legacy `MINIMAX_2_5` kept for backward compat)
- Update related unit / integration tests to assert the new M3 defaults, the retained M2.7 entries, and the new pricing fallback count (4 MiniMax fallback models)
- Update `docs/api/LLM_SERVICE_API.md` model table to list the M3 / M2.7 family

## Why
MiniMax-M3 is the new flagship with a 512K context window, 128K max output, and image input — extending the OpenAI-compatible interface that the existing M2.7 integration already uses. Routing it as the new default pulls Atom forward without dropping the M2.7 fast-path option that production deployments may still rely on. The retained M2.7 family and the legacy `minimax-m2.5` benchmark score keep existing assertions (e.g. the LUX / MiniMax quality parity test) and consumers working unchanged.

## Testing
- Static type / AST validation across all modified files
- Updated assertions in `test_minimax_integration.py`, `test_minimax_m27_integration.py`, `test_minimax_validator_provider.py`, `test_dynamic_pricing_fetcher.py`, `test_llm_service.py`, and `unit/test_llm_service.py`
- BYOK routing assertions verify M3 / M3-highspeed mapping for SIMPLE / MODERATE / COMPLEX / ADVANCED