### PR TITLE
fix(backend): fix AI accounting API routes pattern mismatch

### DIFF
--- a/backend/api/ai_accounting_routes.py
+++ b/backend/api/ai_accounting_routes.py
@@ -16,7 +16,7 @@ from core.decimal_utils import to_decimal
 
 logger = logging.getLogger(__name__)
 
-router = BaseAPIRouter(prefix="/ai-accounting", tags=["AI Accounting"])
+router = BaseAPIRouter(prefix="", tags=["AI Accounting"])
 
 # ==================== REQUEST MODELS ====================
 

--- a/backend/main_api_app.py
+++ b/backend/main_api_app.py
@@ -2067,6 +2067,9 @@ try:
         app.include_router(
             ai_accounting_router, prefix="/api/v1/accounting", tags=["ai-accounting"]
         )
+        app.include_router(
+            ai_accounting_router, prefix="/api/ai-accounting", tags=["ai-accounting"]
+        )
     except (ImportError, TypeError) as e:
         logger.warning(f"Failed to load AI accounting routes: {e}", exc_info=True)
 


### PR DESCRIPTION
- Remove the internal `/ai-accounting` prefix from `ai_accounting_router` definition in `ai_accounting_routes.py`.
- Register the router under both `/api/v1/accounting` and `/api/ai-accounting` prefixes in `main_api_app.py`.
- This ensures full compatibility with the dashboard frontend (which calls `/api/v1/accounting/dashboard/summary`) as well as the Next.js API proxy routes (which call `/api/ai-accounting/...`), resolving the 404 / Failed to fetch forecast runtime error.

## Description

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

<!-- How did you verify this works? -->

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend type-checks (`tsc --noEmit`)
- [ ] Manually tested the user flow

## Checklist

- [ ] Code follows the project style (match surrounding patterns)
- [ ] Self-reviewed the diff
- [ ] Comments added for complex logic
- [ ] No new warnings introduced
