### PR TITLE
fix(frontend): add authentication headers to workflow templates API r…

### DIFF
--- a/frontend-nextjs/components/WorkflowAutomation.tsx
+++ b/frontend-nextjs/components/WorkflowAutomation.tsx
@@ -253,7 +253,12 @@ const WorkflowAutomation: React.FC<{ triggerNew?: number }> = ({ triggerNew }) =
 
   const fetchTemplates = async () => {
     try {
-      const response = await fetch("/api/workflow-templates/"); // Fixed endpoint with trailing slash
+      const token = localStorage.getItem('auth_token');
+      const response = await fetch("/api/workflow-templates/", {
+        headers: {
+          ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+        }
+      }); // Fixed endpoint with trailing slash
       if (response.ok) {
         const data = await response.json();
         // The API returns the list directly, not { success: true, templates: ... }

--- a/frontend-nextjs/pages/marketplace.tsx
+++ b/frontend-nextjs/pages/marketplace.tsx
@@ -82,7 +82,12 @@ export default function MarketplacePage() {
                 ? `/api/workflow-templates?category=${encodeURIComponent(selectedCategory)}`
                 : '/api/workflow-templates'
 
-            const response = await fetch(url)
+            const token = localStorage.getItem('auth_token')
+            const response = await fetch(url, {
+                headers: {
+                    ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+                }
+            })
             if (!response.ok) {
                 const details = await response.text().catch(() => '')
                 throw new Error(details || `Failed to fetch templates (${response.status})`)
@@ -109,9 +114,13 @@ export default function MarketplacePage() {
 
     const handleImport = async (id: string) => {
         try {
+            const token = localStorage.getItem('auth_token')
             const response = await fetch(`/api/workflow-templates/${id}/import`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' }
+                headers: { 
+                    'Content-Type': 'application/json',
+                    ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+                }
             })
 
             if (response.ok) {

--- a/frontend-nextjs/pages/workflows/builder.tsx
+++ b/frontend-nextjs/pages/workflows/builder.tsx
@@ -102,8 +102,12 @@ export default function WorkflowBuilder() {
 
     const fetchTemplates = async () => {
         try {
-            // Use relative path to leverage next.config.js proxy
-            const res = await fetch('/api/workflow-templates');
+            const token = localStorage.getItem('auth_token');
+            const res = await fetch('/api/workflow-templates', {
+                headers: {
+                    ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+                }
+            });
             if (res.ok) {
                 const data = await res.json();
                 setTemplates(data);
@@ -148,9 +152,13 @@ export default function WorkflowBuilder() {
         };
 
         try {
+            const token = localStorage.getItem('auth_token');
             const res = await fetch('/api/workflow-templates', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 
+                    'Content-Type': 'application/json',
+                    ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+                },
                 body: JSON.stringify(templateData)
             });
 
@@ -177,9 +185,13 @@ export default function WorkflowBuilder() {
         toast({ title: 'Executing...', description: `Running template: ${workflowName}` });
 
         try {
+            const token = localStorage.getItem('auth_token');
             const res = await fetch(`/api/workflow-templates/${currentTemplateId}/execute`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 
+                    'Content-Type': 'application/json',
+                    ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+                },
                 body: JSON.stringify({})
             });
 
@@ -198,7 +210,12 @@ export default function WorkflowBuilder() {
 
     const loadTemplate = async (templateId: string) => {
         try {
-            const res = await fetch(`/api/workflow-templates/${templateId}`);
+            const token = localStorage.getItem('auth_token');
+            const res = await fetch(`/api/workflow-templates/${templateId}`, {
+                headers: {
+                    ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+                }
+            });
             if (!res.ok) throw new Error('Failed to load');
 
             const template = await res.json();

--- a/frontend-nextjs/pages/workflows/editor/[id].tsx
+++ b/frontend-nextjs/pages/workflows/editor/[id].tsx
@@ -22,7 +22,12 @@ export default function WorkflowEditorPage() {
     const fetchWorkflow = async (workflowId: string) => {
         setIsLoading(true);
         try {
-            const res = await fetch(`/api/workflow-templates/${workflowId}`);
+            const token = localStorage.getItem('auth_token');
+            const res = await fetch(`/api/workflow-templates/${workflowId}`, {
+                headers: {
+                    ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+                }
+            });
             if (!res.ok) throw new Error('Failed to load workflow');
 
             const template = await res.json();
@@ -109,9 +114,13 @@ export default function WorkflowEditorPage() {
                 steps: steps
             };
 
+            const token = localStorage.getItem('auth_token');
             const res = await fetch(`/api/workflow-templates/${id}`, {
                 method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 
+                    'Content-Type': 'application/json',
+                    ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+                },
                 body: JSON.stringify(payload)
             });
 


### PR DESCRIPTION
…equests

- Fetch the user token from `localStorage` (`auth_token`).
- Inject the `Authorization: Bearer <token>` header into native `fetch` requests for workflow template endpoints.
- Resolves the template loading error ("Could not load workflow templates") on:
  - `/marketplace`
  - `/workflows/builder`
  - `/workflows/editor/[id]`
  - `<WorkflowAutomation />` component

## Description

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

<!-- How did you verify this works? -->

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend type-checks (`tsc --noEmit`)
- [ ] Manually tested the user flow

## Checklist

- [ ] Code follows the project style (match surrounding patterns)
- [ ] Self-reviewed the diff
- [ ] Comments added for complex logic
- [ ] No new warnings introduced
