### PR TITLE
fix(security): prevent SOQL injection in Salesforce list_contacts/list_opportunities

### DIFF
--- a/backend/integrations/salesforce_core_service.py
+++ b/backend/integrations/salesforce_core_service.py
@@ -17,6 +17,9 @@ from enum import Enum
 
 import asyncpg
 
+# SOQL single-quote escaping (defends against SOQL injection).
+from integrations.salesforce_service import escape_soql_string
+
 logger = logging.getLogger(__name__)
 
 class SalesforceEnvironment(Enum):
@@ -449,17 +452,17 @@ class SalesforceCoreService:
             # Build WHERE clause
             conditions = []
             if account_id:
-                conditions.append(f"AccountId = '{account_id}'")
+                conditions.append(f"AccountId = '{escape_soql_string(account_id)}'")
             if query:
                 conditions.append(query)
-            
+
             where_clause = ""
             if conditions:
                 where_clause = f"WHERE {' AND '.join(conditions)}"
-            
+
             soql = f"""
-                SELECT {', '.join(query_fields)} 
-                FROM Contact 
+                SELECT {', '.join(query_fields)}
+                FROM Contact
                 {where_clause}
                 ORDER BY CreatedDate DESC 
                 LIMIT {limit} OFFSET {offset}
@@ -549,9 +552,9 @@ class SalesforceCoreService:
             # Build WHERE clause
             conditions = []
             if account_id:
-                conditions.append(f"AccountId = '{account_id}'")
+                conditions.append(f"AccountId = '{escape_soql_string(account_id)}'")
             if stage:
-                conditions.append(f"StageName = '{stage}'")
+                conditions.append(f"StageName = '{escape_soql_string(stage)}'")
             if query:
                 conditions.append(query)
             


### PR DESCRIPTION
## Summary

`list_contacts` and `list_opportunities` in `salesforce_core_service.py` interpolated raw `account_id` and `stage` arguments directly into SOQL `WHERE` clauses:

```python
conditions.append(f"AccountId = '{account_id}'")
conditions.append(f"StageName = '{stage}'")
```

A single quote in these inputs could break out of the string literal and inject arbitrary SOQL.

## Fix
Route all interpolated values through the existing `escape_soql_string` helper from `salesforce_service.py` (doubles single quotes, the SOQL escape mechanism). This helper is already used by `universal_integration_service` and `salesforce_routes` — this just closes the gap in `salesforce_core_service`.

## Testing
- `python -m py_compile` passes.
- Inputs without quotes are unaffected (doubling `'` only changes strings containing `'`).

Ported from the SaaS fork's security fix (commit lineage).