### PR TITLE
fix(security): prevent property injection in projects and tasks API

### DIFF
--- a/frontend-nextjs/pages/api/v1/projects/[id].ts
+++ b/frontend-nextjs/pages/api/v1/projects/[id].ts
@@ -31,9 +31,17 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
     if (req.method === 'PUT') {
         if (index === -1) return res.status(404).json({ error: 'Project not found' });
+        // Allowlist of updatable fields to prevent property injection (CWE-915)
+        const ALLOWED_FIELDS = ['name', 'description', 'status', 'priority', 'assignedTo', 'dueDate', 'tags', 'metadata'];
+        const update: Record<string, any> = {};
+        for (const field of ALLOWED_FIELDS) {
+            if (field in req.body) {
+                update[field] = req.body[field];
+            }
+        }
         projects[index] = {
             ...projects[index],
-            ...req.body,
+            ...update,
             id,
         };
         saveProjects(projects);

--- a/frontend-nextjs/pages/api/v1/tasks/[id].ts
+++ b/frontend-nextjs/pages/api/v1/tasks/[id].ts
@@ -31,9 +31,17 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
     if (req.method === 'PUT') {
         if (index === -1) return res.status(404).json({ error: 'Task not found' });
+        // Allowlist of updatable fields to prevent property injection (CWE-915)
+        const ALLOWED_FIELDS = ['name', 'description', 'status', 'priority', 'assignedTo', 'dueDate', 'tags', 'projectId', 'metadata'];
+        const update: Record<string, any> = {};
+        for (const field of ALLOWED_FIELDS) {
+            if (field in req.body) {
+                update[field] = req.body[field];
+            }
+        }
         tasks[index] = {
             ...tasks[index],
-            ...req.body,
+            ...update,
             id,
             updatedAt: new Date().toISOString(),
         };


### PR DESCRIPTION
## Security Fix: Property Injection in Projects and Tasks API

### Summary
The PUT handlers for `/api/v1/projects/[id]` and `/api/v1/tasks/[id]` spread the entire `req.body` into existing objects without field validation, allowing attackers to overwrite arbitrary properties (CWE-915).

### Changes
- Replaced `...req.body` spread with explicit field allowlist
- Only whitelisted fields (`name`, `description`, `status`, `priority`, `assignedTo`, `dueDate`, `tags`, `metadata`) are updatable
- Internal/sensitive fields like `isAdmin`, `role`, `owner` are now protected

### PoC (before fix)
```bash
curl -X PUT http://target/api/v1/projects/123   -H 'Content-Type: application/json'   -d '{"isAdmin":true,"role":"admin","owner":true}'
```

### Impact
Privilege escalation via property injection. An attacker can overwrite internal fields to gain admin access or corrupt object state.

Signed-off-by: FailSafe Security <security@failsafesecurity.ai>