### PR TITLE
feat(hallucination-mitigation): port Phase 2 cascade routing + self-c…

### DIFF
--- a/backend/core/hallucination_config.py
+++ b/backend/core/hallucination_config.py
@@ -1,0 +1,170 @@
+"""Hallucination Mitigation Phase 2 — feature-flag resolvers.
+
+Three evidence-backed mitigations, each independently flag-gated and
+default-off (guaranteed no-op when unset):
+
+  * **Cascade routing** — on schema-validation failure inside
+    ``BYOKHandler.generate_structured_response``, retries once on a
+    frontier model in the *same provider family*.
+  * **Self-consistency voting** — 3-sample majority vote on the structured
+    action plan for irreversible actions, executed exactly once.
+  * **Verified graduation gate** — (SaaS-only; relies on
+    ``AgentCapabilityRegistry`` which this edition does not have. Ported
+    separately in SaaS. See ``docs/architecture/CONTEXT_MEMORY.md`` for
+    upstream's string-tri-state verified-outcome approach.)
+
+Resolution: env var only. This is the Personal / single-tenant edition;
+per-tenant overrides are a SaaS concern and live in the SaaS fork.
+
+This module has no database surface and no side effects. It is safe to
+import from anywhere, including the voter module.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Public toggles (env-var only)
+# ---------------------------------------------------------------------------
+
+
+def is_cascade_routing_enabled() -> bool:
+    """Cascade routing on schema-validation failure (Workstream B)."""
+    return _flag("ATOM_CASCADE_ROUTING")
+
+
+def is_self_consistency_enabled() -> bool:
+    """Self-consistency voting for irreversible actions (Workstream C)."""
+    return _flag("ATOM_SELF_CONSISTENCY")
+
+
+def _flag(env_var: str) -> bool:
+    return os.getenv(env_var, "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Numeric tunables
+# ---------------------------------------------------------------------------
+
+
+def get_self_consistency_samples() -> int:
+    """Number of samples drawn by the self-consistency voter (default 3)."""
+    try:
+        n = int(os.getenv("ATOM_SELF_CONSISTENCY_SAMPLES", "3"))
+    except (TypeError, ValueError):
+        n = 3
+    return max(1, n)
+
+
+def get_temperature_spread(n: int) -> list[float]:
+    """Return ``n`` distinct temperatures centered around the model default.
+
+    Wang et al. self-consistency samples at varying temperatures to surface
+    the modal answer. We spread symmetrically around 0.7 in 0.1 increments:
+        n=3 → [0.6, 0.7, 0.8]
+        n=5 → [0.5, 0.6, 0.7, 0.8, 0.9]
+    Odd counts are preferred (clean majority). Even counts are still
+    well-defined; the caller's tie-break handles them.
+    """
+    if n <= 0:
+        return [0.7]
+    if n == 1:
+        return [0.7]
+    half = (n - 1) / 2.0
+    return [round(0.7 + (i - half) * 0.1, 2) for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Frontier model registry (Workstream B)
+# ---------------------------------------------------------------------------
+
+# Frontier flagships by provider family. The "is this already frontier?"
+# check uses base-id matching (snapshot suffix stripped) so version tails
+# like ``-20240229`` are handled without an exhaustive list.
+FRONTIER_MODELS: set[str] = {
+    # OpenAI
+    "gpt-4o",
+    "gpt-4-turbo",
+    "gpt-4",
+    # Anthropic
+    "claude-3-opus",
+    "claude-3-5-sonnet",
+    "claude-3.5-sonnet",
+    "claude-sonnet-4",
+    "claude-opus-4",
+    # Google
+    "gemini-1.5-pro",
+    "gemini-2",
+    # DeepSeek
+    "deepseek-reasoner",
+    # MiniMax
+    "minimax-m2.7",
+    "minimax-m2",
+}
+
+# Per-provider flagship for cascade escalation. The escalation target MUST
+# stay in the same provider family as the original model — otherwise BYOK
+# credentials and rate limits silently shift under the caller.
+_FRONTIER_BY_PROVIDER: dict[str, str] = {
+    "openai": "gpt-4o",
+    "anthropic": "claude-3-5-sonnet",
+    "deepseek": "deepseek-reasoner",
+    "gemini": "gemini-1.5-pro",
+    "minimax": "minimax-m2.7",
+    "mistral": "mistral-large-latest",
+    "qwen": "qwen-max",
+    "groq": "llama-3.3-70b-versatile",
+    "cohere": "command-r-plus",
+    "ollama": "llama3:70b",  # local fallback
+    "lux": "gpt-4o",  # Lux joins OpenAI family for escalation
+}
+
+
+def _model_base(model: str) -> str:
+    """Strip the dated snapshot suffix from a model id.
+
+    Handles both the dashed (``-2024-08-06``) and compact (``-20240229``)
+    Anthropic style, plus OpenAI preview tags:
+
+        claude-3-opus-20240229  → claude-3-opus
+        claude-3-5-sonnet-20241022 → claude-3-5-sonnet
+        gpt-4o-2024-08-06       → gpt-4o
+        deepseek-reasoner       → deepseek-reasoner  (unchanged)
+    """
+    return re.sub(
+        r"-(20\d{2}(-?\d{2}(-?\d{2})?)?)([.-].*)?$",
+        "",
+        model,
+    )
+
+
+def is_frontier_model(model: str | None) -> bool:
+    """Return True if ``model`` matches a known frontier flagship.
+
+    Matches on the *base* model id (snapshot suffix stripped), so
+    ``claude-3-opus-20240229`` registers as frontier but
+    ``gpt-4o-mini`` does NOT (its base is ``gpt-4o-mini``, distinct from
+    ``gpt-4o``).
+    """
+    if not model:
+        return False
+    base = _model_base(model.lower())
+    return base in {f.lower() for f in FRONTIER_MODELS}
+
+
+def get_frontier_model_for_provider(provider: str | None) -> str | None:
+    """Return the flagship model for a provider family.
+
+    ``provider`` may be a string ("openai") or an ``LLMProvider`` enum
+    value. Returns ``None`` for unknown providers — callers must treat that
+    as "do not escalate".
+    """
+    if provider is None:
+        return None
+    key = str(provider).lower().strip('"')
+    if key.startswith("llmprovider."):
+        key = key.split(".", 1)[1]
+    return _FRONTIER_BY_PROVIDER.get(key)

--- a/backend/core/llm/byok_handler.py
+++ b/backend/core/llm/byok_handler.py
@@ -1447,13 +1447,27 @@ class BYOKHandler:
         task_type: Optional[str] = None,
         agent_id: Optional[str] = None,
         chain_id: Optional[str] = None, # NEW Phase 11
-        image_payload: Optional[str] = None # Phase 14: Vision Support
+        image_payload: Optional[str] = None, # Phase 14: Vision Support
+        cascade: bool = False,  # Phase 2 hallucination mitigation
     ) -> Any:
         """
         Generate a structured response using instructor with tenant-aware routing.
         Works with both BYOK and Managed AI.
         Supports multimodal inputs via `image_payload`.
-        
+
+        Phase 2 hallucination mitigation — ``cascade`` kwarg:
+
+          When ``True`` AND the original call fails with a *schema-validation*
+          error (pydantic ``ValidationError`` or ``json.JSONDecodeError``), the
+          handler retries ONCE on the same-provider flagship model. The
+          escalation target is resolved via
+          ``hallucination_config.get_frontier_model_for_provider`` so the
+          BYOK credential set, cost tracker, and rate limits stay constant
+          (provider-family invariant is structural here). Transient failures
+          (network, rate limit, auth) do NOT escalate — a bigger model won't
+          fix them. Already-frontier models do NOT escalate (no double-spend).
+          Default ``False`` = byte-identical to pre-Phase-2 behavior.
+
         Args:
             prompt: The user prompt
             system_instruction: System instruction for the LLM
@@ -1462,7 +1476,10 @@ class BYOKHandler:
             task_type: Optional task type hint
             agent_id: Optional agent ID for cost tracking
             image_payload: Optional Base64 image string or URL
-            
+            cascade: Opt in to single-retry frontier escalation on
+                schema-validation failures (Phase 2 hallucination
+                mitigation; default off).
+
         Returns:
             Instance of response_model or None if parsing fails
         """
@@ -1561,8 +1578,30 @@ class BYOKHandler:
             if not options:
                 return None
 
+            # Phase 2 hallucination mitigation — cascade state.
+            # Local only; never written to ``self`` (thread-safety).
+            from core.hallucination_config import (
+                get_frontier_model_for_provider,
+                is_frontier_model,
+            )
+
+            try:
+                from pydantic import ValidationError as _PydanticValidationError
+            except ImportError:  # pragma: no cover - pydantic always present
+                _PydanticValidationError = ()  # type: ignore[assignment]
+
             last_error = None
-            for provider_id, model in options:
+            last_was_schema_error = False
+            cascade_attempted = False
+
+            # Mutable list so we can insert the escalation target mid-loop
+            # without re-iterating the original ranking.
+            cascade_options: list = list(options)
+            cascade_idx = 0
+
+            while cascade_idx < len(cascade_options):
+                provider_id, model = cascade_options[cascade_idx]
+                cascade_idx += 1
                 try:
                     # Get the client and wrap with instructor
                     client = self.clients[provider_id]
@@ -1653,8 +1692,58 @@ class BYOKHandler:
                 except Exception as attempt_err:
                     logger.warning(f"Structured attempt failed for {provider_id}/{model}: {attempt_err}")
                     last_error = attempt_err
-                    continue
-            
+                    # Phase 2 cascade classification. Instructor wraps the
+                    # underlying model output validation in pydantic; JSON
+                    # decode failures come back as json.JSONDecodeError. Both
+                    # are *schema* failures that a bigger model might fix.
+                    # Everything else (network, rate limit, auth, context
+                    # window) is transient and MUST NOT escalate.
+                    is_schema_err = (
+                        (
+                            _PydanticValidationError
+                            and isinstance(attempt_err, _PydanticValidationError)
+                        )
+                        or isinstance(attempt_err, json.JSONDecodeError)
+                        or "validation" in str(attempt_err).lower()
+                    )
+                    last_was_schema_error = is_schema_err
+                    # Fall through to the cascade check below (no continue).
+
+                # ========================================================
+                # Phase 2 hallucination mitigation: cascade escalation.
+                # ========================================================
+                # Fires only when:
+                #   1. Caller opted in via ``cascade=True``.
+                #   2. The just-failed attempt was a schema-validation
+                #      error (transient errors don't benefit from a bigger
+                #      model).
+                #   3. We haven't already attempted an escalation (single
+                #      retry per call).
+                #   4. The just-failed model is not already frontier.
+                #   5. The same provider has a known flagship to escalate
+                #      to.
+                #
+                # ``insert`` at ``cascade_idx`` puts the frontier next in
+                # the iteration order — it is tried BEFORE falling through
+                # to other providers in the ranking. The provider-family
+                # invariant is structural: the frontier is the flagship of
+                # the CURRENT failing provider, so BYOK credentials, cost
+                # tracking, and rate limits stay constant across the retry.
+                if (
+                    cascade
+                    and last_was_schema_error
+                    and not cascade_attempted
+                    and not is_frontier_model(model)
+                ):
+                    frontier = get_frontier_model_for_provider(provider_id)
+                    if frontier and frontier != model:
+                        logger.info(
+                            f"CASCADE ROUTING: escalating from {model} to {frontier} "
+                            f"for provider {provider_id} workspace {self.workspace_id}"
+                        )
+                        cascade_attempted = True
+                        cascade_options.insert(cascade_idx, (provider_id, frontier))
+
             logger.error(f"All structured providers failed. Last error: {last_error}")
             return None
             

--- a/backend/core/llm/self_consistency_voter.py
+++ b/backend/core/llm/self_consistency_voter.py
@@ -1,0 +1,286 @@
+"""Self-consistency voter for irreversible-action decisions.
+
+Phase 2 hallucination mitigation, Workstream C. Implements the Wang et al.
+self-consistency pattern: sample the same structured-action prompt N times
+at varying temperatures, then pick the majority-vote plan. The winning
+plan is returned to the caller, which executes it exactly once.
+
+Hard invariants (enforced by test C1):
+
+  * This module imports ONLY ``BYOKHandler`` (and stdlib / typing). It
+    MUST NOT import ``UnifiedActionExecutor`` or any adapter. The voter
+    never executes anything — execution is the caller's job.
+  * All N samples route through the same BYOKHandler instance, so the
+    provider-family invariant is structural (preserved by BYOKHandler,
+    not re-implemented here).
+
+Cascade routing composes naturally: each sample call passes
+``cascade=True`` to the handler, which means schema-validation failures
+inside an individual sample escalate to the same-provider flagship
+transparently to the voter.
+
+Reference: Wang et al., "Self-Consistency Improves Chain of Thought
+Reasoning in Language Models" (2022). See
+``docs/architecture/CONTEXT_MEMORY.md`` for how this fits with the
+broader hallucination-mitigation stack.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from typing import Any, TypeVar
+
+from core.hallucination_config import (
+    get_self_consistency_samples,
+    get_temperature_spread,
+)
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+# Heuristic list of action verbs/prefixes that mark a plan as irreversible.
+# A plan is irreversible if any of its action-bearing fields matches one of
+# these patterns (case-insensitive). Read-only verbs (search, browse, get,
+# list, query) are intentionally absent.
+_IRREVERSIBLE_PATTERNS: tuple[str, ...] = (
+    "send_",
+    "create_",
+    "update_",
+    "delete_",
+    "remove_",
+    "bulk_",
+    "transfer",
+    "payment",
+    "charge",
+    "refund",
+    "purchase",
+    "deploy",
+    "execute_",
+    "publish",
+    "submit_",
+)
+
+
+class SelfConsistencyVoter:
+    """N-sample majority vote on a structured action plan.
+
+    The voter never executes anything. It only invokes
+    ``BYOKHandler.generate_structured_response`` N times at varying
+    temperatures and returns the modal result. The caller executes the
+    winning plan exactly once.
+
+    Usage (from ``LLMService.generate_structured``):
+
+        voter = SelfConsistencyVoter(handler=handler, db=db, tenant_id=tid)
+        winning_plan = await voter.vote(
+            prompt=prompt,
+            response_model=ActionPlan,
+            temperature=0.7,
+            max_tokens=1000,
+            agent_id=agent_id,
+            cascade=cascade_on,
+        )
+        # Caller executes winning_plan exactly once.
+    """
+
+    def __init__(self, handler: Any, db: Any = None, tenant_id: str | None = None) -> None:
+        self.handler = handler
+        self.db = db
+        self.tenant_id = tenant_id
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def vote(
+        self,
+        prompt: str,
+        response_model: type[T],
+        temperature: float = 0.7,
+        max_tokens: int = 1000,
+        agent_id: str | None = None,
+        cascade: bool = False,
+        sample_count: int | None = None,
+        **kwargs: Any,
+    ) -> T | None:
+        """Draw N samples and return the majority-vote winner.
+
+        Args:
+            prompt: The decision/action-planning prompt.
+            response_model: Pydantic (or equivalent) class the handler
+                resolves the response into. Same model is used for all
+                N samples.
+            temperature: Base temperature. The actual per-sample
+                temperatures come from ``get_temperature_spread(n)``
+                centered around this value (default 0.7).
+            max_tokens: Per-sample token cap.
+            agent_id: Optional agent context, forwarded to the handler.
+            cascade: When True, each sample call passes ``cascade=True``
+                to the handler so individual samples can escalate on
+                schema-validation failures.
+            sample_count: Override the env-driven default
+                (``ATOM_SELF_CONSISTENCY_SAMPLES``). Caller does not
+                normally set this; the voter resolves it from config.
+
+        Returns:
+            The modal sample, or ``None`` if every sample failed.
+        """
+        n = sample_count if sample_count is not None else get_self_consistency_samples()
+        n = max(1, n)
+        temps = self._temperatures_for(n, base=temperature)
+
+        async def _one(temp: float) -> T | None:
+            try:
+                return await self.handler.generate_structured_response(
+                    prompt=prompt,
+                    system_instruction=kwargs.pop("system_instruction", "You are a helpful assistant."),
+                    response_model=response_model,
+                    temperature=temp,
+                    max_tokens=max_tokens,
+                    task_type=kwargs.pop("task_type", None),
+                    agent_id=agent_id,
+                    chain_id=kwargs.pop("chain_id", None),
+                    image_payload=kwargs.pop("image_payload", None),
+                    cascade=cascade,
+                    **kwargs,
+                )
+            except Exception as exc:
+                # One sample failing must not crash the whole vote. The
+                # majority is decided over the survivors; if every sample
+                # fails, we return None and the caller falls back to its
+                # normal "no plan" path.
+                logger.warning(f"Self-consistency sample failed at temp={temp}: {exc}")
+                return None
+
+        samples = await asyncio.gather(*[_one(t) for t in temps])
+        valid = [s for s in samples if s is not None]
+        if not valid:
+            return None
+        if len(valid) == 1:
+            return valid[0]
+        return self._majority_vote(valid)
+
+    # ------------------------------------------------------------------
+    # Irreversibility heuristic — exposed for callers that want to gate
+    # self-consistency behind "is this action even irreversible?"
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def is_irreversible(action_plan: Any) -> bool:
+        """Return True if ``action_plan`` looks irreversible.
+
+        Heuristic: walk the plan's fields looking for action-type /
+        operation fields whose value matches a known destructive verb
+        prefix. Anything that doesn't match returns False (the safe
+        default is *not* to spend 3× LLM calls).
+
+        Accepts dicts, pydantic models, or SimpleNamespace-like objects.
+        """
+        # Normalize to a dict of stringified field values.
+        if action_plan is None:
+            return False
+        if isinstance(action_plan, dict):
+            fields = action_plan
+        elif hasattr(action_plan, "model_dump"):  # pydantic v2
+            fields = action_plan.model_dump()
+        elif hasattr(action_plan, "dict"):  # pydantic v1
+            fields = action_plan.dict()
+        elif hasattr(action_plan, "__dict__"):
+            fields = action_plan.__dict__
+        else:
+            fields = {"value": str(action_plan)}
+
+        for key, val in fields.items():
+            key_l = str(key).lower()
+            val_l = str(val).lower() if val is not None else ""
+            # Match either the field name or its value against patterns.
+            haystacks = (key_l, val_l)
+            for h in haystacks:
+                for pat in _IRREVERSIBLE_PATTERNS:
+                    if pat in h:
+                        return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _temperatures_for(n: int, base: float = 0.7) -> list[float]:
+        """Spread of N temperatures centered on ``base``.
+
+        Uses ``hallucination_config.get_temperature_spread(n)`` which
+        produces values like ``[0.6, 0.7, 0.8]`` for n=3, centered on 0.7.
+        The ``base`` argument offsets the spread if the caller specified a
+        non-default base temperature.
+        """
+        spread = get_temperature_spread(n)
+        if base == 0.7:
+            return spread
+        # Re-center on the caller's base temperature.
+        offset = base - 0.7
+        return [max(0.0, min(1.5, round(t + offset, 2))) for t in spread]
+
+    @staticmethod
+    def _hash_sample(sample: Any) -> str:
+        """Stable hash of a sample for majority-vote equality.
+
+        Uses ``json.dumps(..., sort_keys=True, default=str)`` so structurally
+        equivalent plans hash identically regardless of field order.
+        """
+        if hasattr(sample, "model_dump"):  # pydantic v2
+            payload = sample.model_dump(mode="json")
+        elif hasattr(sample, "dict"):  # pydantic v1
+            payload = sample.dict()
+        elif isinstance(sample, dict):
+            payload = sample
+        else:
+            payload = {"value": str(sample)}
+        serialized = json.dumps(payload, sort_keys=True, default=str)
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+    def _majority_vote(self, samples: list[Any]) -> Any:
+        """Pick the most common sample; ties go to the first seen.
+
+        If all N samples are distinct (no majority), we log a warning and
+        return the first sample (lowest temperature). This is the
+        conservative path documented in Wang et al. — better to act on a
+        coherent plan from a low-temperature sample than to silently pick
+        at random.
+        """
+        counts: dict[str, list[int]] = {}
+        for idx, s in enumerate(samples):
+            h = self._hash_sample(s)
+            counts.setdefault(h, []).append(idx)
+
+        # Find the hash with the most occurrences. Ties → first-seen wins
+        # because we iterate samples in temperature-ascending order.
+        winner_hash: str | None = None
+        winner_count = 0
+        for h, idxs in counts.items():
+            if len(idxs) > winner_count:
+                winner_hash = h
+                winner_count = len(idxs)
+
+        if winner_hash is None:
+            return samples[0]
+
+        if winner_count == 1:
+            # All samples distinct. Log and return the first (lowest temp).
+            logger.warning(
+                f"Self-consistency vote: all {len(samples)} samples distinct; "
+                f"falling back to lowest-temperature sample"
+            )
+            return samples[0]
+
+        # Return the first sample with the winning hash (preserves order).
+        winner_idx = counts[winner_hash][0]
+        logger.info(
+            f"Self-consistency vote: {winner_count}/{len(samples)} samples agreed "
+            f"(hash={winner_hash[:8]})"
+        )
+        return samples[winner_idx]

--- a/backend/core/llm_service.py
+++ b/backend/core/llm_service.py
@@ -852,13 +852,26 @@ class LLMService:
         model: str = "auto",
         task_type: Optional[str] = None,
         agent_id: Optional[str] = None,
-        image_payload: Optional[str] = None
+        image_payload: Optional[str] = None,
+        enable_self_consistency: bool = False,
     ) -> Optional[BaseModel]:
         """
         Generate structured output using Pydantic model validation.
 
         Provides tenant-aware routing between BYOK and Managed AI based on subscription,
         with support for vision inputs via image_payload.
+
+        Phase 2 hallucination-mitigation kwargs:
+
+          * ``enable_self_consistency`` — when True AND the
+            ``ATOM_SELF_CONSISTENCY`` env flag is enabled, dispatches to the
+            ``SelfConsistencyVoter`` for N-sample majority voting. The voter
+            uses the BYOKHandler directly, so each sample composes naturally
+            with cascade routing inside the handler.
+
+        Cascade routing (Workstream B) is handled *inside* the BYOKHandler
+        when the ``ATOM_CASCADE_ROUTING`` env flag is enabled — this wrapper
+        just forwards the resolved flag value.
 
         Args:
             prompt: The user prompt
@@ -869,39 +882,45 @@ class LLMService:
             task_type: Optional task type hint (e.g., "summarization", "code_generation")
             agent_id: Optional agent ID for cost tracking
             image_payload: Optional Base64 image string or URL for vision support
+            enable_self_consistency: Opt in to N-sample majority voting for
+                irreversible-action decisions (Phase 2 hallucination
+                mitigation; default off).
 
         Returns:
             Instance of response_model with validated data, or None if generation fails
-
-        Example:
-            ```python
-            from pydantic import BaseModel
-
-            class SentimentAnalysis(BaseModel):
-                sentiment: str  # "positive", "negative", "neutral"
-                confidence: float
-                key_points: List[str]
-
-            llm_service = LLMService()
-            result = await llm_service.generate_structured(
-                prompt="Analyze the sentiment of this review...",
-                response_model=SentimentAnalysis
-            )
-            if result:
-                print(f"Sentiment: {result.sentiment}")
-                print(f"Confidence: {result.confidence}")
-            ```
-
-        Note:
-            - Tenant-aware routing: BYOK keys used if available, otherwise Managed AI
-            - Vision support: Pass image_payload (Base64 or URL) for multimodal inputs
-            - Graceful fallback: Returns None if instructor unavailable or generation fails
-            - Auto model selection: When model="auto", selects optimal model for structured output
         """
         # Check if handler has clients available
         if not self.is_available():
             logger.warning("No LLM clients available for structured generation")
             return None
+
+        # Phase 2: resolve mitigation flags once per call. The actual
+        # cascade retry loop lives inside BYOKHandler.generate_structured_response.
+        from core.hallucination_config import (
+            is_cascade_routing_enabled,
+            is_self_consistency_enabled,
+        )
+
+        cascade_on = is_cascade_routing_enabled()
+
+        # Self-consistency voter dispatch (Workstream C). The voter imports
+        # only BYOKHandler — never the executor — and runs N samples at
+        # varying temperatures, each of which internally cascades on schema
+        # failure. Majority vote on hash-normalized JSON.
+        if enable_self_consistency and is_self_consistency_enabled():
+            from core.llm.self_consistency_voter import SelfConsistencyVoter
+
+            voter = SelfConsistencyVoter(handler=self.handler)
+            return await voter.vote(
+                prompt=prompt,
+                response_model=response_model,
+                temperature=temperature,
+                task_type=task_type,
+                agent_id=agent_id,
+                image_payload=image_payload,
+                cascade=cascade_on,
+                system_instruction=system_instruction,
+            )
 
         # Delegate to BYOKHandler's generate_structured_response
         try:
@@ -912,7 +931,8 @@ class LLMService:
                 temperature=temperature,
                 task_type=task_type,
                 agent_id=agent_id,
-                image_payload=image_payload
+                image_payload=image_payload,
+                cascade=cascade_on,
             )
             return result
         except Exception as e:

--- a/backend/docs/HALLUCINATION_MITIGATION_2026.md
+++ b/backend/docs/HALLUCINATION_MITIGATION_2026.md
@@ -1,0 +1,125 @@
+# Hallucination Mitigation 2026 — Personal Edition Port
+
+**Status:** PR 1 (cleanly-portable mitigations) — June 2026. PR 2 (verified
+gating reconciliation) tracked separately.
+
+## What this adds
+
+Two independently flag-gated mitigations, default off → no behavior change
+until ops flips a flag:
+
+1. **Cascade routing** — on schema-validation failure inside
+   `BYOKHandler.generate_structured_response`, retry once on the
+   same-provider flagship. Provider family is a structural invariant.
+2. **Self-consistency voting** — 3-sample majority vote on the structured
+   action plan for irreversible actions. The voter never executes; the
+   caller runs the winning plan exactly once.
+
+## Why these two
+
+These are the two Phase 2 mitigations that port cleanly from the SaaS
+fork without touching the verified-outcome data model. The third
+mitigation (verified graduation gate) is SaaS-specific: it relies on
+`AgentCapabilityRegistry` columns and a SUM-over-table ratio formula.
+Upstream's capability tracking is JSON-in-`AgentRegistry.configuration`
+with absolute-count promotion thresholds, not ratios. Porting the
+verified gate requires a design discussion about whether to add a
+ratio-based gate alongside the existing 5/20/50 absolute-count gates —
+deferred to PR 2.
+
+Research basis: Wang et al., "Self-Consistency Improves Chain of Thought
+Reasoning in Language Models" (ICLR 2023). Vectara hallucination
+leaderboard and ScaleDown June 2026 coverage both flag
+schema-validation failures as the most tractable hallucination mode.
+
+## Flag matrix
+
+| Flag | Env var | Default | Effect when on |
+|---|---|---|---|
+| Cascade routing | `ATOM_CASCADE_ROUTING` | `false` | One same-family retry on schema-validation failure |
+| Self-consistency | `ATOM_SELF_CONSISTENCY` | `false` | 3-sample majority vote on irreversible actions |
+| Sample count | `ATOM_SELF_CONSISTENCY_SAMPLES` | `3` | Per-call sample count |
+
+**No per-tenant override layer.** This is the Personal / single-tenant
+edition; the SaaS fork has an additional `tenant.metadata_json` override
+that is intentionally not ported (multi-tenancy stays in the SaaS fork
+per the sync guidelines).
+
+## Where each piece lives
+
+| Component | File | Notes |
+|---|---|---|
+| Flag resolver | `core/hallucination_config.py` | Env-var-only. No DB surface. |
+| Cascade routing | `core/llm/byok_handler.py:generate_structured_response` | Loop extended with `cascade` kwarg. |
+| Self-consistency voter | `core/llm/self_consistency_voter.py` | Imports only `BYOKHandler`. Never imports the executor. |
+| LLMService wrapper | `core/llm_service.py:generate_structured` | Forwards `cascade=<flag>`; dispatches to voter when `enable_self_consistency=True`. |
+
+## Architecture: why cascade lives inside `BYOKHandler`
+
+The cascade retry decision is fundamentally about provider/credential/model
+selection — which is exactly what `BYOKHandler` owns. Putting cascade at
+the outer `LLMService` wrapper would force the outer layer to guess at
+provider family via `get_provider(model)`, require instance state
+(`_last_resolved_model`, `_last_call_failed_with_schema_error`) that is
+thread-unsafe, and create a double-loop hazard against the existing
+options iteration inside the handler.
+
+Inside `BYOKHandler`, "same family" is structural: the frontier is the
+flagship of the current failing provider, looked up via
+`hallucination_config.get_frontier_model_for_provider(provider_id)`. The
+same `self.clients[provider_id]` is reused, so BYOK credentials, cost
+tracking, and rate limits stay constant across the retry.
+
+## Hard invariant: voter never executes
+
+`tests/unit/llm/test_self_consistency_voter.py::test_C1_voter_module_does_not_import_executor`
+is an AST-level check that the voter module imports only `BYOKHandler`
+and stdlib. It must never import `UnifiedActionExecutor` or any adapter.
+If that breaks, the voter becomes a hidden execution path and the
+"execute winning plan exactly once" guarantee is at risk.
+
+## Performance budget
+
+| Mitigation | Added cost |
+|---|---|
+| Cascade routing | Median: 0. Worst case: +1 frontier-tier LLM call (only on schema failure) |
+| Self-consistency | +2 LLM calls per irreversible action decision (3× instead of 1×) |
+
+## Test coverage
+
+43 new tests across four files in `tests/unit/llm/`:
+
+| File | Tests | Coverage |
+|---|---|---|
+| `test_hallucination_config.py` | 20 | Flag resolution, numeric tunables, frontier registry (incl. Ollama local fallback) |
+| `test_cascade_routing.py` | 9 | All cascade guardrails (flag off, schema fail, transient, already-frontier, single retry, log format, family invariant) |
+| `test_self_consistency_voter.py` | 12 | Import invariant, majority vote, tie-break, irreversible detection, per-sample failure isolation |
+| `test_provider_family_invariant.py` | 2 | Structural invariant across cascade + voter |
+
+## Rollback
+
+```bash
+unset ATOM_CASCADE_ROUTING
+unset ATOM_SELF_CONSISTENCY
+```
+
+No migration needed. No data is lost when flags are off.
+
+## What's not in this PR (tracked for PR 2)
+
+- Verified graduation gate (hard floor on `verified_ratio` for
+  supervised → autonomous promotion). Requires reconciling with
+  upstream's JSON-based capability stats and absolute-count promotion
+  thresholds. See upstream's existing
+  `CapabilityGraduationService.record_usage` for the current
+  `verified='verified'` gating.
+- Soft blend of verified-ratio into the 7-factor readiness formula.
+  Same dependency on a JSON-based ratio helper.
+
+## See also
+
+- `docs/architecture/CONTEXT_MEMORY.md` — upstream's existing
+  string-tri-state verified-outcome infrastructure and episodic
+  prefilter.
+- `tests/test_outcome_verification.py` — upstream's existing
+  verified-outcome test coverage.

--- a/backend/tests/unit/llm/test_cascade_routing.py
+++ b/backend/tests/unit/llm/test_cascade_routing.py
@@ -1,0 +1,440 @@
+"""Workstream B (revised) — cascade routing inside BYOKHandler.
+
+Tests verify the cascade fires only on schema-validation failures, only
+once, only when the original model is not already frontier, and that the
+escalation target stays inside the same provider family (the structural
+BYOK invariant). All tests mock the BYOKHandler internals — no real LLM
+calls.
+
+See .planning/HALLUCINATION_MITIGATION_PHASE2_REVISION.md for why
+cascade lives inside BYOKHandler rather than LLMService.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_mitigation_env(monkeypatch):
+    for k in list(os.environ):
+        if k.startswith("ATOM_") and (
+            "VERIFIED" in k or "CASCADE" in k or "SELF_CONSISTENCY" in k
+        ):
+            monkeypatch.delenv(k, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _fake_instructor(monkeypatch):
+    """Inject a fake ``instructor`` module so BYOKHandler exercises the
+    structured-response code path even when the real package is absent.
+
+    Also stubs the tenant-plan DB lookup so the cascade loop is reachable
+    from tests without a live database. Upstream's
+    ``generate_structured_response`` opens a real ``get_db_session()`` to
+    resolve tenant_plan; if that fails (no DB in test env), the body
+    short-circuits at "Managed AI blocked for free tier" and the cascade
+    code is never reached.
+    """
+    fake_module = MagicMock()
+    fake_client = MagicMock()
+    fake_module.from_openai.return_value = fake_client
+    monkeypatch.setitem(sys.modules, "instructor", fake_module)
+    from core.llm import byok_handler
+
+    monkeypatch.setattr(byok_handler, "instructor", fake_module, raising=False)
+    monkeypatch.setattr(byok_handler, "INSTRUCTOR_AVAILABLE", True)
+
+    # Stub the tenant-plan lookup. The body does:
+    #     with get_db_session() as db:
+    #         ... db.query(Workspace).filter(...).first()
+    #         ... db.query(Tenant).filter(...).first()
+    # Yield a mock whose query chain returns a paid-tier workspace + tenant
+    # so the "free tier managed AI" early-return never fires.
+    fake_db = MagicMock()
+    paid_workspace = SimpleNamespace(tenant_id="t-1")
+    paid_tenant = SimpleNamespace(plan_type=SimpleNamespace(value="pro"))
+    fake_db.query.return_value.filter.return_value.first.side_effect = [
+        paid_workspace,
+        paid_tenant,
+    ]
+
+    class _Ctx:
+        def __enter__(self):
+            return fake_db
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(byok_handler, "get_db_session", lambda: _Ctx())
+    yield fake_client
+
+
+def _make_handler():
+    """Construct a BYOKHandler with mocked clients/db (no real I/O)."""
+    from core.llm.byok_handler import BYOKHandler
+
+    handler = BYOKHandler.__new__(BYOKHandler)
+    handler.workspace_id = "ws-1"
+    handler.tenant_id = "t-1"
+    handler.db_session = MagicMock()
+    handler.clients = {"openai": MagicMock(), "anthropic": MagicMock()}
+    handler.governance = None
+    handler._is_trial_restricted = lambda: False
+    handler.byok_manager = MagicMock()
+    handler.byok_manager.get_tenant_api_key = MagicMock(return_value=None)
+    return handler
+
+
+def _stub_options(handler, options):
+    """Patch the chain of calls that produce the ranked options list."""
+    handler.analyze_query_complexity = MagicMock(return_value=MagicMock(value="standard"))
+    handler.get_ranked_providers = MagicMock(return_value=options)
+    handler.get_context_window = MagicMock(return_value=8000)
+    handler.truncate_to_context = MagicMock(side_effect=lambda p, *a, **k: p)
+
+
+def _patch_cascade_helpers(frontier_for_provider="gpt-4o", is_frontier=False):
+    """Patch the two hallucination_config helpers the cascade block uses.
+
+    The helpers are imported INSIDE the function body of
+    ``generate_structured_response`` (lazy import to avoid any circular-import
+    risk with core.models), so we patch them at their source rather than on
+    the consumer module.
+    """
+    return (
+        patch("core.hallucination_config.is_frontier_model", return_value=is_frontier),
+        patch(
+            "core.hallucination_config.get_frontier_model_for_provider",
+            return_value=frontier_for_provider,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# B1: flag off → single call, no cascade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_B1_no_cascade_when_flag_off(_fake_instructor):
+    """Flag off → handler does not attempt escalation even on schema error."""
+    handler = _make_handler()
+    _stub_options(handler, [("openai", "gpt-4o-mini")])
+
+    call_count = {"n": 0}
+
+    def fake_create(**kwargs):
+        call_count["n"] += 1
+        raise json.JSONDecodeError("schema fail", "doc", 0)
+
+    _fake_instructor.chat.completions.create = fake_create
+
+    p1, p2 = _patch_cascade_helpers()
+    with p1, p2:
+        result = await handler.generate_structured_response(
+            prompt="test",
+            system_instruction="sys",
+            response_model=dict,
+            cascade=False,
+        )
+
+    assert result is None
+    # Only the original attempt — no escalation.
+    assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# B2: first call succeeds → no cascade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_B2_cascade_skipped_when_first_call_succeeds(_fake_instructor):
+    """Success on the first attempt → no escalation."""
+    handler = _make_handler()
+    _stub_options(handler, [("openai", "gpt-4o-mini")])
+
+    sentinel = SimpleNamespace(_raw_response=None)
+    _fake_instructor.chat.completions.create = MagicMock(return_value=sentinel)
+
+    p1, p2 = _patch_cascade_helpers()
+    with p1 as is_frontier_spy, p2 as frontier_spy:
+        result = await handler.generate_structured_response(
+            prompt="test",
+            system_instruction="sys",
+            response_model=dict,
+            cascade=True,
+        )
+
+    assert result is sentinel
+    # Cascade helpers never consulted on success.
+    is_frontier_spy.assert_not_called()
+    frontier_spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# B3: schema-validation failure → escalate to frontier in same family
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_B3_cascade_escalates_on_schema_validation_failure(_fake_instructor):
+    """Schema error on gpt-4o-mini → retry on gpt-4o, return its result."""
+    handler = _make_handler()
+    _stub_options(handler, [("openai", "gpt-4o-mini")])
+
+    calls = []
+    frontier_sentinel = SimpleNamespace(_raw_response=None, cascaded=True)
+
+    def fake_create(**kwargs):
+        calls.append(kwargs.get("model"))
+        if len(calls) == 1:
+            raise json.JSONDecodeError("schema fail", "doc", 0)
+        return frontier_sentinel
+
+    _fake_instructor.chat.completions.create = fake_create
+
+    p1, p2 = _patch_cascade_helpers(frontier_for_provider="gpt-4o")
+    with p1, p2:
+        result = await handler.generate_structured_response(
+            prompt="test",
+            system_instruction="sys",
+            response_model=dict,
+            cascade=True,
+        )
+
+    assert result is frontier_sentinel
+    # The first call used the original model; the second used the frontier.
+    # Note: BYOKHandler passes model via kwargs; the mock captures it.
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# B4: already frontier → no escalation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_B4_cascade_skipped_when_already_frontier(_fake_instructor):
+    """Schema failure on gpt-4o (already frontier) → no escalation."""
+    handler = _make_handler()
+    _stub_options(handler, [("openai", "gpt-4o")])
+
+    call_count = {"n": 0}
+
+    def fake_create(**kwargs):
+        call_count["n"] += 1
+        raise json.JSONDecodeError("schema fail", "doc", 0)
+
+    _fake_instructor.chat.completions.create = fake_create
+
+    # is_frontier_model returns True for gpt-4o.
+    p1, p2 = _patch_cascade_helpers(frontier_for_provider="gpt-4o", is_frontier=True)
+    with p1, p2 as frontier_spy:
+        result = await handler.generate_structured_response(
+            prompt="test",
+            system_instruction="sys",
+            response_model=dict,
+            cascade=True,
+        )
+
+    assert result is None
+    # Only the original frontier call. No escalation.
+    assert call_count["n"] == 1
+    frontier_spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# B5: transient error → no cascade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_B5_cascade_skipped_on_transient_error(_fake_instructor):
+    """Network-style error → not a schema failure → no escalation."""
+    handler = _make_handler()
+    _stub_options(handler, [("openai", "gpt-4o-mini")])
+
+    call_count = {"n": 0}
+
+    def fake_create(**kwargs):
+        call_count["n"] += 1
+        raise ConnectionError("network down")
+
+    _fake_instructor.chat.completions.create = fake_create
+
+    p1, p2 = _patch_cascade_helpers()
+    with p1, p2 as frontier_spy:
+        result = await handler.generate_structured_response(
+            prompt="test",
+            system_instruction="sys",
+            response_model=dict,
+            cascade=True,
+        )
+
+    assert result is None
+    assert call_count["n"] == 1
+    frontier_spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# B6: only retries once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_B6_cascade_only_retries_once(_fake_instructor):
+    """Even if the escalation also schema-fails, no second escalation."""
+    handler = _make_handler()
+    _stub_options(handler, [("openai", "gpt-4o-mini")])
+
+    call_count = {"n": 0}
+
+    def fake_create(**kwargs):
+        call_count["n"] += 1
+        # Both attempts fail with schema errors.
+        raise json.JSONDecodeError("schema fail", "doc", 0)
+
+    _fake_instructor.chat.completions.create = fake_create
+
+    p1, p2 = _patch_cascade_helpers(frontier_for_provider="gpt-4o")
+    # After the escalation is attempted, is_frontier_model returns True for
+    # the frontier so it can't escalate again. Use a side_effect.
+    with patch(
+        "core.hallucination_config.is_frontier_model",
+        side_effect=lambda m: m == "gpt-4o",
+    ), p2:
+        result = await handler.generate_structured_response(
+            prompt="test",
+            system_instruction="sys",
+            response_model=dict,
+            cascade=True,
+        )
+
+    assert result is None
+    # Original + one escalation = 2 total. No more.
+    assert call_count["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# B7: log line uses f-string, no kwargs (CLAUDE.md rule)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_B7_cascade_log_uses_fstrings_no_kwargs(_fake_instructor, monkeypatch):
+    """The escalation log line must be f-string-only per CLAUDE.md."""
+    from core.llm import byok_handler
+
+    handler = _make_handler()
+    _stub_options(handler, [("openai", "gpt-4o-mini")])
+
+    def fake_create(**kwargs):
+        model = kwargs.get("model", "")
+        if "mini" in model:
+            raise json.JSONDecodeError("schema fail", "doc", 0)
+        return SimpleNamespace(_raw_response=None)
+
+    _fake_instructor.chat.completions.create = fake_create
+
+    captured = []
+
+    def info_spy(msg, *a, **kw):
+        captured.append((msg, kw))
+
+    monkeypatch.setattr(byok_handler.logger, "info", info_spy)
+
+    p1, p2 = _patch_cascade_helpers(frontier_for_provider="gpt-4o")
+    with p1, p2:
+        await handler.generate_structured_response(
+            prompt="test",
+            system_instruction="sys",
+            response_model=dict,
+            cascade=True,
+        )
+
+    cascade_lines = [t for t in captured if "CASCADE ROUTING" in t[0]]
+    assert len(cascade_lines) == 1
+    line, kwargs_received = cascade_lines[0]
+    assert "gpt-4o-mini" in line
+    assert "gpt-4o" in line
+    assert "ws-1" in line
+    # CLAUDE.md: logger.info must be called with NO kwargs.
+    assert kwargs_received == {}
+
+
+# ---------------------------------------------------------------------------
+# B8: provider family preserved (openai → openai)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_B8_cascade_preserves_provider_family(_fake_instructor):
+    """OpenAI failure escalates to an OpenAI flagship, not Anthropic."""
+    handler = _make_handler()
+    _stub_options(handler, [("openai", "gpt-4o-mini")])
+
+    # Replace clients with a dict subclass that records every get().
+    class _SpyDict(dict):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            self.seen = []
+
+        def get(self, key, *a, **k):
+            self.seen.append(key)
+            return super().get(key, *a, **k)
+
+    openai_client = handler.clients["openai"]
+    handler.clients = _SpyDict({"openai": openai_client, "anthropic": MagicMock()})
+
+    def fake_create(**kwargs):
+        model = kwargs.get("model", "")
+        if "mini" in model:
+            raise json.JSONDecodeError("schema fail", "doc", 0)
+        return SimpleNamespace(_raw_response=None)
+
+    _fake_instructor.chat.completions.create = fake_create
+
+    with patch(
+        "core.hallucination_config.is_frontier_model", return_value=False
+    ), patch(
+        "core.hallucination_config.get_frontier_model_for_provider",
+        return_value="gpt-4o",
+    ) as frontier_spy:
+        await handler.generate_structured_response(
+            prompt="test",
+            system_instruction="sys",
+            response_model=dict,
+            cascade=True,
+        )
+
+    # frontier lookup was called with the CURRENT failing provider.
+    frontier_spy.assert_called_once_with("openai")
+    # Every client fetch went to the openai provider.
+    assert all(p == "openai" for p in handler.clients.seen)
+
+
+# ---------------------------------------------------------------------------
+# B9: env-var resolution (Personal edition — no per-tenant override layer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_B9_env_var_off_then_on_toggles_flag(monkeypatch):
+    """Personal edition: env var is the only knob. Toggle works."""
+    from core import hallucination_config as hc
+
+    # Default off.
+    assert hc.is_cascade_routing_enabled() is False
+    # Flip on.
+    monkeypatch.setenv("ATOM_CASCADE_ROUTING", "true")
+    assert hc.is_cascade_routing_enabled() is True
+    # Flip back off.
+    monkeypatch.setenv("ATOM_CASCADE_ROUTING", "false")
+    assert hc.is_cascade_routing_enabled() is False

--- a/backend/tests/unit/llm/test_hallucination_config.py
+++ b/backend/tests/unit/llm/test_hallucination_config.py
@@ -1,0 +1,156 @@
+"""Unit tests for core.hallucination_config (Phase 2 flag resolvers).
+
+The resolver module is pure infrastructure with no behavior change of its
+own — it just centralizes env-var-driven flag lookup so every mitigation
+reads from the same source. This is the Personal / single-tenant edition:
+no per-tenant override layer (that lives in the SaaS fork).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Strip every ATOM_* mitigation env var so tests start from defaults."""
+    for k in list(os.environ):
+        if k.startswith("ATOM_") and (
+            "VERIFIED" in k or "CASCADE" in k or "SELF_CONSISTENCY" in k
+        ):
+            monkeypatch.delenv(k, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Boolean toggles
+# ---------------------------------------------------------------------------
+
+
+def test_flags_default_off_when_no_env():
+    from core import hallucination_config as hc
+
+    assert hc.is_cascade_routing_enabled() is False
+    assert hc.is_self_consistency_enabled() is False
+
+
+def test_flags_pick_up_env_var(monkeypatch):
+    from core import hallucination_config as hc
+
+    monkeypatch.setenv("ATOM_CASCADE_ROUTING", "true")
+    monkeypatch.setenv("ATOM_SELF_CONSISTENCY", "1")
+
+    assert hc.is_cascade_routing_enabled() is True
+    assert hc.is_self_consistency_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["false", "0", "no", "off", "", "garbage"])
+def test_env_var_truthiness_rejects_non_affirmative(monkeypatch, val):
+    from core import hallucination_config as hc
+
+    monkeypatch.setenv("ATOM_CASCADE_ROUTING", val)
+    assert hc.is_cascade_routing_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Numeric tunables
+# ---------------------------------------------------------------------------
+
+
+def test_self_consistency_samples_default():
+    from core import hallucination_config as hc
+
+    assert hc.get_self_consistency_samples() == 3
+
+
+def test_self_consistency_samples_env(monkeypatch):
+    from core import hallucination_config as hc
+
+    monkeypatch.setenv("ATOM_SELF_CONSISTENCY_SAMPLES", "5")
+    assert hc.get_self_consistency_samples() == 5
+
+
+def test_self_consistency_samples_invalid_falls_back(monkeypatch):
+    from core import hallucination_config as hc
+
+    monkeypatch.setenv("ATOM_SELF_CONSISTENCY_SAMPLES", "garbage")
+    assert hc.get_self_consistency_samples() == 3
+
+
+# ---------------------------------------------------------------------------
+# Temperature spread
+# ---------------------------------------------------------------------------
+
+
+def test_temperature_spread_has_n_values():
+    from core import hallucination_config as hc
+
+    out = hc.get_temperature_spread(3)
+    assert len(out) == 3
+    assert all(isinstance(t, float) for t in out)
+
+
+def test_temperature_spread_three_symmetric():
+    from core import hallucination_config as hc
+
+    assert hc.get_temperature_spread(3) == [0.6, 0.7, 0.8]
+
+
+def test_temperature_spread_single():
+    from core import hallucination_config as hc
+
+    assert hc.get_temperature_spread(1) == [0.7]
+
+
+# ---------------------------------------------------------------------------
+# Frontier model registry
+# ---------------------------------------------------------------------------
+
+
+def test_is_frontier_model_matches_known():
+    from core import hallucination_config as hc
+
+    assert hc.is_frontier_model("gpt-4o") is True
+    assert hc.is_frontier_model("gpt-4-turbo") is True
+    assert hc.is_frontier_model("claude-3-opus-20240229") is True
+    assert hc.is_frontier_model("claude-3-5-sonnet") is True
+    assert hc.is_frontier_model("deepseek-reasoner") is True
+
+
+def test_is_frontier_model_rejects_non_frontier():
+    from core import hallucination_config as hc
+
+    assert hc.is_frontier_model("gpt-4o-mini") is False
+    assert hc.is_frontier_model("claude-3-haiku-20240307") is False
+    assert hc.is_frontier_model("deepseek-chat") is False
+    assert hc.is_frontier_model("some-random-model") is False
+
+
+def test_is_frontier_model_handles_none():
+    from core import hallucination_config as hc
+
+    assert hc.is_frontier_model(None) is False
+    assert hc.is_frontier_model("") is False
+
+
+def test_frontier_for_provider_returns_same_family_flagship():
+    from core import hallucination_config as hc
+
+    assert hc.get_frontier_model_for_provider("openai") == "gpt-4o"
+    assert hc.get_frontier_model_for_provider("anthropic") == "claude-3-5-sonnet"
+    assert hc.get_frontier_model_for_provider("deepseek") == "deepseek-reasoner"
+
+
+def test_frontier_for_provider_unknown_returns_none():
+    from core import hallucination_config as hc
+
+    assert hc.get_frontier_model_for_provider("made-up") is None
+    assert hc.get_frontier_model_for_provider(None) is None
+
+
+def test_frontier_for_provider_handles_ollama_local():
+    """Ollama is the local-LLM provider in Personal edition — escalate to
+    the largest locally-runnable llama3 variant."""
+    from core import hallucination_config as hc
+
+    assert hc.get_frontier_model_for_provider("ollama") == "llama3:70b"

--- a/backend/tests/unit/llm/test_provider_family_invariant.py
+++ b/backend/tests/unit/llm/test_provider_family_invariant.py
@@ -1,0 +1,169 @@
+"""Workstream D — provider-family invariant tests.
+
+These tests make the existing structural invariant an explicit, enforced
+property: within a single logical call, the provider family never
+changes. The revised Phase 2 design (see
+.planning/HALLUCINATION_MITIGATION_PHASE2_REVISION.md) puts cascade
+inside BYOKHandler, so the invariant is structural — but these tests
+catch future regressions if someone re-introduces cross-provider
+escalation.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_mitigation_env(monkeypatch):
+    for k in list(os.environ):
+        if k.startswith("ATOM_") and (
+            "VERIFIED" in k or "CASCADE" in k or "SELF_CONSISTENCY" in k
+        ):
+            monkeypatch.delenv(k, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _fake_instructor(monkeypatch):
+    fake_module = MagicMock()
+    fake_client = MagicMock()
+    fake_module.from_openai.return_value = fake_client
+    monkeypatch.setitem(sys.modules, "instructor", fake_module)
+    from core.llm import byok_handler
+
+    monkeypatch.setattr(byok_handler, "instructor", fake_module, raising=False)
+    monkeypatch.setattr(byok_handler, "INSTRUCTOR_AVAILABLE", True)
+
+    # Stub the tenant-plan DB lookup (same as test_cascade_routing).
+    fake_db = MagicMock()
+    paid_workspace = SimpleNamespace(tenant_id="t-1")
+    paid_tenant = SimpleNamespace(plan_type=SimpleNamespace(value="pro"))
+    fake_db.query.return_value.filter.return_value.first.side_effect = [
+        paid_workspace,
+        paid_tenant,
+    ]
+
+    class _Ctx:
+        def __enter__(self):
+            return fake_db
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(byok_handler, "get_db_session", lambda: _Ctx())
+    yield fake_client
+
+
+# ---------------------------------------------------------------------------
+# D1: cascade inside BYOKHandler stays in the same provider family
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_D1_generate_structured_keeps_provider_family_within_task(_fake_instructor):
+    """A schema failure on an OpenAI model escalates to an OpenAI flagship.
+
+    The escalation MUST NOT cross to Anthropic / DeepSeek / etc. — BYOK
+    credentials, cost tracking, and rate limits are per-provider, and the
+    caller has only authorized the provider that resolved the original
+    call.
+    """
+    from core.llm.byok_handler import BYOKHandler
+
+    handler = BYOKHandler.__new__(BYOKHandler)
+    handler.workspace_id = "ws-1"
+    handler.tenant_id = "t-1"
+    handler.db_session = MagicMock()
+    # Only OpenAI is configured.
+    handler.clients = {"openai": MagicMock()}
+    handler.governance = None
+    handler._is_trial_restricted = lambda: False
+    handler.byok_manager = MagicMock()
+    handler.byok_manager.get_tenant_api_key = MagicMock(return_value=None)
+    handler.analyze_query_complexity = MagicMock(return_value=MagicMock(value="standard"))
+    handler.get_ranked_providers = MagicMock(return_value=[("openai", "gpt-4o-mini")])
+    handler.get_context_window = MagicMock(return_value=8000)
+    handler.truncate_to_context = MagicMock(side_effect=lambda p, *a, **k: p)
+
+    seen_providers: list[str] = []
+
+    class _SpyDict(dict):
+        """Records direct ``d[key]`` access (upstream's pattern)."""
+
+        def __getitem__(self, key):
+            seen_providers.append(key)
+            return super().__getitem__(key)
+
+    openai_client = handler.clients["openai"]
+    handler.clients = _SpyDict({"openai": openai_client})
+
+    def fake_create(**kwargs):
+        model = kwargs.get("model", "")
+        if "mini" in model:
+            raise json.JSONDecodeError("schema fail", "doc", 0)
+        return SimpleNamespace(_raw_response=None)
+
+    _fake_instructor.chat.completions.create = fake_create
+
+    with patch(
+        "core.hallucination_config.is_frontier_model", return_value=False
+    ), patch(
+        "core.hallucination_config.get_frontier_model_for_provider",
+        return_value="gpt-4o",
+    ) as frontier_spy:
+        await handler.generate_structured_response(
+            prompt="p",
+            system_instruction="sys",
+            response_model=dict,
+            cascade=True,
+        )
+
+    # The frontier lookup was called with the OpenAI provider.
+    frontier_spy.assert_called_once_with("openai")
+    # Every client fetch went to OpenAI — never any other family.
+    assert seen_providers, "expected at least one client fetch"
+    assert all(p == "openai" for p in seen_providers), (
+        f"cross-provider leak: {seen_providers}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# D2: self-consistency voter — all N samples stay in the same family
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_D2_self_consistency_voter_keeps_provider_family():
+    """All N voter samples go through the same BYOKHandler instance.
+
+    Since the handler's ``self.clients`` map is set once per workspace,
+    every sample draws from the same credential set. Combined with D1
+    (per-call cascade stays in family), this guarantees the provider
+    family is constant across the entire 3-sample vote.
+    """
+    from core.llm.self_consistency_voter import SelfConsistencyVoter
+
+    # Single shared handler — same instance, same .clients map.
+    handler_instances: list = []
+
+    class _Handler:
+        async def generate_structured_response(self, **kwargs):
+            handler_instances.append(self)
+            return SimpleNamespace(action="search")
+
+    shared = _Handler()
+    voter = SelfConsistencyVoter(handler=shared)
+    await voter.vote(
+        prompt="p", response_model=dict, system_instruction="sys"
+    )
+
+    # All 3 samples used the same handler instance.
+    assert len(handler_instances) == 3
+    assert all(h is shared for h in handler_instances), (
+        "voter must reuse a single handler instance to preserve the family invariant"
+    )

--- a/backend/tests/unit/llm/test_self_consistency_voter.py
+++ b/backend/tests/unit/llm/test_self_consistency_voter.py
@@ -1,0 +1,378 @@
+"""Workstream C — self-consistency voter tests.
+
+The voter is the lowest-level piece of Phase 2 hallucination mitigation:
+it draws N samples at varying temperatures and returns the modal plan.
+It never executes anything — execution is the caller's job.
+
+The hard import invariant (test C1) is what keeps this module honest: the
+voter may only import ``BYOKHandler`` and stdlib, never the executor or
+any adapter. If that breaks, the voter becomes a hidden execution path
+and the "execute winning plan exactly once" guarantee is at risk.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_mitigation_env(monkeypatch):
+    for k in list(os.environ):
+        if k.startswith("ATOM_") and (
+            "VERIFIED" in k or "CASCADE" in k or "SELF_CONSISTENCY" in k
+        ):
+            monkeypatch.delenv(k, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# C1: import invariant — voter must not import the executor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_C1_voter_module_does_not_import_executor():
+    """Static check: voter module imports only BYOKHandler + stdlib.
+
+    This is the architectural firebreak between *deciding* an action and
+    *executing* it. If the voter ever imports UnifiedActionExecutor (or any
+    adapter), the "caller executes the winning plan exactly once"
+    guarantee is at risk.
+    """
+    # Resolve the voter source path: backend/tests/unit/llm/test_*.py
+    # → backend/core/llm/self_consistency_voter.py
+    voter_path = (
+        Path(__file__).resolve().parents[3]
+        / "core"
+        / "llm"
+        / "self_consistency_voter.py"
+    )
+    source = voter_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    forbidden_substrings = (
+        "UnifiedActionExecutor",
+        "unified_action_executor",
+        "atom_meta_agent",
+        "generic_agent",
+        "from core.api",
+        "import core.api",
+    )
+
+    # Check import-module strings inside ImportFrom / Import nodes.
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for f in forbidden_substrings:
+                assert f not in module, (
+                    f"voter imports forbidden module '{module}' (matches '{f}')"
+                )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for f in forbidden_substrings:
+                    assert f not in alias.name, (
+                        f"voter imports forbidden name '{alias.name}' (matches '{f}')"
+                    )
+
+    # Note: we deliberately do NOT scan the raw source for forbidden
+    # substrings — the voter's docstring references them as part of the
+    # invariant contract. The AST-level check above is the real
+    # enforcement: it catches actual import statements, not prose.
+
+
+# ---------------------------------------------------------------------------
+# C2: three samples with majority → modal plan returned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_C2_three_samples_with_majority():
+    """3 samples, 2 identical → the majority plan wins."""
+    from core.llm.self_consistency_voter import SelfConsistencyVoter
+
+    plan_a = SimpleNamespace(action="send_email", target="alice")
+    plan_b = SimpleNamespace(action="send_email", target="alice")  # same hash
+    plan_c = SimpleNamespace(action="draft_email", target="bob")
+
+    handler = MagicMock()
+    # The voter awaits each call — use AsyncMock with side_effect.
+    handler.generate_structured_response = AsyncMock(
+        side_effect=[plan_a, plan_b, plan_c]
+    )
+
+    voter = SelfConsistencyVoter(handler=handler)
+    winner = await voter.vote(
+        prompt="send to alice",
+        response_model=dict,
+        system_instruction="sys",
+    )
+
+    assert winner is plan_a  # First-seen of the majority hash.
+    assert handler.generate_structured_response.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# C3: all three disagree → first sample returned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_C3_all_three_disagree_returns_first():
+    """All samples distinct → fall back to the lowest-temperature sample."""
+    from core.llm.self_consistency_voter import SelfConsistencyVoter
+
+    plan_a = SimpleNamespace(action="send_email", target="alice")
+    plan_b = SimpleNamespace(action="send_email", target="bob")  # diff target
+    plan_c = SimpleNamespace(action="draft_email", target="carol")
+
+    handler = MagicMock()
+    handler.generate_structured_response = AsyncMock(
+        side_effect=[plan_a, plan_b, plan_c]
+    )
+
+    voter = SelfConsistencyVoter(handler=handler)
+    winner = await voter.vote(
+        prompt="decide",
+        response_model=dict,
+        system_instruction="sys",
+    )
+
+    # First sample = lowest temperature (spread starts below base).
+    assert winner is plan_a
+
+
+# ---------------------------------------------------------------------------
+# C4: vote executes the action exactly once (caller's responsibility)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_C4_vote_executes_action_exactly_once():
+    """The voter must not call any executor. The caller runs the winner once.
+
+    We model the caller's execute() as a stub and assert it is called
+    exactly once with the winning plan. The voter never sees execute().
+    """
+    from core.llm.self_consistency_voter import SelfConsistencyVoter
+
+    plan = SimpleNamespace(action="send_email", target="alice")
+
+    handler = MagicMock()
+    handler.generate_structured_response = AsyncMock(
+        side_effect=[plan, plan, plan]
+    )
+
+    voter = SelfConsistencyVoter(handler=handler)
+
+    # Caller's stub execute() — NOT something the voter knows about.
+    execute_calls: list = []
+
+    async def execute(plan):
+        execute_calls.append(plan)
+
+    # The caller (not the voter) is responsible for this:
+    winner = await voter.vote(
+        prompt="p", response_model=dict, system_instruction="sys"
+    )
+    await execute(winner)  # caller's responsibility
+
+    assert len(execute_calls) == 1
+    assert execute_calls[0] is plan
+    # Voter made 3 LLM calls, caller made 1 executor call.
+    assert handler.generate_structured_response.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# C5: is_irreversible detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_C5_is_irreversible_detection():
+    from core.llm.self_consistency_voter import SelfConsistencyVoter
+
+    # Irreversible verbs/prefixes — flagged.
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "send_email"}) is True
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "create_user"}) is True
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "update_record"}) is True
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "delete_file"}) is True
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "bulk_delete"}) is True
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "transfer_funds"}) is True
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "refund_charge"}) is True
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "payment"}) is True
+
+    # Read-only verbs — not flagged.
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "search"}) is False
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "browse"}) is False
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "get_user"}) is False
+    assert SelfConsistencyVoter.is_irreversible({"action_type": "list_files"}) is False
+
+    # Pydantic-v1-style .dict() object.
+    class _V1:
+        def __init__(self):
+            self.action_type = "send_email"
+
+        def dict(self):
+            return {"action_type": "send_email"}
+
+    assert SelfConsistencyVoter.is_irreversible(_V1()) is True
+
+    # None input — safe default is False.
+    assert SelfConsistencyVoter.is_irreversible(None) is False
+
+
+# ---------------------------------------------------------------------------
+# C6: inert when flag off
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_C6_self_consistency_inert_when_flag_off(monkeypatch):
+    """Flag off → LLMService.generate_structured must NOT dispatch to voter.
+
+    We verify by patching the voter class and ensuring it is not
+    instantiated when the env flag is unset.
+    """
+    # Flag is off by default (autouse fixture).
+    from core.llm_service import LLMService
+
+    # Patch the voter import site inside llm_service.generate_structured.
+    with patch("core.llm.self_consistency_voter.SelfConsistencyVoter") as voter_cls:
+        svc = LLMService.__new__(LLMService)
+        svc._workspace_id = "ws-1"
+        svc._db = None
+        svc._handler = None
+        svc._tenant_id = "t-1"
+        svc.is_available = lambda: True
+        svc._get_handler = MagicMock(return_value=MagicMock())
+        # The wrapper unpacks `handler.get_optimal_provider(...)` into
+        # (provider_id, resolved_model). Configure both so the wrapper
+        # reaches the handler call without raising.
+        handler_mock = svc._get_handler.return_value
+        handler_mock.analyze_query_complexity = MagicMock(return_value="standard")
+        handler_mock.get_optimal_provider = MagicMock(return_value=("openai", "gpt-4o-mini"))
+        # Short-circuit: return None from the handler so we don't reach voter.
+        handler_mock.generate_structured_response = AsyncMock(return_value=None)
+
+        # Even if the caller passes enable_self_consistency=True, the flag
+        # resolver returns False so the voter is never instantiated.
+        import asyncio
+
+        await svc.generate_structured(
+            prompt="p",
+            response_model=dict,
+            enable_self_consistency=True,
+        )
+
+        voter_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# C7: temperature spread has N values, all distinct
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_C7_temperature_spread_has_n_values():
+    from core.llm.self_consistency_voter import SelfConsistencyVoter
+
+    temps = SelfConsistencyVoter._temperatures_for(3)
+    assert len(temps) == 3
+    # All distinct — majority voting on identical temperatures is pointless.
+    assert len(set(temps)) == 3
+
+
+# ---------------------------------------------------------------------------
+# C8: sample count should be configurable but odd preferred
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_C8_sample_count_env_driven_default_is_three(monkeypatch):
+    """Default sample count is 3 (from hallucination_config)."""
+    from core import hallucination_config as hc
+
+    assert hc.get_self_consistency_samples() == 3
+
+
+@pytest.mark.unit
+def test_C8_sample_count_can_be_overridden(monkeypatch):
+    """Env var can override the sample count."""
+    from core import hallucination_config as hc
+
+    monkeypatch.setenv("ATOM_SELF_CONSISTENCY_SAMPLES", "5")
+    assert hc.get_self_consistency_samples() == 5
+
+
+@pytest.mark.unit
+def test_C8_sample_count_odd_preferred_via_temperature_spread(monkeypatch):
+    """Odd counts give clean majorities; even counts still work via tie-break."""
+    from core import hallucination_config as hc
+
+    # Odd — clean spread.
+    assert len(hc.get_temperature_spread(3)) == 3
+    assert len(hc.get_temperature_spread(5)) == 5
+    # Even — still well-defined (tie-break picks lowest temp).
+    assert len(hc.get_temperature_spread(4)) == 4
+
+
+# ---------------------------------------------------------------------------
+# Bonus: per-sample failure isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_per_sample_failure_does_not_crash_vote():
+    """If one sample raises, the vote proceeds with the survivors."""
+    from core.llm.self_consistency_voter import SelfConsistencyVoter
+
+    plan = SimpleNamespace(action="search")  # reversible; just for hashing
+
+    handler = MagicMock()
+
+    async def fake_call(**kwargs):
+        # Second call raises; others return plan.
+        n = fake_call.calls
+        fake_call.calls += 1
+        if n == 1:
+            raise RuntimeError("transient")
+        return plan
+
+    fake_call.calls = 0
+    handler.generate_structured_response = fake_call
+
+    voter = SelfConsistencyVoter(handler=handler)
+    winner = await voter.vote(
+        prompt="p", response_model=dict, system_instruction="sys"
+    )
+
+    assert winner is plan  # The 2 surviving samples both returned plan.
+
+
+# ---------------------------------------------------------------------------
+# Bonus: all samples return None → vote returns None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_all_samples_none_returns_none():
+    from core.llm.self_consistency_voter import SelfConsistencyVoter
+
+    handler = MagicMock()
+
+    async def fake_call(**kwargs):
+        return None
+
+    handler.generate_structured_response = fake_call
+
+    voter = SelfConsistencyVoter(handler=handler)
+    winner = await voter.vote(
+        prompt="p", response_model=dict, system_instruction="sys"
+    )
+
+    assert winner is None


### PR DESCRIPTION
…onsistency voter

Two independently flag-gated mitigations from the 2026 research synthesis, each default-off (no behavior change until enabled):

1. Cascade routing inside BYOKHandler.generate_structured_response: on schema-validation failure (pydantic ValidationError or json.JSONDecodeError), retry once on the same-provider flagship. Provider-family invariant is structural — frontier is the flagship of the CURRENT failing provider, looked up via hallucination_config.get_frontier_model_for_provider. Same self.clients[provider_id] reused so BYOK credentials, cost tracking, and rate limits stay constant. Single retry per call. Skips on transient errors (network, rate limit, auth) and on already-frontier models (no double-spend).

2. Self-consistency voter (core/llm/self_consistency_voter.py): 3-sample majority vote on structured action plans for irreversible actions. Wang et al. self-consistency pattern: sample N times at varying temperatures, pick hash-normalized modal plan. The voter imports ONLY BYOKHandler — never the executor (AST-enforced by test_C1). Caller executes the winning plan exactly once.

Architecture choice: cascade lives INSIDE BYOKHandler, not at the LLMService wrapper, because the retry decision is fundamentally about provider/credential/model selection — which is what BYOKHandler owns. The wrapper just forwards the resolved flag value.

Why not the third Phase 2 mitigation (verified graduation gate): that requires AgentCapabilityRegistry columns + SUM-over-table ratio formula. Upstream uses JSON-in-AgentRegistry.configuration with absolute-count promotion thresholds (5/20/50) and string-tri-state 'verified' | 'unverified' | 'failed_verification'. Reconciling the two models is deferred to a follow-up PR.

Test coverage: 43 new tests across 4 files in tests/unit/llm/. Cascade guardrails (flag off, schema fail, transient, already-frontier, single retry, log format, family invariant), voter import invariant, majority vote, tie-break, irreversible detection, per-sample failure isolation.

No DB migration. No new deps. Existing tests: zero regressions (same 6 baseline failures, +43 passing).