### PR TITLE
fix(auth): add timeout to OAuth token exchange request

### DIFF
--- a/backend/consolidated/core/auth_service.py
+++ b/backend/consolidated/core/auth_service.py
@@ -336,7 +336,7 @@ class AuthService:
             "redirect_uri": redirect_uri,
         }
 
-        response = requests.post(provider_config["token_url"], data=data)
+        response = requests.post(provider_config["token_url"], data=data, timeout=15)
         response.raise_for_status()
 
         return response.json()
@@ -363,7 +363,7 @@ class AuthService:
                 "grant_type": "refresh_token",
             }
 
-            response = requests.post(provider_config["token_url"], data=data)
+            response = requests.post(provider_config["token_url"], data=data, timeout=15)
             response.raise_for_status()
 
             new_tokens = response.json()
@@ -400,7 +400,7 @@ class AuthService:
                 return {}
 
             headers = {"Authorization": f"Bearer {access_token}"}
-            response = requests.get(endpoint, headers=headers)
+            response = requests.get(endpoint, headers=headers, timeout=15)
             response.raise_for_status()
 
             return response.json()
@@ -424,7 +424,7 @@ class AuthService:
                 return True  # No revocation endpoint, consider it successful
 
             data = {"token": access_token}
-            response = requests.post(endpoint, data=data)
+            response = requests.post(endpoint, data=data, timeout=15)
 
             # Some providers return 200, others might have different success codes
             return response.status_code in [200, 204]


### PR DESCRIPTION
The OAuth flows in auth_service.py call requests.post and requests.get against provider token URLs with no timeout argument. A slow or unresponsive identity provider will hang the connection indefinitely, blocking worker threads and causing downstream availability issues.

Added timeout=15 (seconds) to all four calls in the file: the authorization-code token exchange, the token refresh, the user info fetch, and the token revocation. Fifteen seconds is generous enough for a healthy provider and tight enough to fail fast when one is not.