### PR TITLE
fix(harness): R82 follow-ups — debounced drift healing, composite patch identity, family-keyed mining

### DIFF
--- a/backend/core/harness_evolution_service.py
+++ b/backend/core/harness_evolution_service.py
@@ -108,12 +108,22 @@ class HarnessEvolutionService:
                 except Exception:
                     pass
 
-            # Group key by step type and tool
-            key = (f.step_type, tool_name)
+            # Cluster per model family so prompt-patch proposals are born
+            # scoped (requested_model is the router-selected concrete ID;
+            # resolved_model is the provider echo — either identifies the
+            # family, prefer requested for consistency with serve-time
+            # filtering).
+            model_family = normalize_model_family(
+                getattr(f, "requested_model", None) or getattr(f, "resolved_model", None)
+            )
+
+            # Group key by model family, step type and tool
+            key = (model_family, f.step_type, tool_name)
             if key not in patterns:
                 patterns[key] = {
                     "step_type": f.step_type,
                     "tool": tool_name,
+                    "model_family": model_family or None,
                     "failure_count": 0,
                     "examples": []
                 }
@@ -153,6 +163,7 @@ class HarnessEvolutionService:
             }
             model_scope = "all"
             model_family = None
+            patch_id = f"patch_{step_type}_{tool}"
         elif step_type == "thought":
             target = "system_prompt"
             payload = {
@@ -160,6 +171,10 @@ class HarnessEvolutionService:
             }
             model_scope = "model_family"
             model_family = pattern.get("model_family")
+            # Composite identity: two families can carry variants of the same
+            # logical patch without overwriting each other on deploy.
+            family_slug = (model_family or "unknown").replace(" ", "-")
+            patch_id = f"patch_{step_type}_{tool}_{family_slug}"
         else:
             target = "context_compaction"
             payload = {
@@ -171,9 +186,10 @@ class HarnessEvolutionService:
             # scoping once mining attributes overflow failures to families.
             model_scope = "all"
             model_family = None
+            patch_id = f"patch_{step_type}_{tool}"
 
         return {
-            "patch_id": f"patch_{step_type}_{tool}",
+            "patch_id": patch_id,
             "target_component": target,
             "mutation_payload": payload,
             "model_scope": model_scope,
@@ -264,6 +280,16 @@ class HarnessEvolutionService:
         except Exception:
             pass
 
+        # Scope-policy gate (R82 adjudicated): prose-level patches must never
+        # be universal — enforce at the gate, not by proposer convention.
+        if target == "system_prompt" and patch.get("model_scope", "all") != "model_family":
+            logger.warning(
+                f"Patch {patch['patch_id']} is a system_prompt patch with "
+                f"model_scope={patch.get('model_scope')!r} — refusing: prompt "
+                "patches must be model_family-scoped"
+            )
+            return False
+
         return True
 
     async def deploy_harness_patch(self, patch: Dict[str, Any], agent_id: str) -> bool:
@@ -299,9 +325,16 @@ class HarnessEvolutionService:
         except Exception:
             pass  # rollback is best-effort; never blocks deployment
 
-        # Upsert patch configuration
+        # Upsert patch configuration. Composite key: (patch_id, model_family)
+        # — two family variants of the same logical patch coexist instead of
+        # overwriting each other.
         patches = agent.configuration["harness_patches"]
-        patches = [p for p in patches if p["patch_id"] != patch["patch_id"]]
+        def _same_variant(p: Dict[str, Any]) -> bool:
+            return (
+                p.get("patch_id") == patch["patch_id"]
+                and (p.get("model_family") or None) == (patch.get("model_family") or None)
+            )
+        patches = [p for p in patches if not _same_variant(p)]
         patches.append(patch)
         agent.configuration["harness_patches"] = patches
 

--- a/backend/core/llm/model_provenance.py
+++ b/backend/core/llm/model_provenance.py
@@ -18,8 +18,12 @@ Components:
 - :class:`ModelDriftDetector` — baseline map keyed ``(provider_id,
   requested_model) -> resolved`` persisted to a JSON state file. Fires a
   :class:`DriftEvent` when the echo changes under a stable requested key.
-  Missing echoes are "unknown", never "unchanged". Self-heals when the echo
-  stabilizes.
+  Missing echoes are "unknown", never "unchanged". A drifted key only heals
+  after ``ATOM_DRIFT_STABLE_ECHOES`` (default 3) consecutive echoes matching
+  the new baseline — a silent bump IS a new steady state, so a single repeat
+  observation must not re-enable patches that were never re-validated on the
+  new checkpoint. :meth:`ModelDriftDetector.mark_revalidated` clears drift
+  immediately once scoped patches have been explicitly re-validated.
 - :func:`normalize_model_family` — policy-based family collapse for patch
   scoping: strips dates/snapshots/preview/free suffixes but KEEPS variant
   tiers (deepseek-v4-flash != deepseek-v4-pro). Family governs harness-patch
@@ -47,6 +51,8 @@ from typing import Dict, Optional
 logger = logging.getLogger(__name__)
 
 _FLAG = "ATOM_MODEL_DRIFT_DETECTION_ENABLED"
+_STABLE_ECHOES_FLAG = "ATOM_DRIFT_STABLE_ECHOES"
+_DEFAULT_STABLE_ECHOES = 3
 _DEFAULT_STATE_PATH = Path("./data/model_resolution_state.json")
 
 _resolved_model_cv: ContextVar[Optional[str]] = ContextVar(
@@ -70,6 +76,14 @@ def clear_resolved_model() -> None:
 
 def _enabled() -> bool:
     return os.getenv(_FLAG, "true").lower() == "true"
+
+
+def _stable_echoes_required() -> int:
+    try:
+        n = int(os.getenv(_STABLE_ECHOES_FLAG, str(_DEFAULT_STABLE_ECHOES)))
+        return max(1, n)
+    except (TypeError, ValueError):
+        return _DEFAULT_STABLE_ECHOES
 
 
 # ── family normalization (policy, not guesswork) ──────────────────────
@@ -114,10 +128,14 @@ class ModelDriftDetector:
     """Detects provider-side checkpoint bumps under stable request aliases.
 
     State shape (JSON): ``{"baselines": {"<provider>:<requested>": "<resolved>"}}``
-    plus an in-memory set of currently-drifted keys. A key is drifted between
-    the observation that diverges and the observation where the echo
-    stabilizes on the new value (provider rollback to the ORIGINAL value also
-    heals, since the next steady state matches whatever baseline is stored).
+    plus in-memory sets of currently-drifted keys and their consecutive
+    stable-echo counts. On detection the baseline moves to the new echo and
+    the key is marked drifted — family-scoped patches for that identity are
+    suppressed. Healing is debounced: the key stays drifted until the echo has
+    matched the new baseline ``ATOM_DRIFT_STABLE_ECHOES`` times in a row
+    (default 3) OR :meth:`mark_revalidated` is called after explicit patch
+    re-validation. Rationale: a silent bump is a steady state, so one repeat
+    observation proves consistency, not that the old patches are still good.
     """
 
     def __init__(self, state_path: Optional[Path] = None):
@@ -125,6 +143,7 @@ class ModelDriftDetector:
         self._lock = threading.Lock()
         self._baselines: Dict[str, str] = {}
         self._drifted: set = set()
+        self._stable: Dict[str, int] = {}
         self._load()
 
     # ── persistence (best-effort, never raises) ──
@@ -178,10 +197,15 @@ class ModelDriftDetector:
                     return None
                 if previous == resolved_model:
                     if key in self._drifted:
-                        self._drifted.discard(key)  # healed: echo stabilized
+                        self._stable[key] = self._stable.get(key, 0) + 1
+                        if self._stable[key] >= _stable_echoes_required():
+                            # debounced heal: echo proven consistent N times
+                            self._drifted.discard(key)
+                            self._stable.pop(key, None)
                     return None
                 self._baselines[key] = resolved_model
                 self._drifted.add(key)
+                self._stable.pop(key, None)
                 self._save()
             event = DriftEvent(
                 provider_id=provider_id,
@@ -201,12 +225,26 @@ class ModelDriftDetector:
             return None
 
     def is_drifted(self, provider_id: str, requested_model: str) -> bool:
-        """True while the echo for this identity is unstable (active drift)."""
+        """True while the echo for this identity is unstable or unre-validated."""
         try:
             with self._lock:
                 return self._key(provider_id, requested_model) in self._drifted
         except Exception:
             return False
+
+    def mark_revalidated(self, provider_id: str, requested_model: str) -> None:
+        """Clear drift immediately after explicit patch re-validation.
+
+        Callers: the re-validation path (sandbox validate_mutation_in_sandbox
+        against the new checkpoint) — NOT the observe loop. Never raises.
+        """
+        try:
+            with self._lock:
+                key = self._key(provider_id, requested_model)
+                self._drifted.discard(key)
+                self._stable.pop(key, None)
+        except Exception:
+            pass
 
 
 _detector: Optional[ModelDriftDetector] = None

--- a/backend/tests/test_round82_model_provenance.py
+++ b/backend/tests/test_round82_model_provenance.py
@@ -10,8 +10,10 @@ read-time applicability filtering (normalize -> scope match -> drift expiry).
 All tests mock-heavy: zero network, zero LLM spend.
 """
 
+import asyncio
 import json
 import threading
+from datetime import datetime, timezone
 
 import pytest
 
@@ -96,14 +98,50 @@ def test_drift_same_value_no_event(tmp_path):
     assert det.observe("openai", "m", "m-snap-1") is None
 
 
-def test_drift_heals_when_provider_rolls_back(tmp_path):
+def test_drift_healing_is_debounced(tmp_path):
+    """A silent bump IS a steady state: one repeated echo must NOT heal —
+    suppression persists until N consecutive stable echoes (default 3)."""
     det = _detector(tmp_path)
     det.observe("openai", "m", "snap-a")
     assert det.is_drifted("openai", "m") is False  # steady baseline
     det.observe("openai", "m", "snap-b")
-    assert det.is_drifted("openai", "m") is True  # bump fires
+    assert det.is_drifted("openai", "m") is True   # bump fires
     det.observe("openai", "m", "snap-b")
-    assert det.is_drifted("openai", "m") is False  # echo stabilized → healed
+    assert det.is_drifted("openai", "m") is True   # 1 stable echo: still drifted
+    det.observe("openai", "m", "snap-b")
+    assert det.is_drifted("openai", "m") is True   # 2 stable echoes: still drifted
+    det.observe("openai", "m", "snap-b")
+    assert det.is_drifted("openai", "m") is False  # 3 stable echoes: healed
+
+
+def test_drift_revalidation_clears_immediately(tmp_path):
+    det = _detector(tmp_path)
+    det.observe("openai", "m", "snap-a")
+    det.observe("openai", "m", "snap-b")
+    assert det.is_drifted("openai", "m") is True
+    det.mark_revalidated("openai", "m")  # explicit post-validation clear
+    assert det.is_drifted("openai", "m") is False
+
+
+def test_drift_second_bump_resets_stable_counter(tmp_path):
+    det = _detector(tmp_path)
+    det.observe("openai", "m", "snap-a")
+    det.observe("openai", "m", "snap-b")
+    det.observe("openai", "m", "snap-b")  # 1 stable
+    det.observe("openai", "m", "snap-c")  # bumps again mid-heal
+    assert det.is_drifted("openai", "m") is True
+    det.observe("openai", "m", "snap-c")  # stable counter restarted from 0
+    assert det.is_drifted("openai", "m") is True
+
+
+def test_drift_stable_echoes_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATOM_DRIFT_STABLE_ECHOES", "1")
+    det = _detector(tmp_path)
+    det.observe("openai", "m", "snap-a")
+    det.observe("openai", "m", "snap-b")
+    assert det.is_drifted("openai", "m") is True
+    det.observe("openai", "m", "snap-b")
+    assert det.is_drifted("openai", "m") is False  # 1 echo suffices
 
 
 def test_drift_state_persists_across_instances(tmp_path):
@@ -247,10 +285,61 @@ async def test_propose_mutation_prompt_patch_is_family_scoped():
     from core.harness_evolution_service import HarnessEvolutionService
 
     svc = HarnessEvolutionService.__new__(HarnessEvolutionService)
-    patch = await svc.propose_mutation({"tool": "unknown", "step_type": "thought"})
+    patch = await svc.propose_mutation(
+        {"tool": "unknown", "step_type": "thought", "model_family": "gpt-5.4"}
+    )
     assert patch["target_component"] == "system_prompt"
     assert patch["model_scope"] == "model_family"
-    assert "model_family" in patch
+    assert patch["model_family"] == "gpt-5.4"
+    # Composite identity: family is part of the patch_id so cross-family
+    # variants can't overwrite each other on deploy.
+    assert patch["patch_id"] == "patch_thought_unknown_gpt-5.4"
+
+
+def test_default_validation_rejects_universal_prompt_patch():
+    from core.harness_evolution_service import HarnessEvolutionService
+
+    svc = HarnessEvolutionService.__new__(HarnessEvolutionService)
+    assert svc._default_patch_validation({
+        "patch_id": "p", "target_component": "system_prompt",
+        "model_scope": "all", "mutation_payload": {},
+    }) is False
+    assert svc._default_patch_validation({
+        "patch_id": "p", "target_component": "system_prompt",
+        "model_scope": "model_family", "model_family": "gpt-5.4",
+        "mutation_payload": {},
+    }) is True
+
+
+def test_deploy_keyed_on_patch_id_and_family():
+    """Two family variants of the same logical patch coexist in the store."""
+    from unittest.mock import MagicMock
+    from core.harness_evolution_service import HarnessEvolutionService
+    from core.models import AgentRegistry
+
+    svc = HarnessEvolutionService.__new__(HarnessEvolutionService)
+    svc.db = MagicMock()
+
+    gpt_patch = {"patch_id": "patch_thought_shell", "target_component": "system_prompt",
+                 "model_scope": "model_family", "model_family": "gpt-5.4"}
+    ds_patch = {"patch_id": "patch_thought_shell", "target_component": "system_prompt",
+                "model_scope": "model_family", "model_family": "deepseek-v4-flash"}
+
+    agent = AgentRegistry(id="a1", name="a", category="ops",
+                          configuration={"harness_patches": []})
+    svc.db.query.return_value.filter.return_value.first.return_value = agent
+    for p in (gpt_patch, ds_patch):
+        asyncio.run(svc.deploy_harness_patch(p, "a1"))
+
+    ids = {(p["patch_id"], p["model_family"]) for p in agent.configuration["harness_patches"]}
+    assert ("patch_thought_shell", "gpt-5.4") in ids
+    assert ("patch_thought_shell", "deepseek-v4-flash") in ids  # not overwritten
+
+    # Re-deploying the same variant replaces only that variant.
+    asyncio.run(svc.deploy_harness_patch(gpt_patch, "a1"))
+    fams = [p["model_family"] for p in agent.configuration["harness_patches"]
+            if p["patch_id"] == "patch_thought_shell"]
+    assert fams.count("gpt-5.4") == 1
 
 
 @pytest.mark.asyncio
@@ -309,6 +398,45 @@ def test_applicable_patches_drift_expiry(tmp_path, monkeypatch):
     after = {p["patch_id"] for p in applicable_patches(
         patches, "gpt-5.4-2026-03", provider_id="openai", drift_detector=det)}
     assert after == {"portable"}  # scoped patch expired immediately
+
+
+# ── mining keys clusters on model family ──────────────────────────────
+
+
+def test_mine_weaknesses_clusters_by_model_family():
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+    from core.harness_evolution_service import HarnessEvolutionService
+
+    svc = HarnessEvolutionService.__new__(HarnessEvolutionService)
+    svc.db = MagicMock()
+
+    def step(step_type, tool, requested=None, resolved=None):
+        return SimpleNamespace(
+            id="x", tenant_id="t", timestamp=datetime.now(timezone.utc),
+            verified="failed_verification", feedback_score=-1,
+            step_type=step_type, action={"tool": tool},
+            requested_model=requested, resolved_model=resolved,
+            thought="t", observation="o", verification_evidence="e",
+        )
+
+    rows = [
+        step("thought", "shell", requested="gpt-5.4-2026-03"),
+        step("thought", "shell", resolved="gpt-5.4-2026-09"),   # echo fallback
+        step("thought", "shell", requested="deepseek-v4-flash"),
+        step("action", "shell", requested="gpt-5.4-2026-03"),   # same family, diff step
+    ]
+    svc.db.query.return_value.filter.return_value.all.return_value = rows
+
+    patterns = asyncio.run(svc.mine_weaknesses("t"))
+    by_key = {(p["model_family"], p["step_type"], p["tool"]): p for p in patterns}
+
+    # Both gpt echoes collapse to one family cluster of 2
+    assert by_key[("gpt-5.4", "thought", "shell")]["failure_count"] == 2
+    # deepseek clusters separately
+    assert by_key[("deepseek-v4-flash", "thought", "shell")]["failure_count"] == 1
+    # same family, different step_type stays a separate cluster
+    assert by_key[("gpt-5.4", "action", "shell")]["failure_count"] == 1
 
 
 # ── rec #1d: reasoning-step provenance columns ────────────────────────

--- a/docs/architecture/HARNESS_EVOLUTION.md
+++ b/docs/architecture/HARNESS_EVOLUTION.md
@@ -75,14 +75,16 @@ The problem statement above notes that *different foundation models have differe
 
 ### Silent-bump drift detection
 
-CAIN-style vendor drift changes the resolved ID while the requested alias stays stable — invisible to requested-keyed consumers. `ModelDriftDetector` keeps a persisted baseline map `(provider_id, requested_model) → resolved` (`./data/model_resolution_state.json`) and fires a `DriftEvent` on divergence. Missing echoes are *unknown*, never *unchanged*; the detector self-heals when the echo stabilizes. Flag: `ATOM_MODEL_DRIFT_DETECTION_ENABLED` (default ON, detection-only, never raises).
+CAIN-style vendor drift changes the resolved ID while the requested alias stays stable — invisible to requested-keyed consumers. `ModelDriftDetector` keeps a persisted baseline map `(provider_id, requested_model) → resolved` (`./data/model_resolution_state.json`) and fires a `DriftEvent` on divergence. Missing echoes are *unknown*, never *unchanged*. Healing is **debounced**: a drifted key stays drifted until the echo has matched the new baseline `ATOM_DRIFT_STABLE_ECHOES` consecutive times (default 3) or `mark_revalidated()` is called after explicit patch re-validation — a silent bump IS a steady state, so a single repeat echo proves consistency, not that the old scoped patches are still good. Flag: `ATOM_MODEL_DRIFT_DETECTION_ENABLED` (default ON, detection-only, never raises).
 
 ### Patch scoping policy
 
 `propose_mutation` now tags by component class:
 
 - `ast_tripwire`, `context_compaction` → `"model_scope": "all"` (deterministic blast-radius controls are portable). Compaction is secretly model-sensitive via context windows — schema permits scoping later.
-- `system_prompt` → `"model_scope": "model_family"` (+ `model_family` once mining keys clusters on `requested_model`). Evidence basis is precautionary, not demonstrated: AHE's −2.3pp system-prompt result is a same-model ablation (its cross-model runs transfer the full harness), but prompt-level artifacts also fail across task surfaces (ACE playbook regressing below seed on SWE-bench) and across models (PromptBridge model-drifting measurements).
+- `system_prompt` → `"model_scope": "model_family"`. Mining clusters failures on `(model_family, step_type, tool)` via `AgentReasoningStep.requested_model` (echo `resolved_model` as fallback), so prompt patches are born with a concrete family — never `None`, never universal. Evidence basis is precautionary, not demonstrated: AHE's −2.3pp system-prompt result is a same-model ablation (its cross-model runs transfer the full harness), but prompt-level artifacts also fail across task surfaces (ACE playbook regressing below seed on SWE-bench) and across models (PromptBridge model-drifting measurements).
+
+**Composite patch identity**: family-scoped `patch_id`s embed the family (`patch_thought_shell_gpt-5.4`), and `deploy_harness_patch` upserts on `(patch_id, model_family)` — two family variants of the same logical patch coexist instead of overwriting each other. The structural validator additionally REJECTS any `system_prompt` patch whose scope isn't `model_family` (gate-enforced policy, not proposer convention).
 
 **Family granularity is policy**: `normalize_model_family()` collapses dates/snapshots (`gpt-5.4-2026-03` → `gpt-5.4`) and `free`/`preview` tags, but PRESERVES variant tiers (`deepseek-v4-flash` ≠ `-pro`). Drift detection stays keyed on the concrete ID for maximum sensitivity; families govern only patch breadth.
 
@@ -92,7 +94,7 @@ The tag alone is inert. `core/harness_evolution_service.py::applicable_patches(p
 
 1. scope match — `all` always; family-scoped only on normalized family equality;
 2. fail-safe — unknown origin family ⇒ excluded, never silently universalized;
-3. **drift expiry** — active drift on `(provider_id, current_model_id)` suppresses matching family-scoped patches IMMEDIATELY (serve-path action, not next-cycle correction), restoring when the echo stabilizes.
+3. **drift expiry** — active drift on `(provider_id, current_model_id)` suppresses matching family-scoped patches IMMEDIATELY (serve-path action, not next-cycle correction). Restoration requires `ATOM_DRIFT_STABLE_ECHOES` consecutive stable echoes (debounced — one repeat echo does not restore) or explicit `mark_revalidated()` after re-validating the patches against the new checkpoint.
 
 **Known gaps**: streaming create sites uninstrumented; `requested_model` not yet populated at the meta-agent persistence seam; no runtime consumer exists yet — the filter ships first so the invariant is inherited, not retrofitted.
 


### PR DESCRIPTION
## Fixes the three R82 review findings

### 1. Drift expiry self-healed after one echo (suppression window ≈ zero)
A silent bump IS a new steady state: a single repeat echo proved consistency, not that the scoped patches were still good — the old code healed on the first matching observation, so `applicable_patches` saw the drift flag for at most one call.
- Healing now requires `ATOM_DRIFT_STABLE_ECHOES` (default 3) consecutive echoes matching the new baseline.
- New `mark_revalidated(provider, model)` clears drift immediately for the explicit re-validation path.
- A second bump mid-heal resets the stable counter.

### 2. Composite patch identity was missing (deploy overwrote cross-family variants)
`deploy_harness_patch` upserted on `patch_id` alone and proposed IDs contained no family — once mining attributed families, a gpt-5.4 variant and a deepseek variant of the same pattern would silently overwrite each other.
- Upsert now keys on `(patch_id, model_family)`; family-scoped `patch_id`s embed the family (`patch_thought_shell_gpt-5.4`).
- `_default_patch_validation` now rejects `system_prompt` patches with any scope other than `model_family` — gate-enforced policy, not proposer convention.

### 3. Prompt patches shipped fully inert
`mine_weaknesses` grouped only on `(step_type, tool)`, so `model_family` was always `None` and the fail-safe excluded every prompt patch forever.
- Mining now clusters on `(model_family, step_type, tool)` using `AgentReasoningStep.requested_model` (`resolved_model` fallback); prompt patches are born with a concrete family.

## Verification
- 36 R82 tests pass (6 new: debounce, revalidation, counter-reset, env override, composite deploy, family-keyed mining, universal-prompt rejection)
- 66 pass with w77 + unit harness suites; 89 with w107/R81 suites
- HARNESS_EVOLUTION.md updated to match behavior
- Note: mypy not available in the local python3.14 env — not run (R82 ran it in a different interpreter)