### PR TITLE
fix(security): escape KQL injection in Teams message search

### DIFF
--- a/backend/integrations/teams_enhanced_service.py
+++ b/backend/integrations/teams_enhanced_service.py
@@ -840,12 +840,19 @@ class TeamsEnhancedService(IntegrationService):
             if not client:
                 raise Exception("Failed to create Graph client")
             
-            # Build search query
-            search_query = f'"{query}"'
+            # Build search query.
+            # Sanitize each user-supplied term by escaping double quotes (KQL
+            # uses doubled quotes "" to represent a literal quote inside a
+            # quoted phrase). Without this, a quote in the input could break
+            # out of the phrase and inject arbitrary KQL operators.
+            def _kql_escape(value: str) -> str:
+                return str(value).replace('"', '""') if value else ""
+
+            search_query = f'"{_kql_escape(query)}"'
             if channel_id:
-                search_query += f' AND channel:"{channel_id}"'
+                search_query += f' AND channel:"{_kql_escape(channel_id)}"'
             if user_id:
-                search_query += f' AND from:"{user_id}"'
+                search_query += f' AND from:"{_kql_escape(user_id)}"'
             
             # Search using Microsoft Search API
             search_url = f"https://graph.microsoft.com/v1.0/search/query"


### PR DESCRIPTION
## Summary

`search_messages` in `teams_enhanced_service.py` interpolated raw `query`/`channel_id`/`user_id` into a KQL (Keyword Query Language) search string wrapped in double quotes. A double quote in any of these inputs could break out of the quoted phrase and inject arbitrary KQL operators.

For example, a query of `" OR body:secret` would alter the search semantics beyond the caller's intent.

## Fix
Escape double quotes by doubling them (`""`), which is the KQL escape mechanism for a literal quote inside a quoted phrase. Applied to all three interpolated terms via a small `_kql_escape` helper.

## Testing
- `python -m py_compile` passes.
- Existing search behavior is unchanged for inputs without quotes (doubling `"` only affects strings that contain `"`).

Ported from the SaaS fork's security fix lineage.