### PR TITLE
fix(router): wire RouteLLMTrainer into live router and fix learning bugs

### DIFF
--- a/backend/core/learning_llm_router.py
+++ b/backend/core/learning_llm_router.py
@@ -37,6 +37,12 @@ from sqlalchemy.orm import Session
 
 from core.database import SessionLocal
 from core.models import Tenant, TenantSetting
+from core.llm.routing import (
+    RouteLLMTrainer,
+    TrainingConfig,
+    TrainingExample,
+    TrainingStatus,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -141,8 +147,23 @@ class LearningBasedRouter:
         self.db = db
         self._model_registry: Dict[str, ModelSpec] = {}
         self._preference_data: Dict[str, List[RoutingFeedback]] = {}
-        self._router_cache: Dict[str, Tuple[ModelSpec, float]] = {}
+        # Learned per-task weights derived from feedback, keyed "{tenant}:{task}".
+        self._router_cache: Dict[str, Dict[str, float]] = {}
         self._training_samples: List[Dict[str, Any]] = []
+        # Trained satisfaction-model id per "{tenant}:{task}" so predict() uses
+        # the right persisted model even after other tenants retrain.
+        self._trained_model_ids: Dict[str, str] = {}
+
+        # Bounded-memory caps (R17-2): unbounded caches grew without limit.
+        self._max_router_cache_size = 1000
+        self._max_preference_data_per_key = 5000
+
+        # Minimum samples before attempting a retrain (mirrors
+        # TrainingConfig.min_samples so train_test_split has enough data).
+        self._min_training_samples = TrainingConfig().min_samples
+
+        # Lazily-instantiated RouteLLM trainer for satisfaction prediction.
+        self._trainer: Optional[RouteLLMTrainer] = None
 
         # Initialize model registry
         self._initialize_model_registry()
@@ -817,7 +838,13 @@ class LearningBasedRouter:
     def _get_learned_weights(
         self, task_type: str, tenant_id: str
     ) -> Dict[str, float]:
-        """Get learned preference weights for task type"""
+        """Get learned preference weights for task type.
+
+        When a tenant/task pair has accumulated enough feedback to retrain,
+        ``_retrain_router`` derives real ``{quality, cost, speed}`` weights from
+        observed per-model success rates and stores them in ``_router_cache``.
+        Otherwise we fall back to sensible per-task-type defaults.
+        """
         # Check for tenant-specific learning data
         cache_key = f"{tenant_id}:{task_type}"
 
@@ -911,8 +938,17 @@ class LearningBasedRouter:
 
         self._preference_data[feedback_key].append(feedback)
 
-        # Trigger retraining after accumulating enough feedback
-        if len(self._preference_data[feedback_key]) >= 10:
+        # Bound memory: keep only the most recent feedback per key (R17-2).
+        if len(self._preference_data[feedback_key]) > self._max_preference_data_per_key:
+            # Drop the oldest entries to stay within the cap.
+            del self._preference_data[feedback_key][
+                : len(self._preference_data[feedback_key]) - self._max_preference_data_per_key
+            ]
+
+        # Trigger retraining after accumulating enough feedback for a real
+        # train/test split (matches TrainingConfig.min_samples). Before that
+        # threshold the per-model sample counts are too noisy to learn from.
+        if len(self._preference_data[feedback_key]) >= self._min_training_samples:
             await self._retrain_router(feedback.tenant_id, feedback.task_type)
 
         logger.debug(
@@ -924,14 +960,18 @@ class LearningBasedRouter:
         """
         Retrain router with accumulated preference data.
 
-        Implements active learning by updating routing weights.
+        Runs the RouteLLMTrainer on the collected feedback (when there are
+        enough samples) and derives real ``{quality, cost, speed}`` routing
+        weights from observed per-model success rates. The previous
+        implementation computed those rates and then threw them away, storing
+        a ``(None, 0.0)`` placeholder; this does the actual learning.
         """
         feedback_list = self._preference_data.get(f"{tenant_id}:{task_type}", [])
 
         if not feedback_list:
             return
 
-        # Simple weight adjustment based on success rates
+        # ---- Per-model empirical success rates (used to derive weights) ----
         model_success = defaultdict(lambda: {"success": 0, "total": 0})
 
         for feedback in feedback_list:
@@ -939,18 +979,163 @@ class LearningBasedRouter:
             if feedback.success and feedback.quality_satisfied:
                 model_success[feedback.model_id]["success"] += 1
 
-        # Update learned weights (simplified)
-        # In production, this would use proper ML training
         cache_key = f"{tenant_id}:{task_type}"
-        self._router_cache[cache_key] = (
-            None,  # Placeholder for trained model
-            0.0,  # Placeholder for accuracy
-        )
+
+        # ---- Train the satisfaction model (best-effort) ----
+        # Convert feedback into TrainingExample for the ML pipeline. Note:
+        # RoutingFeedback carries no prompt text, so we synthesize the prompt
+        # features the extractor needs (task-type one-hots) from task_type and
+        # leave token-derived features at neutral defaults. The classifier
+        # still learns from the satisfaction signal; per-model routing below
+        # is driven by the empirical success rates.
+        trained_model_id: Optional[str] = None
+        if len(feedback_list) >= self._min_training_samples:
+            examples = [
+                self._feedback_to_training_example(fb, task_type)
+                for fb in feedback_list
+            ]
+            try:
+                trainer = self._get_trainer()
+                result = trainer.train(examples, model_id=f"{cache_key}")
+                if result.status == TrainingStatus.COMPLETED:
+                    trained_model_id = result.model_id
+                    self._trained_model_ids[cache_key] = result.model_id
+                    logger.info(
+                        f"Trained router model for tenant={tenant_id}, "
+                        f"task={task_type}: model_id={result.model_id}, "
+                        f"accuracy={result.accuracy:.3f}, "
+                        f"samples={result.samples_trained}"
+                    )
+                else:
+                    logger.warning(
+                        f"Router training did not complete for "
+                        f"tenant={tenant_id}, task={task_type}: "
+                        f"{result.metadata.get('error', result.status)}"
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"Router training failed for tenant={tenant_id}, "
+                    f"task={task_type}: {e}"
+                )
+
+        # ---- Derive {quality, cost, speed} weights from success rates ----
+        weights = self._derive_weights_from_success(model_success, task_type)
+        self._set_cached_weights(cache_key, weights, tenant_id)
 
         logger.info(
-            f"Retrained router for tenant={tenant_id}, task={task_type} "
+            f"Updated router weights for tenant={tenant_id}, task={task_type} "
             f"with {len(feedback_list)} samples"
+            + (f", model={trained_model_id}" if trained_model_id else "")
         )
+
+    def _get_trainer(self) -> RouteLLMTrainer:
+        """Lazily instantiate the RouteLLM trainer (sklearn is a heavy import)."""
+        if self._trainer is None:
+            self._trainer = RouteLLMTrainer()
+        return self._trainer
+
+    def _feedback_to_training_example(
+        self, feedback: RoutingFeedback, task_type: str
+    ) -> TrainingExample:
+        """Convert a RoutingFeedback into a trainer TrainingExample.
+
+        RoutingFeedback has no prompt text, so prompt-derived features use
+        neutral defaults; only the task-type one-hot is set from task_type.
+        The satisfaction target is taken from user_satisfaction when present,
+        otherwise derived from success + quality.
+        """
+        # Map this router's task_type strings to the collector's one-hot keys.
+        task_key = task_type
+        prompt_features = {
+            "log_tokens": 0.0,
+            "token_bucket": 1.0,  # mid-size bucket
+            "task_code": 1.0 if task_key == "code_generation" else 0.0,
+            "task_analysis": 1.0 if task_key == "extraction" else 0.0,
+            "task_reasoning": 1.0 if task_key == "reasoning" else 0.0,
+            "task_chat": 1.0 if task_key == "question_answering" else 0.0,
+            "task_general": 1.0 if task_key not in {
+                "code_generation", "extraction", "reasoning", "question_answering"
+            } else 0.0,
+            "has_code": 1.0 if task_key == "code_generation" else 0.0,
+            "has_numbers": 0.0,
+            "avg_word_length": 5.0,
+        }
+
+        if feedback.user_satisfaction is not None:
+            satisfaction = float(feedback.user_satisfaction)
+        else:
+            satisfaction = 1.0 if (feedback.success and feedback.quality_satisfied) else 0.0
+
+        return TrainingExample(
+            estimated_tokens=0,
+            task_type=task_type,
+            prompt_features=prompt_features,
+            chosen_model=feedback.model_id,
+            user_satisfaction=satisfaction,
+            was_successful=feedback.success,
+            quality_score=satisfaction,
+        )
+
+    @staticmethod
+    def _derive_weights_from_success(
+        model_success: Dict[str, Dict[str, int]], task_type: str
+    ) -> Dict[str, float]:
+        """Translate per-model success rates into {quality, cost, speed} weights.
+
+        Higher observed success → weight quality more heavily (the models that
+        deliver quality are the ones worth prioritizing). Cost/speed are scaled
+        down in proportion so the weights stay normalized. Falls back to the
+        per-task defaults when no usable samples exist.
+        """
+        defaults = {
+            "code_generation": {"quality": 0.5, "cost": 0.2, "speed": 0.3},
+            "question_answering": {"quality": 0.4, "cost": 0.3, "speed": 0.3},
+            "reasoning": {"quality": 0.6, "cost": 0.1, "speed": 0.3},
+            "tool_use": {"quality": 0.3, "cost": 0.3, "speed": 0.4},
+            "vision": {"quality": 0.5, "cost": 0.2, "speed": 0.3},
+            "extraction": {"quality": 0.3, "cost": 0.4, "speed": 0.3},
+        }
+
+        total_samples = sum(s["total"] for s in model_success.values())
+        if total_samples == 0:
+            return defaults.get(task_type, {"quality": 0.4, "cost": 0.3, "speed": 0.3})
+
+        overall_success = sum(s["success"] for s in model_success.values()) / total_samples
+        base = defaults.get(task_type, {"quality": 0.4, "cost": 0.3, "speed": 0.3})
+
+        # Scale quality by how well models are doing overall relative to a
+        # neutral 0.5 baseline: strong outcomes → favor quality; poor outcomes
+        # → favor cost/speed (i.e. be more conservative).
+        quality_factor = 0.5 + overall_success  # range ~0.5..1.5
+        quality = min(0.8, base["quality"] * quality_factor)
+
+        # Redistribute the remainder between cost and speed, preserving their
+        # original ratio.
+        remainder = 1.0 - quality
+        cost_speed_sum = base["cost"] + base["speed"] or 1.0
+        cost = remainder * (base["cost"] / cost_speed_sum)
+        speed = remainder * (base["speed"] / cost_speed_sum)
+
+        return {"quality": quality, "cost": cost, "speed": speed}
+
+    def _set_cached_weights(
+        self,
+        cache_key: str,
+        weights: Dict[str, float],
+        tenant_id: str,
+    ) -> None:
+        """Store learned weights, evicting oldest entries when over the cap (R17-2)."""
+        self._router_cache[cache_key] = weights
+        if len(self._router_cache) > self._max_router_cache_size:
+            # Evict oldest tenant entries first (deterministic by insertion key).
+            # Keys are "{tenant}:{task}"; drop until back under the cap.
+            overflow = len(self._router_cache) - self._max_router_cache_size
+            for key in list(self._router_cache.keys())[:overflow]:
+                del self._router_cache[key]
+            logger.debug(
+                f"Evicted {overflow} router cache entries (cap="
+                f"{self._max_router_cache_size}) for tenant={tenant_id}"
+            )
 
     async def get_routing_statistics(
         self, tenant_id: str

--- a/backend/core/llm/routing/cache_optimizer.py
+++ b/backend/core/llm/routing/cache_optimizer.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple
+import numpy as np
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -173,6 +174,7 @@ class AccessPatternAnalyzer:
 
         # Detect pattern
         if len(gaps) < 3:
+            self.pattern_cache[prompt_hash] = AccessPattern.RANDOM
             return AccessPattern.RANDOM
 
         gap_variance = sum((g - np.mean(gaps))**2 for g in gaps) / len(gaps)

--- a/backend/core/llm/routing/routellm_trainer.py
+++ b/backend/core/llm/routing/routellm_trainer.py
@@ -144,7 +144,7 @@ class FeatureExtractor:
             Feature matrix X of shape (n_samples, n_features)
         """
         if not examples:
-            return np.array([])
+            return np.zeros((0, len(self.feature_names)))
 
         features = []
         for example in examples:
@@ -261,17 +261,18 @@ class RouteLLMTrainer:
             if len(X) == 0 or len(y) == 0:
                 raise ValueError("No features extracted from examples")
 
-            # Train/test split
-            X_train, X_test, y_train, y_test = train_test_split(
-                X, y,
+            # Train/test split (split weights alongside so they stay paired)
+            splits = train_test_split(
+                X, y, weights,
                 test_size=self.config.test_size,
                 random_state=self.config.random_seed,
                 stratify=y if len(np.unique(y)) > 1 else None
             )
+            X_train, X_test, y_train, y_test, weights_train, _weights_test = splits
 
             # Train model
             self.model = self._create_model()
-            self.model.fit(X_train, y_train, sample_weight=weights[:len(X_train)])
+            self.model.fit(X_train, y_train, sample_weight=weights_train)
 
             # Evaluate
             y_pred = self.model.predict(X_test)
@@ -397,7 +398,11 @@ class RouteLLMTrainer:
         # Predict probability of satisfaction
         if hasattr(self.model, 'predict_proba'):
             proba = self.model.predict_proba(feature_vector)
-            return proba[0][1] if proba.shape[1] > 1 else proba[0][0]
+            if proba.shape[1] > 1:
+                return float(proba[0][1])
+            # Single-class case: the one column is P(class 0) = P(not satisfied),
+            # so invert it to get the satisfaction score.
+            return float(1.0 - proba[0][0])
         else:
             prediction = self.model.predict(feature_vector)
             return float(prediction[0])
@@ -426,20 +431,29 @@ class RouteLLMTrainer:
         best_score = -1
         best_result = None
 
+        # Preserve the caller's config so the comparison loop has no side effects.
+        original_type = self.config.model_type
+
         for model_type in model_types:
-            # Temporarily change config
-            original_type = self.config.model_type
             self.config.model_type = model_type
 
             result = self.train(examples)
 
-            # Restore original config
-            self.config.model_type = original_type
-
-            if result.accuracy > best_score:
+            if result.status == TrainingStatus.COMPLETED and result.accuracy > best_score:
                 best_score = result.accuracy
                 best_model = model_type
                 best_result = result
+
+        # Point self at the winner (train() leaves self.model on whichever
+        # type ran last, which is not necessarily the best one). Also persist
+        # the winning model type on config so future predict()/retrain calls
+        # stay consistent.
+        if best_result is not None:
+            self.config.model_type = best_model
+            self.load_model(best_result.model_id)
+        else:
+            # Nothing trained successfully; restore the caller's config.
+            self.config.model_type = original_type
 
         return best_model, best_result
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -85,6 +85,7 @@ enterprise = [
     # Advanced analytics
     "pandas>=2.0.0",
     "numpy>=1.24.0",
+    "scikit-learn>=1.3.0",
 
     # Rate limiting
     "slowapi>=0.1.9",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -55,6 +55,7 @@ python3-saml>=1.14.0  # SAML 2.0 SSO support
 # Data Processing & Utilities
 pandas>=1.5.0,<3.0.0
 numpy>=1.24.0,<2.0.0
+scikit-learn>=1.3.0,<2.0.0
 openpyxl>=3.1.0,<4.0.0
 python-dotenv>=1.0.0,<2.0.0
 click>=8.1.0,<9.0.0

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -74,6 +74,7 @@ extras_require = {
         # Advanced analytics
         "pandas>=2.0.0",
         "numpy>=1.24.0",
+        "scikit-learn>=1.3.0",
 
         # Rate limiting
         "slowapi>=0.1.9",

--- a/backend/tests/test_routing_trainer_integration.py
+++ b/backend/tests/test_routing_trainer_integration.py
@@ -1,0 +1,314 @@
+"""
+End-to-end integration tests for the LLM routing trainer.
+
+These tests exercise the real scikit-learn training pipeline (not stubs):
+- RouteLLMTrainer.train() on synthetic data → a persisted, loadable model
+- get_best_model() leaves the trainer pointing at the winner (regression test
+  for the destructive-state bug)
+- cache_optimizer.detect_pattern() with enough history to reach the previously
+  buggy np.mean branch
+- LearningBasedRouter._retrain_router() produces real learned weights instead
+  of the old (None, 0.0) placeholder
+
+All training is CPU-only via scikit-learn (no GPU required).
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+def _make_example(task_type: str, satisfied: bool, tokens: int = 800,
+                  has_code: bool = False) -> "TrainingExample":
+    """Build a realistic TrainingExample for the trainer's feature extractor."""
+    from core.llm.routing import TrainingExample
+
+    one_hot = {
+        "task_code": 1.0 if task_type == "code_generation" else 0.0,
+        "task_analysis": 1.0 if task_type == "extraction" else 0.0,
+        "task_reasoning": 1.0 if task_type == "reasoning" else 0.0,
+        "task_chat": 1.0 if task_type == "question_answering" else 0.0,
+        "task_general": 1.0 if task_type not in {
+            "code_generation", "extraction", "reasoning", "question_answering"
+        } else 0.0,
+    }
+    import math
+    return TrainingExample(
+        estimated_tokens=tokens,
+        task_type=task_type,
+        prompt_features={
+            "log_tokens": math.log2(tokens + 1),
+            "token_bucket": 1.0,
+            **one_hot,
+            "has_code": 1.0 if has_code else 0.0,
+            "has_numbers": 1.0,
+            "avg_word_length": 5.0,
+        },
+        chosen_model="gpt-4o" if satisfied else "gpt-4o-mini",
+        user_satisfaction=0.9 if satisfied else 0.1,
+        was_successful=satisfied,
+        quality_score=0.9 if satisfied else 0.1,
+    )
+
+
+def _balanced_dataset(n: int = 120) -> list:
+    """A dataset with a learnable signal: code+has_code → satisfied."""
+    examples = []
+    for i in range(n):
+        # Code-generation prompts with code → satisfied; others → not.
+        if i % 2 == 0:
+            examples.append(_make_example("code_generation", satisfied=True,
+                                          tokens=1200, has_code=True))
+        else:
+            examples.append(_make_example("question_answering", satisfied=False,
+                                          tokens=400, has_code=False))
+    return examples
+
+
+# ----------------------------------------------------------------------------
+# RouteLLMTrainer end-to-end
+# ----------------------------------------------------------------------------
+
+class TestRouteLLMTrainerEndToEnd:
+    """Exercise the real sklearn training pipeline."""
+
+    @pytest.fixture
+    def trainer(self, tmp_path):
+        """A trainer writing to an isolated temp model directory."""
+        from core.llm.routing import RouteLLMTrainer, TrainingConfig
+
+        config = TrainingConfig(model_path=str(tmp_path / "models"))
+        return RouteLLMTrainer(config)
+
+    def test_train_completes_and_persists_model(self, trainer, tmp_path):
+        """train() should return COMPLETED, report accuracy, and write a .pkl."""
+        from core.llm.routing import TrainingStatus
+
+        result = trainer.train(_balanced_dataset(120))
+
+        assert result.status == TrainingStatus.COMPLETED, (
+            f"Training did not complete: {result.metadata}"
+        )
+        assert result.samples_trained == 120
+        assert 0.0 <= result.accuracy <= 1.0
+        # A learnable signal (code+has_code → satisfied) should beat chance.
+        assert result.accuracy > 0.5, (
+            f"Accuracy {result.accuracy} below chance — training may be broken"
+        )
+        # A model file must exist on disk.
+        model_files = list((tmp_path / "models").glob("*.pkl"))
+        assert model_files, "No model .pkl written to model_path"
+        assert result.model_id in model_files[0].name
+
+    def test_load_and_predict_round_trip(self, trainer):
+        """A trained, reloaded model should predict a satisfaction score in [0,1]."""
+        from core.llm.routing import TrainingStatus
+
+        result = trainer.train(_balanced_dataset(120))
+        assert result.status == TrainingStatus.COMPLETED
+
+        # Drop the in-memory model and reload from disk.
+        trainer.model = None
+        assert trainer.predict({}) == 0.5  # uncertainty with no model
+
+        loaded = trainer.load_model(result.model_id)
+        assert loaded is True
+
+        features = {
+            "log_tokens": 10.0, "token_bucket": 1.0,
+            "task_code": 1.0, "task_analysis": 0.0, "task_reasoning": 0.0,
+            "task_chat": 0.0, "task_general": 0.0,
+            "has_code": 1.0, "has_numbers": 1.0, "avg_word_length": 5.0,
+        }
+        score = trainer.predict(features)
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
+    def test_get_best_model_leaves_winner_loaded(self, trainer):
+        """Regression test: get_best_model() must leave self.model on the winner."""
+        from core.llm.routing import ModelType, TrainingStatus
+
+        dataset = _balanced_dataset(120)
+        best_type, best_result = trainer.get_best_model(
+            dataset,
+            model_types=[ModelType.RANDOM_FOREST, ModelType.LOGISTIC_REGRESSION],
+        )
+
+        assert best_type in (ModelType.RANDOM_FOREST, ModelType.LOGISTIC_REGRESSION)
+        assert best_result is not None
+        assert best_result.status == TrainingStatus.COMPLETED
+
+        # The winning model id must be the one currently loaded in memory.
+        assert trainer.model is not None, "get_best_model left no model loaded"
+        # And config must reflect the winner.
+        assert trainer.config.model_type == best_type
+        # Predict must work (uses the loaded winner).
+        score = trainer.predict({
+            "log_tokens": 10.0, "token_bucket": 1.0,
+            "task_code": 1.0, "task_analysis": 0.0, "task_reasoning": 0.0,
+            "task_chat": 0.0, "task_general": 0.0,
+            "has_code": 1.0, "has_numbers": 1.0, "avg_word_length": 5.0,
+        })
+        assert 0.0 <= score <= 1.0
+
+    def test_empty_features_returns_correct_shape(self, trainer):
+        """extract_features on empty input should be 2-D, not (0,)."""
+        X = trainer.feature_extractor.extract_features([])
+        assert X.shape == (0, len(trainer.feature_extractor.feature_names))
+
+
+# ----------------------------------------------------------------------------
+# cache_optimizer — the np.mean regression
+# ----------------------------------------------------------------------------
+
+class TestCacheOptimizerNpBug:
+    """detect_pattern must not raise NameError once ≥4 accesses accumulate."""
+
+    def test_detect_pattern_with_enough_history(self):
+        from core.llm.routing.cache_optimizer import AccessPatternAnalyzer, AccessPattern
+
+        analyzer = AccessPatternAnalyzer()
+        prompt_hash = "prompt_with_regular_access"
+
+        # Record 5 accesses ~60s apart → a TEMPORAL pattern (low variance).
+        # This path previously raised `NameError: name 'np' is not defined`.
+        base = datetime(2026, 1, 1, 12, 0, 0)
+        for i in range(5):
+            analyzer.record_access(
+                prompt_hash, timestamp=base + timedelta(seconds=60 * i)
+            )
+
+        pattern = analyzer.detect_pattern(prompt_hash)
+        assert pattern in (
+            AccessPattern.TEMPORAL, AccessPattern.SEQUENTIAL, AccessPattern.RANDOM
+        )
+        # 60s-apart accesses have tiny variance (< 60) → TEMPORAL.
+        assert pattern == AccessPattern.TEMPORAL
+
+
+# ----------------------------------------------------------------------------
+# LearningBasedRouter — real learned weights (no more None/0.0 stub)
+# ----------------------------------------------------------------------------
+
+class TestRouterLearnsRealWeights:
+    """The live router must produce real weights after enough feedback."""
+
+    @pytest.fixture
+    def router(self, monkeypatch, tmp_path):
+        """A router whose trainer writes to an isolated temp dir."""
+        from core import learning_llm_router
+
+        # Patch TrainingConfig default model_path so the router's trainer
+        # doesn't pollute the real data/router_models dir.
+        original_init = learning_llm_router.TrainingConfig.__init__
+
+        def patched_init(self, *args, **kwargs):
+            kwargs.setdefault("model_path", str(tmp_path / "models"))
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(learning_llm_router.TrainingConfig, "__init__",
+                            patched_init)
+
+        router = learning_llm_router.LearningBasedRouter(Mock())
+        # Lower the thresholds so the test doesn't need 100 feedbacks.
+        router._min_training_samples = 30
+        # And let the trainer actually train on that many samples.
+        router._get_trainer().config.min_samples = 30
+        return router
+
+    def _feedback(self, model_id, success, quality, tenant="t1",
+                  task="code_generation", satisfaction=None):
+        from core.learning_llm_router import RoutingFeedback
+        return RoutingFeedback(
+            routing_result_id="r",
+            tenant_id=tenant,
+            model_id=model_id,
+            task_type=task,
+            success=success,
+            quality_satisfied=quality,
+            cost_within_budget=True,
+            user_satisfaction=satisfaction,
+        )
+
+    @pytest.mark.asyncio
+    async def test_retrain_produces_real_weights(self, router):
+        """After enough feedback, _router_cache holds a real weights dict."""
+        # gpt-4o succeeds reliably; gpt-4o-mini fails. The router should learn
+        # to weight quality higher as overall success climbs.
+        for _ in range(20):
+            await router.record_feedback(
+                self._feedback("gpt-4o", True, True, satisfaction=0.9)
+            )
+        for _ in range(10):
+            await router.record_feedback(
+                self._feedback("gpt-4o-mini", False, False, satisfaction=0.1)
+            )
+
+        cache_key = "t1:code_generation"
+        assert cache_key in router._router_cache, "No learned weights cached"
+        weights = router._router_cache[cache_key]
+
+        # The old stub stored a (None, 0.0) tuple — weights must now be a dict.
+        assert isinstance(weights, dict), (
+            f"Expected dict of weights, got {type(weights)}: {weights}"
+        )
+        assert set(weights.keys()) == {"quality", "cost", "speed"}
+        # Weights should be normalized and non-negative.
+        assert all(v >= 0 for v in weights.values())
+        assert abs(sum(weights.values()) - 1.0) < 1e-6
+        # 30/30 success overall (20 success + 10 fail, but success flag varies) —
+        # with the strong-outcome path, quality should be boosted above the
+        # code_generation default of 0.5.
+        assert weights["quality"] > 0.5, (
+            f"Expected boosted quality weight, got {weights}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_learned_weights_returns_learned_dict(self, router):
+        """_get_learned_weights returns the learned dict, falling back to defaults."""
+        # Before any training: defaults.
+        defaults = router._get_learned_weights("code_generation", "t2")
+        assert defaults == {"quality": 0.5, "cost": 0.2, "speed": 0.3}
+
+        # Seed enough feedback and retrain.
+        for _ in range(30):
+            await router.record_feedback(
+                self._feedback("gpt-4o", True, True, satisfaction=0.9)
+            )
+
+        learned = router._get_learned_weights("code_generation", "t1")
+        assert isinstance(learned, dict)
+        assert set(learned.keys()) == {"quality", "cost", "speed"}
+
+    @pytest.mark.asyncio
+    async def test_preference_data_is_trimmed_to_cap(self, router):
+        """R17-2: _preference_data per key must not exceed its cap."""
+        # Set a tiny cap to exercise eviction without a huge loop.
+        router._max_preference_data_per_key = 50
+        # Disable retraining to isolate the trimming behavior.
+        router._min_training_samples = 10_000_000
+        for _ in range(120):
+            await router.record_feedback(
+                self._feedback("gpt-4o", True, True, tenant="t3", task="reasoning")
+            )
+        key = "t3:reasoning"
+        assert len(router._preference_data[key]) <= router._max_preference_data_per_key
+
+    def test_router_cache_evicts_when_over_cap(self, router):
+        """R17-2: _router_cache must evict down to its cap when over."""
+        router._max_router_cache_size = 5
+        for i in range(20):
+            router._set_cached_weights(
+                f"tenant{i}:code_generation",
+                {"quality": 0.4, "cost": 0.3, "speed": 0.3},
+                tenant_id=f"tenant{i}",
+            )
+        assert len(router._router_cache) <= router._max_router_cache_size


### PR DESCRIPTION
The LLM routing trainer was incomplete: the RouteLLMTrainer package had a working sklearn pipeline but was orphaned (zero production importers), while the live LearningBasedRouter._retrain_router was a stub that stored (None, 0.0) and discarded the per-model success rates it computed. _get_learned_weights returned hardcoded constants.

Wiring + bug fixes:
- Wire RouteLLMTrainer into LearningBasedRouter._retrain_router: trains a real satisfaction model (persisted as .pkl) once >= min_samples feedback accumulates, and derives {quality,cost,speed} weights from observed per-model success rates (previously computed and thrown away).
- Fix _router_cache type annotation (was Tuple, used as Dict).
- Restore R17b memory-leak caps (_max_router_cache_size, _max_preference_data_per_key) lost from the working tree; enforce eviction in _set_cached_weights and trimming in record_feedback.
- cache_optimizer: add missing numpy import (NameError on np.mean at line 178 once >=4 accesses accumulated); cache the <3-gaps branch.
- routellm_trainer: fix sample-weight misalignment in train() (weights were sliced rather than split alongside X/y), get_best_model() destructive state (now reloads the winner), predict() single-class probability inversion, and empty-features shape.
- Add scikit-learn>=1.3.0 to requirements.txt/pyproject.toml/setup.py (was installed but never declared).
- Add end-to-end integration tests (test_routing_trainer_integration.py) covering real training, load/predict round-trip, get_best_model regression, the np.mean path, and router learned-weight derivation.

Known limitation: the trainer learns a satisfaction classifier on prompt features, not per-model selection; per-model routing uses empirical success rates.