### PR TITLE
feat(oauth): wire up Outlook/Microsoft OAuth integration flow

### DIFF
--- a/backend/main_api_app.py
+++ b/backend/main_api_app.py
@@ -1791,9 +1791,15 @@ try:
         app.include_router(system_health_router)
 
         # Backward compatibility for the /integrations list
-        from api.integrations_catalog_routes import router as catalog_router
-
         app.include_router(catalog_router, prefix="")
+
+        # OAuth Status and Authorization Endpoints
+        try:
+            from oauth_status_routes import router as oauth_status_router
+            app.include_router(oauth_status_router)
+            logger.info("✓ OAuth Status and Authorization Routes Loaded")
+        except Exception as e:
+            logger.error(f"Failed to load OAuth status routes: {e}")
 
         # Integration Registry API (Capability Discovery)
 

--- a/backend/oauth_status_routes.py
+++ b/backend/oauth_status_routes.py
@@ -483,3 +483,17 @@ async def overall_oauth_status():
         "missing_services": validation["missing"],
         "timestamp": datetime.now().isoformat(),
     }
+
+
+from fastapi.responses import RedirectResponse
+
+@router.get("/{provider}/initiate")
+async def redirect_oauth_initiate(provider: str):
+    """Alias/redirect route to the unified v1 initiate endpoint."""
+    provider_map = {
+        "outlook": "microsoft",
+        "teams": "microsoft",
+        "gdrive": "google",
+    }
+    target_provider = provider_map.get(provider, provider)
+    return RedirectResponse(url=f"/api/v1/auth/oauth/{target_provider}/initiate")

--- a/frontend-nextjs/components/OutlookIntegration.tsx
+++ b/frontend-nextjs/components/OutlookIntegration.tsx
@@ -166,6 +166,26 @@ const OutlookIntegration: React.FC = () => {
 
     const { toast } = useToast();
 
+    const handleConnect = async () => {
+        try {
+            const response = await fetch("/api/auth/outlook/authorize");
+            if (!response.ok) throw new Error("Failed to get authorization URL");
+            const data = await response.json();
+            if (data.auth_url) {
+                window.location.href = data.auth_url;
+            } else {
+                throw new Error("No authorization URL returned");
+            }
+        } catch (error) {
+            console.error("Connect error:", error);
+            toast({
+                title: "Error",
+                description: "Failed to initiate Outlook connection.",
+                variant: "destructive",
+            });
+        }
+    };
+
     // Check connection status
     const checkConnection = async () => {
         try {
@@ -467,9 +487,7 @@ const OutlookIntegration: React.FC = () => {
                                 <Button
                                     size="lg"
                                     className="w-full bg-blue-600 hover:bg-blue-700"
-                                    onClick={() =>
-                                        (window.location.href = "/api/auth/outlook/authorize")
-                                    }
+                                    onClick={handleConnect}
                                 >
                                     <ArrowRight className="mr-2 w-4 h-4" />
                                     Connect Outlook Account

--- a/frontend-nextjs/next.config.js
+++ b/frontend-nextjs/next.config.js
@@ -162,6 +162,22 @@ const nextConfig = {
       },
       // Specific Auth Rewrites (Delegate only these to Python Backend)
       {
+        source: "/api/auth/:service/authorize",
+        destination: "http://127.0.0.1:8000/api/auth/:service/authorize",
+      },
+      {
+        source: "/api/auth/:service/initiate",
+        destination: "http://127.0.0.1:8000/api/auth/:service/initiate",
+      },
+      {
+        source: "/api/auth/:service/status",
+        destination: "http://127.0.0.1:8000/api/auth/:service/status",
+      },
+      {
+        source: "/api/v1/auth/oauth/:path*",
+        destination: "http://127.0.0.1:8000/api/v1/auth/oauth/:path*",
+      },
+      {
         source: "/api/auth/login",
         destination: "http://127.0.0.1:8000/api/auth/login",
       },


### PR DESCRIPTION
- Mount `oauth_status_routes` in the backend `main_api_app.py` to expose integration status endpoints.
- Define a generic redirect helper in `oauth_status_routes.py` to route `/api/auth/{provider}/initiate` alias requests to `/api/v1/auth/oauth/{provider}/initiate`.
- Add Next.js rewrites to proxy `/api/auth/:service/authorize`, `/api/auth/:service/initiate`, `/api/auth/:service/status`, and `/api/v1/auth/oauth/:path*` to the FastAPI backend.
- Update `OutlookIntegration.tsx` to handle OAuth flow initiation asynchronously, obtaining the authentic authorization URL from the status API, resolving the 404/JSON dump connection issues.

## Description

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

<!-- How did you verify this works? -->

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend type-checks (`tsc --noEmit`)
- [ ] Manually tested the user flow

## Checklist

- [ ] Code follows the project style (match surrounding patterns)
- [ ] Self-reviewed the diff
- [ ] Comments added for complex logic
- [ ] No new warnings introduced
