### PR TITLE
fix(finance): forward authorization headers for cash-flow forecast an…

### DIFF
--- a/frontend-nextjs/components/finance/ForecastingSandbox.tsx
+++ b/frontend-nextjs/components/finance/ForecastingSandbox.tsx
@@ -20,7 +20,14 @@ const ForecastingSandbox = () => {
 
     const fetchForecast = async () => {
         try {
-            const response = await fetch(`/api/accounting/forecast?workspace_id=${workspaceId}`);
+            const token = localStorage.getItem('auth_token');
+            const headers: Record<string, string> = {};
+            if (token) {
+                headers['Authorization'] = `Bearer ${token}`;
+            }
+            const response = await fetch(`/api/accounting/forecast?workspace_id=${workspaceId}`, {
+                headers
+            });
             if (!response.ok) throw new Error("Failed to fetch forecast");
             const data = await response.json();
             setForecastData(data.projection || []);
@@ -35,8 +42,14 @@ const ForecastingSandbox = () => {
         if (!scenarioText) return;
         setLoading(true);
         try {
+            const token = localStorage.getItem('auth_token');
+            const headers: Record<string, string> = {};
+            if (token) {
+                headers['Authorization'] = `Bearer ${token}`;
+            }
             const response = await fetch(`/api/accounting/scenario?workspace_id=${workspaceId}&scenario_description=${encodeURIComponent(scenarioText)}`, {
-                method: 'POST'
+                method: 'POST',
+                headers
             });
             if (!response.ok) throw new Error("Scenario analysis failed");
             const data = await response.json();
@@ -74,7 +87,7 @@ const ForecastingSandbox = () => {
                                 />
                                 <YAxis fontSize={12} tickFormatter={(val) => `$${val.toLocaleString()}`} />
                                 <Tooltip
-                                    formatter={(val: number) => [`$${val.toLocaleString()}`, 'Projected Balance']}
+                                    formatter={(val: any) => [`$${Number(val).toLocaleString()}`, 'Projected Balance']}
                                     labelFormatter={(label) => new Date(label).toLocaleDateString()}
                                 />
                                 <ReferenceLine y={0} stroke="#ef4444" strokeDasharray="3 3" />

--- a/frontend-nextjs/pages/api/accounting/forecast.ts
+++ b/frontend-nextjs/pages/api/accounting/forecast.ts
@@ -15,7 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const response = await fetch(url, {
             method: 'GET',
             headers: {
-                // 'Authorization': `Bearer ${token}` // Add auth if needed later
+                ...(req.headers.authorization ? { 'Authorization': req.headers.authorization } : {})
             },
         });
 

--- a/frontend-nextjs/pages/api/accounting/scenario.ts
+++ b/frontend-nextjs/pages/api/accounting/scenario.ts
@@ -15,7 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const response = await fetch(url, {
             method: 'POST',
             headers: {
-                // 'Authorization': `Bearer ${token}` // Add auth if needed later
+                ...(req.headers.authorization ? { 'Authorization': req.headers.authorization } : {})
             },
         });
 


### PR DESCRIPTION
…d scenario requests

- Attach user `auth_token` to `fetchForecast` and `runScenario` queries in `ForecastingSandbox.tsx`.
- Forward incoming `Authorization` headers in Next.js server-side proxies `pages/api/accounting/forecast.ts` and `pages/api/accounting/scenario.ts`.
- Resolves the 401 Unauthorized backend error causing the "Failed to fetch forecast" crash.

## Description

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

<!-- How did you verify this works? -->

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend type-checks (`tsc --noEmit`)
- [ ] Manually tested the user flow

## Checklist

- [ ] Code follows the project style (match surrounding patterns)
- [ ] Self-reviewed the diff
- [ ] Comments added for complex logic
- [ ] No new warnings introduced
