### PR TITLE
fix(security): prevent command injection and path traversal in desktop-bridge API

### DIFF
--- a/frontend-nextjs/pages/api/dev/desktop-bridge.ts
+++ b/frontend-nextjs/pages/api/dev/desktop-bridge.ts
@@ -2,7 +2,34 @@ import { NextApiRequest, NextApiResponse } from "next";
 import fs from "fs";
 import path from "path";
 import os from "os";
-import { exec } from "child_process";
+import { execFile } from "child_process";
+
+/**
+ * Allowed base directory for file operations.
+ * Restricts all file read/write/list operations to this directory tree.
+ */
+const ALLOWED_BASE_DIR = path.resolve(process.cwd());
+
+/**
+ * Validate that a resolved path is within the allowed base directory.
+ * Prevents path traversal attacks (CWE-22).
+ */
+function validatePath(userPath: string): string {
+  const resolved = path.resolve(userPath);
+  if (!resolved.startsWith(ALLOWED_BASE_DIR + path.sep) && resolved !== ALLOWED_BASE_DIR) {
+    throw new Error("Path is outside the allowed directory");
+  }
+  return resolved;
+}
+
+/**
+ * Allowlist of commands that may be executed via the execute_command handler.
+ * Each entry maps to a safe execFile invocation with controlled arguments.
+ */
+const ALLOWED_COMMANDS: Record<string, string> = {
+  "node --version": "node",
+  "npm --version": "npm",
+};
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {
@@ -32,10 +59,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (!filePath) {
         return res.status(400).json({ success: false, error: "Path is required" });
       }
-      if (!fs.existsSync(filePath)) {
+      const safePath = validatePath(filePath);
+      if (!fs.existsSync(safePath)) {
         return res.status(400).json({ success: false, error: "File does not exist" });
       }
-      const content = fs.readFileSync(filePath, "utf8");
+      const content = fs.readFileSync(safePath, "utf8");
       return res.status(200).json({ success: true, content });
     }
 
@@ -45,18 +73,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (!filePath) {
         return res.status(400).json({ success: false, error: "Path is required" });
       }
-      fs.writeFileSync(filePath, content, "utf8");
+      const safePath = validatePath(filePath);
+      fs.writeFileSync(safePath, content, "utf8");
       return res.status(200).json({ success: true });
     }
 
     if (command === "list_directory") {
-      const dirPath = args?.path || process.cwd();
-      if (!fs.existsSync(dirPath)) {
+      const dirPath = args?.path || ALLOWED_BASE_DIR;
+      const safePath = validatePath(dirPath);
+      if (!fs.existsSync(safePath)) {
         return res.status(400).json({ success: false, error: "Directory does not exist" });
       }
-      const files = fs.readdirSync(dirPath);
+      const files = fs.readdirSync(safePath);
       const entries = files.map((file) => {
-        const fullPath = path.join(dirPath, file);
+        const fullPath = path.join(safePath, file);
         let isDir = false;
         let size = 0;
         try {
@@ -77,10 +107,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     if (command === "execute_command") {
-      const { command: cmd, args: cmdArgs, workingDir } = args;
+      const { command: cmd, args: cmdArgs } = args;
       const fullCmd = `${cmd} ${cmdArgs ? cmdArgs.join(" ") : ""}`.trim();
-      
-      exec(fullCmd, { cwd: workingDir || process.cwd() }, (error, stdout, stderr) => {
+
+      // Only allow commands from a strict allowlist
+      const allowedBinary = ALLOWED_COMMANDS[fullCmd];
+      if (!allowedBinary) {
+        return res.status(403).json({
+          success: false,
+          error: "Command not in allowlist. Only safe read-only commands are permitted.",
+        });
+      }
+
+      execFile(allowedBinary, ["--version"], { cwd: ALLOWED_BASE_DIR }, (error, stdout, stderr) => {
         return res.status(200).json({
           success: !error,
           output: stdout + (stderr ? `\nError: ${stderr}` : ""),


### PR DESCRIPTION
## Security Fix: Command Injection + Path Traversal in desktop-bridge API

### Summary
The `/api/dev/desktop-bridge` endpoint had two critical vulnerabilities:

1. **Command Injection (CWE-78)** — The `execute_command` handler passed user-controlled `cmd` and `cmdArgs` directly to `exec()` with shell execution, allowing unauthenticated RCE.
2. **Path Traversal (CWE-22)** — The `list_directory`, `read_file_content`, and `write_file_content` commands accepted unvalidated `args.path` values, allowing arbitrary file system access.

### Changes
- Replaced `exec()` with `execFile()` and a strict command allowlist
- Added `validatePath()` function that restricts all file operations to the project base directory
- Applied path validation to `read_file_content`, `write_file_content`, and `list_directory`
- Removed uncontrolled `workingDir` parameter from `execute_command`

### PoC (before fix)
```bash
# Command injection
curl -X POST http://target/api/dev/desktop-bridge   -H 'Content-Type: application/json'   -d '{"command":"execute_command","args":{"command":"cat /etc/passwd","args":[]}}'

# Path traversal
curl -X POST http://target/api/dev/desktop-bridge   -H 'Content-Type: application/json'   -d '{"command":"read_file_content","args":{"path":"/etc/shadow"}}'
```

### Impact
Unauthenticated remote code execution and arbitrary file read/write on the server.

### Testing
- Verified that `execute_command` with non-allowlisted commands returns 403
- Verified that path traversal attempts (`../../etc/passwd`) are rejected
- Verified that legitimate operations within the project directory still work

Signed-off-by: FailSafe Security <security@failsafesecurity.ai>