### PR TITLE
feat(zoho): re-land WorkDrive folder sync with auth

### DIFF
--- a/backend/api/zoho_workdrive_routes.py
+++ b/backend/api/zoho_workdrive_routes.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import logging
 from typing import Any, Dict, List, Optional
-from fastapi import Depends, Request
+from fastapi import Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from core.auth import get_current_user, User
@@ -10,9 +10,10 @@ from integrations.zoho_workdrive_service import ZohoWorkDriveService
 
 logger = logging.getLogger(__name__)
 
-# Round 37: Zoho WorkDrive endpoints read/ingest a user's cloud files. They were
-# fully anonymous and trusted a client-supplied user_id, allowing cross-user
-# file access. Identity now comes from the token.
+# Round 37 + review follow-up: every Zoho WorkDrive endpoint reads/ingests a
+# user's cloud files. These were previously anonymous with a client-supplied
+# user_id (cross-user file access). Identity ALWAYS comes from the token — the
+# router-level dependency is the enforcement floor for every endpoint below.
 router = BaseAPIRouter(
     prefix="/api/zoho-workdrive",
     tags=["zoho-workdrive"],
@@ -26,58 +27,173 @@ zoho_service = ZohoWorkDriveService()
 class FileListRequest(BaseModel):
     user_id: str = Field(..., description="User ID")
     parent_id: str = Field("root", description="Parent folder or team ID")
+    team_id: Optional[str] = Field(None, description="Explicit team ID")
+    workspace_id: Optional[str] = Field(None, description="Explicit workspace ID")
+    recursive: bool = Field(False, description="Recursively list subfolders")
 
 class IngestRequest(BaseModel):
     user_id: str = Field(..., description="User ID")
     file_id: str = Field(..., description="Zoho WorkDrive file ID")
 
+class IngestFolderRequest(BaseModel):
+    user_id: str = Field(..., description="User ID")
+    folder_id: str = Field(..., description="Root folder ID to ingest")
+    team_id: Optional[str] = Field(None, description="Explicit team ID")
+    workspace_id: Optional[str] = Field(None, description="Explicit workspace ID")
+    recursive: bool = Field(True, description="Recursively ingest subfolders")
+    max_files: int = Field(500, description="Maximum files to ingest")
+
+class SyncTeamRequest(BaseModel):
+    user_id: str = Field(..., description="User ID")
+    team_id: Optional[str] = Field(None, description="Explicit team ID")
+    workspace_id: Optional[str] = Field(None, description="Explicit workspace ID")
+    folder_id: Optional[str] = Field(None, description="Specific folder ID to sync")
+    recursive: bool = Field(True, description="Recursively sync subfolders")
+
+class FolderTreeRequest(BaseModel):
+    user_id: str = Field(..., description="User ID")
+    workspace_id: Optional[str] = Field(None, description="Explicit workspace ID")
+    team_id: Optional[str] = Field(None, description="Explicit team ID")
+    max_depth: int = Field(10, description="Maximum tree depth")
+
 @router.get("/teams", summary="List Zoho WorkDrive teams")
 async def get_teams(current_user: User = Depends(get_current_user)):
     """Get teams for the authenticated Zoho user"""
     try:
-        teams = await zoho_service.get_teams(current_user.id)
-        return router.success_response(data=teams)
+        teams = await zoho_service.get_teams(str(current_user.id))
+        return router.success_response(data=teams or [])
     except Exception as e:
         logger.error(f"Error fetching Zoho teams: {e}")
         raise router.internal_error(message="Error fetching Zoho teams", details={"error": "Internal error"})
 
-@router.post("/files/list", summary="List files in a folder")
-async def list_files(request: FileListRequest, current_user: User = Depends(get_current_user)):
-    """List files and folders in a specific parent ID"""
+@router.get("/team-folders", summary="List team folders across all teams (or specific team)")
+async def get_team_folders(
+    team_id: Optional[str] = Query(None),
+    current_user: User = Depends(get_current_user),
+):
+    """List all team folders across teams (or specific team).
+
+    Returns: {id, name, team_id, team_name, workspace_id, type}
+    """
     try:
-        files = await zoho_service.list_files(current_user.id, request.parent_id)
-        return router.success_response(data=files)
+        folders = await zoho_service.get_team_folders(str(current_user.id), team_id)
+        return router.success_response(data=folders or [])
+    except Exception as e:
+        logger.error(f"Error fetching Zoho team folders: {e}")
+        raise router.internal_error(message="Error fetching Zoho team folders", details={"error": "Internal error"})
+
+@router.post("/files/list", summary="List files in a folder, workspace, or team folder")
+async def list_files(request_body: FileListRequest, current_user: User = Depends(get_current_user)):
+    """List files and folders in a specific parent ID, workspace, or team.
+
+    Supports:
+    - parent_id="root" (default): user's private workspace
+    - team_id: explicit team's root workspace
+    - workspace_id: explicit workspace (personal or team)
+    - recursive: recursively list all subfolders
+    """
+    try:
+        files = await zoho_service.list_files(
+            str(current_user.id), request_body.parent_id,
+            request_body.team_id, request_body.workspace_id,
+            request_body.recursive
+        )
+        return router.success_response(data=files or [])
     except Exception as e:
         logger.error(f"Error listing Zoho files: {e}")
         raise router.internal_error(message="Error listing Zoho files", details={"error": "Internal error"})
 
 @router.post("/ingest", summary="Ingest file to ATOM memory")
-async def ingest_file(request: IngestRequest, current_user: User = Depends(get_current_user)):
+async def ingest_file(request_body: IngestRequest, current_user: User = Depends(get_current_user)):
     """Download and ingest a file into ATOM knowledge base"""
     try:
-        result = await zoho_service.ingest_file_to_memory(current_user.id, request.file_id)
+        result = await zoho_service.ingest_file_to_memory(str(current_user.id), request_body.file_id)
         return result
     except Exception as e:
         logger.error(f"Error ingesting Zoho file: {e}")
         raise router.internal_error(message="Error ingesting Zoho file", details={"error": "Internal error"})
 
+@router.post("/ingest-folder", summary="Ingest entire folder tree recursively")
+async def ingest_folder(request_body: IngestFolderRequest, current_user: User = Depends(get_current_user)):
+    """Recursively ingest all parseable files in a folder tree.
+
+    Supports:
+    - folder_id: root folder ID (or "root" for workspace root)
+    - team_id / workspace_id: explicit team/workspace
+    - recursive: traverse subfolders
+    - max_files: safety cap
+    - file extensions: .docx, .xlsx, .xls, .csv, .pdf, .txt, .md, .pptx
+    """
+    try:
+        result = await zoho_service.ingest_folder_tree(
+            str(current_user.id), request_body.folder_id,
+            request_body.team_id, request_body.workspace_id,
+            request_body.recursive, max_files=request_body.max_files
+        )
+        return result
+    except Exception as e:
+        logger.error(f"Error ingesting Zoho folder tree: {e}")
+        raise router.internal_error(message="Error ingesting folder", details={"error": "Internal error"})
+
+@router.post("/sync-team", summary="Full sync for specific team/workspace/folder")
+async def sync_team(request_body: SyncTeamRequest, current_user: User = Depends(get_current_user)):
+    """Full dual-pipeline sync for specific team, workspace, or folder.
+
+    Pipeline 1: Ingest parseable files into ATOM memory (LanceDB + GraphRAG)
+    Pipeline 2: Refresh Postgres metrics cache
+
+    Supports:
+    - team_id: explicit team
+    - workspace_id: explicit workspace (personal or team)
+    - folder_id: specific folder to sync (with recursive traversal)
+    - recursive: traverse subfolders
+    """
+    try:
+        result = await zoho_service.full_sync(
+            str(current_user.id),
+            workspace_id=request_body.workspace_id,
+            team_id=request_body.team_id,
+            folder_id=request_body.folder_id,
+            recursive=request_body.recursive
+        )
+        return result
+    except Exception as e:
+        logger.error(f"Error syncing Zoho team: {e}")
+        raise router.internal_error(message="Error syncing team", details={"error": "Internal error"})
+
+@router.post("/folder-tree", summary="Get full folder tree for a workspace/team")
+async def get_folder_tree(request_body: FolderTreeRequest, current_user: User = Depends(get_current_user)):
+    """Get full nested folder tree structure for a workspace/team.
+
+    Returns nested structure: {id, name, type: 'folder', children: [...], file_count}
+    Use this to display the full folder hierarchy in the UI.
+    """
+    try:
+        tree = await zoho_service.get_folder_tree(
+            str(current_user.id),
+            workspace_id=request_body.workspace_id,
+            team_id=request_body.team_id,
+            max_depth=request_body.max_depth
+        )
+        return router.success_response(data=tree)
+    except Exception as e:
+        logger.error(f"Error fetching Zoho folder tree: {e}")
+        raise router.internal_error(message="Error fetching Zoho folder tree", details={"error": "Internal error"})
+
 @router.post("/full-sync", summary="Full ingestion sync of the entire WorkDrive tree")
-async def full_sync(
-    http_request: Request,
-    current_user: User = Depends(get_current_user),
-):
+async def full_sync(current_user: User = Depends(get_current_user)):
     """Walk every subfolder of the private workspace AND all team folders
     (paginated), attempt every file type through the parser chain, and write
     to Atom memory (LanceDB + GraphRAG) with folder-path context. Also
     refreshes the Postgres metrics cache."""
     try:
-        uid = str(current_user.id)
-        result = await zoho_service.full_sync(uid)
+        # Identity always comes from the token — never from a client-supplied
+        # user_id, and never a silent demo-user fallback.
+        result = await zoho_service.full_sync(str(current_user.id))
         return result
     except Exception as e:
         logger.error(f"Error running Zoho WorkDrive full sync: {e}")
         raise router.internal_error(message="Error running Zoho WorkDrive full sync", details={"error": "Internal error"})
-
 
 @router.get("/health", summary="Zoho WorkDrive health check")
 async def health_check():

--- a/backend/api/zoho_workdrive_routes.py
+++ b/backend/api/zoho_workdrive_routes.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import logging
 from typing import Any, Dict, List, Optional
-from fastapi import Depends, HTTPException, Query, Request
+from fastapi import Depends, Query
 from pydantic import BaseModel, Field
 
 from core.auth import get_current_user, User
@@ -23,38 +23,35 @@ router = BaseAPIRouter(
 # Initialize service
 zoho_service = ZohoWorkDriveService()
 
-# Pydantic models
+# Pydantic models. None carry user_id: identity comes exclusively from the
+# auth token (router-level get_current_user dependency) — a client-supplied
+# user_id must never reappear on these surfaces.
 class FileListRequest(BaseModel):
-    user_id: str = Field(..., description="User ID")
     parent_id: str = Field("root", description="Parent folder or team ID")
     team_id: Optional[str] = Field(None, description="Explicit team ID")
     workspace_id: Optional[str] = Field(None, description="Explicit workspace ID")
     recursive: bool = Field(False, description="Recursively list subfolders")
 
 class IngestRequest(BaseModel):
-    user_id: str = Field(..., description="User ID")
     file_id: str = Field(..., description="Zoho WorkDrive file ID")
 
 class IngestFolderRequest(BaseModel):
-    user_id: str = Field(..., description="User ID")
     folder_id: str = Field(..., description="Root folder ID to ingest")
     team_id: Optional[str] = Field(None, description="Explicit team ID")
     workspace_id: Optional[str] = Field(None, description="Explicit workspace ID")
     recursive: bool = Field(True, description="Recursively ingest subfolders")
-    max_files: int = Field(500, description="Maximum files to ingest")
+    max_files: int = Field(500, ge=1, le=2000, description="Maximum files to ingest")
 
 class SyncTeamRequest(BaseModel):
-    user_id: str = Field(..., description="User ID")
     team_id: Optional[str] = Field(None, description="Explicit team ID")
     workspace_id: Optional[str] = Field(None, description="Explicit workspace ID")
     folder_id: Optional[str] = Field(None, description="Specific folder ID to sync")
     recursive: bool = Field(True, description="Recursively sync subfolders")
 
 class FolderTreeRequest(BaseModel):
-    user_id: str = Field(..., description="User ID")
     workspace_id: Optional[str] = Field(None, description="Explicit workspace ID")
     team_id: Optional[str] = Field(None, description="Explicit team ID")
-    max_depth: int = Field(10, description="Maximum tree depth")
+    max_depth: int = Field(10, ge=1, le=25, description="Maximum tree depth")
 
 @router.get("/teams", summary="List Zoho WorkDrive teams")
 async def get_teams(current_user: User = Depends(get_current_user)):

--- a/backend/core/auto_document_ingestion.py
+++ b/backend/core/auto_document_ingestion.py
@@ -260,6 +260,30 @@ class DocumentParser:
         """Parse Excel to text - compatible with DocumentLifecycleLearner.
         Also extracts formulas and stores them in Atom's formula memory.
         """
+        # Old-format .xls (OLE2 Compound File): only xlrd reads these. The
+        # zip-based parsers (openpyxl/pandas) raise BadZipFile on OLE2 content,
+        # so detect by the OLE2 magic bytes BEFORE anything touches them.
+        if content[:8] == b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1":
+            try:
+                import xlrd
+                wb = xlrd.open_workbook(file_contents=content)
+                parts = []
+                for sheet in wb.sheets():
+                    parts.append(f"--- Sheet: {sheet.name} ---")
+                    for r in range(getattr(sheet, "nrows", 0)):
+                        row = []
+                        for c in range(getattr(sheet, "ncols", 0)):
+                            val = sheet.cell_value(r, c)
+                            row.append(str(val) if val is not None else "")
+                        parts.append(" | ".join(row))
+                return "\n".join(parts)
+            except ImportError:
+                logger.warning("xlrd not installed; cannot parse old .xls (OLE2) files")
+                return ""
+            except Exception as e:
+                logger.error(f"XLS (xlrd) parse error: {e}")
+                return ""
+
         # Extract formulas if file_path is provided
         if file_path:
             try:

--- a/backend/integrations/zoho_workdrive_service.py
+++ b/backend/integrations/zoho_workdrive_service.py
@@ -1,8 +1,9 @@
 import os
 import json
+import asyncio
 import logging
 import httpx
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 from datetime import datetime, timedelta, timezone
 from fastapi import HTTPException
 from core.database import SessionLocal
@@ -11,6 +12,9 @@ from core.models import IntegrationMetric
 from core.integration_service import IntegrationService
 
 logger = logging.getLogger(__name__)
+
+# Parseable file extensions for auto-ingestion
+PARSEABLE_EXTS = (".docx", ".xlsx", ".xls", ".csv", ".pdf", ".txt", ".md", ".pptx")
 
 class ZohoWorkDriveService(IntegrationService):
     """
@@ -287,21 +291,128 @@ class ZohoWorkDriveService(IntegrationService):
         except Exception as e:
             logger.warning(f"Zoho WorkDrive org-team fallback failed: {e}")
 
-    async def list_files(self, user_id: str, parent_id: str = "root") -> List[Dict[str, Any]]:
-        """List files in a specific folder or 'root' (user's private workspace)."""
+    async def get_team_folders(self, user_id: str, team_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List all team folders across teams (or specific team).
+
+        Returns normalized list: {id, name, team_id, team_name, workspace_id, type}
+        """
+        token = await self.get_access_token(user_id)
+        if not token:
+            logger.warning("get_team_folders: No access token for user %s", user_id)
+            return []
+
+        try:
+            headers = {"Authorization": f"Zoho-oauthtoken {token}"}
+
+            # 1. Get teams (or use provided team_id)
+            teams_to_query = []
+            if team_id:
+                teams_to_query = [{"id": team_id}]
+            else:
+                teams_res = await self.client.get(f"{self.base_url}/teams", headers=headers)
+                logger.debug(f"GET /teams -> {teams_res.status_code}")
+                if teams_res.status_code != 200:
+                    logger.warning(f"GET /teams failed: {teams_res.status_code} - {teams_res.text[:200]}")
+                    return []
+                teams_to_query = teams_res.json().get("data", [])
+                logger.debug(f"Found {len(teams_to_query)} teams")
+                if not teams_to_query:
+                    # Plain members may be absent from /teams — fall back to
+                    # the org team id advertised on /users/me.
+                    me_res = await self.client.get(f"{self.base_url}/users/me", headers=headers)
+                    if me_res.status_code == 200:
+                        me_attrs = me_res.json().get("data", {}).get("attributes", {})
+                        tid = me_attrs.get("preferred_team_id")
+                        if tid:
+                            teams_to_query = [{"id": tid}]
+                            logger.debug("Fell back to preferred_team_id %s from /users/me", tid)
+
+            all_folders = []
+            for team in teams_to_query:
+                t_id = team.get("id")
+                t_name = team.get("attributes", {}).get("name") or team.get("attributes", {}).get("display_name", t_id)
+
+                # 2. Get team folders for this team
+                tf_res = await self.client.get(
+                    f"{self.base_url}/teams/{t_id}/teamfolders",
+                    headers=headers
+                )
+                logger.debug(f"GET /teams/{t_id}/teamfolders -> {tf_res.status_code}")
+                if tf_res.status_code != 200:
+                    logger.warning(f"Failed to get teamfolders for team {t_id}: {tf_res.status_code} - {tf_res.text[:300]}")
+                    # If 403/401, likely missing scope - log clearly
+                    if tf_res.status_code in (401, 403):
+                        logger.error("Team folders access denied - check OAuth scopes: WorkDrive.teamfolders.READ required")
+                    continue
+
+                tf_data = tf_res.json()
+                for item in tf_data.get("data", []):
+                    attrs = item.get("attributes", {})
+                    workspace = attrs.get("workspace", {})
+                    ws_id = workspace.get("id") if isinstance(workspace, dict) else None
+                    all_folders.append({
+                        "id": item.get("id"),
+                        "name": attrs.get("name") or attrs.get("display_name", "Unnamed"),
+                        "team_id": t_id,
+                        "team_name": t_name,
+                        "workspace_id": ws_id,
+                        "type": "teamfolder",
+                        "description": attrs.get("description"),
+                        "created_time": attrs.get("created_time"),
+                        "modified_time": attrs.get("modified_time"),
+                    })
+
+            logger.info(f"Found {len(all_folders)} team folders across {len(teams_to_query)} teams")
+            return all_folders
+        except Exception as e:
+            logger.error(f"Failed to list Zoho WorkDrive team folders: {e}")
+            return []
+
+    async def list_files(self, user_id: str, parent_id: str = "root",
+                         team_id: Optional[str] = None,
+                         workspace_id: Optional[str] = None,
+                         recursive: bool = False) -> List[Dict[str, Any]]:
+        """List files in a specific folder, workspace, or team folder.
+
+        Args:
+            parent_id: Folder ID, or "root" for workspace root
+            team_id: Explicit team ID (browses that team's root workspace)
+            workspace_id: Explicit workspace ID (personal or team workspace)
+            recursive: If True, recursively list all files in subfolders
+        """
         token = await self.get_access_token(user_id)
         if not token:
             return []
-        
+
         try:
             headers = {
                 "Authorization": f"Zoho-oauthtoken {token}",
                 "Accept": "application/vnd.api+json",
             }
-            
+
             target_url = None
-            if not parent_id or parent_id == "root":
-                # Get user ID from /users/me then fetch private space workspace
+
+            # Explicit workspace takes priority (covers both personal and team workspaces)
+            if workspace_id:
+                target_url = f"{self.base_url}/workspaces/{workspace_id}/files"
+            # Explicit team_id: fetch that team's root workspace
+            elif team_id:
+                if parent_id and parent_id != "root":
+                    # parent_id is a team folder id — list its files directly.
+                    target_url = f"{self.base_url}/teamfolders/{parent_id}/files"
+                else:
+                    # GET /teams/{team_id} -> get workspace_id from team's root workspace
+                    team_res = await self.client.get(f"{self.base_url}/teams/{team_id}", headers=headers)
+                    if team_res.status_code == 200:
+                        team_data = team_res.json().get("data", {})
+                        attrs = team_data.get("attributes", {})
+                        root_ws = attrs.get("root_workspace", {})
+                        ws_id = root_ws.get("id") if isinstance(root_ws, dict) else None
+                        if ws_id:
+                            target_url = f"{self.base_url}/workspaces/{ws_id}/files"
+            # parent_id is "root" or folder ID
+            elif not parent_id or parent_id == "root":
+                # Default to user's private workspace
                 user_res = await self.client.get(f"{self.base_url}/users/me", headers=headers)
                 if user_res.status_code == 200:
                     zoho_uid = user_res.json().get("data", {}).get("id")
@@ -313,8 +424,10 @@ class ZohoWorkDriveService(IntegrationService):
                                 ws_id = ps_data[0].get("id")
                                 target_url = f"{self.base_url}/workspaces/{ws_id}/files"
 
+            # Fallback: parent_id as folder/files
             if not target_url:
                 target_url = f"{self.base_url}/files/{parent_id}/files"
+
 
             files = []
             offset = 0
@@ -369,11 +482,129 @@ class ZohoWorkDriveService(IntegrationService):
                 if len(page_items) < self.PAGE_SIZE or len(files) >= self.MAX_LIST_ITEMS:
                     break
                 offset += self.PAGE_SIZE
+
+            # Recursive traversal if requested. Subfolders are always regular
+            # folders (even inside team folders / workspaces), so recurse with
+            # plain parent_id — dropping team_id/workspace_id prevents routing
+            # subfolders to the teamfolders/workspaces endpoints.
+            if recursive:
+                all_files = list(files)
+                for f in files:
+                    if f.get("type") == "folder":
+                        subfiles = await self.list_files(
+                            user_id, parent_id=f["id"], recursive=True
+                        )
+                        all_files.extend(subfiles)
+                return all_files
+
             return files
         except Exception as e:
             logger.error(f"Failed to list Zoho WorkDrive files: {e}")
             return []
 
+
+    async def get_folder_tree(self, user_id: str,
+                               workspace_id: Optional[str] = None,
+                               team_id: Optional[str] = None,
+                               max_depth: int = 10) -> Dict[str, Any]:
+        """Get full folder tree structure for a workspace/team.
+
+        Returns nested folder structure: {id, name, type: 'folder', children: [...], file_count}
+        """
+        token = await self.get_access_token(user_id)
+        if not token:
+            return {"id": "root", "name": "Root", "type": "folder", "children": [], "error": "No access token"}
+
+        try:
+            headers = {
+                "Authorization": f"Zoho-oauthtoken {token}",
+                "Accept": "application/vnd.api+json",
+            }
+
+            # Resolve workspace URL
+            target_url = None
+            if workspace_id:
+                target_url = f"{self.base_url}/workspaces/{workspace_id}/files"
+            elif team_id:
+                team_res = await self.client.get(f"{self.base_url}/teams/{team_id}", headers=headers)
+                if team_res.status_code == 200:
+                    team_data = team_res.json().get("data", {})
+                    attrs = team_data.get("attributes", {})
+                    root_ws = attrs.get("root_workspace", {})
+                    ws_id = root_ws.get("id") if isinstance(root_ws, dict) else None
+                    if ws_id:
+                        target_url = f"{self.base_url}/workspaces/{ws_id}/files"
+            else:
+                user_res = await self.client.get(f"{self.base_url}/users/me", headers=headers)
+                if user_res.status_code == 200:
+                    zoho_uid = user_res.json().get("data", {}).get("id")
+                    if zoho_uid:
+                        ps_res = await self.client.get(f"{self.base_url}/users/{zoho_uid}/privatespace", headers=headers)
+                        if ps_res.status_code == 200:
+                            ps_data = ps_res.json().get("data", [])
+                            if ps_data and len(ps_data) > 0:
+                                ws_id = ps_data[0].get("id")
+                                target_url = f"{self.base_url}/workspaces/{ws_id}/files"
+
+            if not target_url:
+                return {"id": "root", "name": "Root", "type": "folder", "children": [], "error": "Could not resolve workspace"}
+
+            # Build tree recursively
+            async def build_tree(folder_id: str, depth: int) -> Dict[str, Any]:
+                if depth > max_depth:
+                    return {"id": folder_id, "name": "..." if depth > 0 else "Root", "type": "folder", "children": [], "truncated": True}
+
+                # Get folder contents
+                if folder_id == "root":
+                    url = target_url
+                else:
+                    url = f"{self.base_url}/files/{folder_id}/files"
+
+                resp = await self.client.get(url, headers=headers)
+                if resp.status_code in (400, 404) and folder_id != "root":
+                    fallback = f"{self.base_url}/workspaces/{folder_id}/files"
+                    fb = await self.client.get(fallback, headers=headers)
+                    if fb.status_code == 200:
+                        resp = fb
+
+                if resp.status_code != 200:
+                    return {"id": folder_id, "name": "Error", "type": "folder", "children": [], "error": f"HTTP {resp.status_code}"}
+
+                data = resp.json()
+                node = {
+                    "id": folder_id if folder_id != "root" else target_url.split("/")[-2],
+                    "name": "Root" if folder_id == "root" else "Folder",
+                    "type": "folder",
+                    "children": [],
+                    "file_count": 0
+                }
+
+                # Get name for non-root
+                if folder_id != "root":
+                    meta_resp = await self.client.get(f"{self.base_url}/files/{folder_id}", headers=headers)
+                    if meta_resp.status_code == 200:
+                        meta = meta_resp.json().get("data", {}).get("attributes", {})
+                        node["name"] = meta.get("name") or meta.get("display_name") or "Folder"
+
+                for item in data.get("data", []):
+                    attrs = item.get("attributes", {})
+                    item_type = attrs.get("type", "file")
+                    name = attrs.get("name") or attrs.get("display_name", "Untitled")
+
+                    if item_type == "folder":
+                        child = await build_tree(item.get("id"), depth + 1)
+                        child["name"] = name
+                        node["children"].append(child)
+                    else:
+                        node["file_count"] += 1
+
+                return node
+
+            return await build_tree("root", 0)
+
+        except Exception as e:
+            logger.error(f"Failed to build folder tree: {e}")
+            return {"id": "root", "name": "Root", "type": "folder", "children": [], "error": str(e)}
     async def get_team_folder_ids(self, user_id: str) -> List[str]:
         """Return the IDs of all team folders (shared workspaces) across the
         user's teams. Team folders are the shared-drive counterpart to the
@@ -453,16 +684,31 @@ class ZohoWorkDriveService(IntegrationService):
             await _walk(rid, "", 0, label)
         return out
 
+
     async def download_file(self, user_id: str, file_id: str) -> Optional[bytes]:
-        """Download file content from WorkDrive"""
+        """Download file content from WorkDrive.
+
+        Uses a short-lived client instead of the shared pool: Zoho's
+        /download/{id} endpoint redirects to a signed URL and can stall
+        indefinitely on a stale keep-alive pooled connection (bytes trickle
+        just often enough to defeat httpx's per-read timeout). A fresh
+        connection, redirect-following, and a hard total-time cap keep this
+        from hanging the request (which previously surfaced as a proxy 500).
+        """
         token = await self.get_access_token(user_id)
         if not token:
             return None
-        
+
         try:
             headers = {"Authorization": f"Zoho-oauthtoken {token}"}
             url = f"{self.base_url}/download/{file_id}"
-            response = await self.client.get(url, headers=headers)
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(30.0, connect=10.0),
+                follow_redirects=True,
+            ) as client:
+                response = await asyncio.wait_for(
+                    client.get(url, headers=headers), timeout=60.0
+                )
             response.raise_for_status()
             return response.content
         except Exception as e:
@@ -504,9 +750,87 @@ class ZohoWorkDriveService(IntegrationService):
                 external_id=file_id,
             )
 
+            if result.get("status") != "ingested":
+                # Don't mask skipped/errored parses as success — the UI must
+                # tell the user nothing was stored (e.g. unsupported format).
+                reason = result.get("reason") or result.get("status") or "unknown"
+                logger.warning(f"Ingest skipped for {file_name}: {reason}")
+                return {"success": False, "error": f"File not ingested ({reason})"}
+
             return {"success": True, "result": result}
         except Exception as e:
             logger.error(f"Failed to ingest Zoho WorkDrive file: {e}")
+            return {"success": False, "error": str(e)}
+
+    async def ingest_folder_tree(self, user_id: str,
+                                 folder_id: str,
+                                 team_id: Optional[str] = None,
+                                 workspace_id: Optional[str] = None,
+                                 recursive: bool = True,
+                                 file_extensions: Tuple[str, ...] = PARSEABLE_EXTS,
+                                 max_files: int = 500) -> Dict[str, Any]:
+        """Recursively ingest all parseable files in a folder tree.
+
+        Args:
+            folder_id: Root folder ID to start ingestion (or "root" for workspace root)
+            team_id: Explicit team ID
+            workspace_id: Explicit workspace ID
+            recursive: If True, traverse subfolders
+            file_extensions: Tuple of extensions to ingest
+            max_files: Maximum files to ingest (safety cap)
+
+        Returns:
+            {success, ingested, errors, files_processed}
+        """
+        token = await self.get_access_token(user_id)
+        if not token:
+            return {"success": False, "error": "No Zoho WorkDrive access token. Connect the integration first."}
+
+        try:
+            from core.auto_document_ingestion import AutoDocumentIngestionService
+            ingestor = AutoDocumentIngestionService()
+
+            ingested = 0
+            errors: List[str] = []
+            processed = 0
+
+            # Get all files recursively
+            all_files = await self.list_files(
+                user_id, parent_id=folder_id, team_id=team_id,
+                workspace_id=workspace_id, recursive=recursive
+            )
+
+            for f in all_files:
+                if processed >= max_files:
+                    errors.append(f"Max files limit ({max_files}) reached")
+                    break
+
+                if f.get("type") != "file":
+                    continue
+
+                name = f.get("name", "") or ""
+                if not name.lower().endswith(file_extensions):
+                    continue
+
+                try:
+                    res = await self.ingest_file_to_memory(user_id, f.get("id"))
+                    processed += 1
+                    if res.get("success"):
+                        ingested += 1
+                    elif res.get("error"):
+                        errors.append(f"{name}: {res['error']}")
+                except Exception as file_err:
+                    errors.append(f"{name}: {file_err}")
+
+            return {
+                "success": True,
+                "folder_id": folder_id,
+                "files_processed": processed,
+                "files_ingested": ingested,
+                "errors": errors,
+            }
+        except Exception as e:
+            logger.error(f"Failed to ingest folder tree: {e}")
             return {"success": False, "error": str(e)}
 
     async def sync_to_postgres_cache(self, user_id: str) -> Dict[str, Any]:
@@ -561,7 +885,11 @@ class ZohoWorkDriveService(IntegrationService):
             logger.error(f"Zoho WorkDrive PostgreSQL cache sync failed: {e}")
             return {"success": False, "error": str(e)}
 
-    async def full_sync(self, user_id: str, workspace_id: Optional[str] = None) -> Dict[str, Any]:
+    async def full_sync(self, user_id: str,
+                         workspace_id: Optional[str] = None,
+                         team_id: Optional[str] = None,
+                         folder_id: Optional[str] = None,
+                         recursive: bool = True) -> Dict[str, Any]:
         """Trigger full dual-pipeline sync for Zoho WorkDrive.
 
         Pipeline 1: Ingest every file (all types, all subfolders, private
@@ -571,9 +899,28 @@ class ZohoWorkDriveService(IntegrationService):
         type the parsers support (including OCR-able images, code, json) is
         captured.
         Pipeline 2: Refresh the Postgres metrics cache.
+
+        Args:
+            user_id: User ID
+            workspace_id: Explicit workspace ID (personal or team workspace)
+            team_id: Explicit team ID
+            folder_id: Specific folder ID to sync (with recursive traversal)
+            recursive: If True, recursively traverse subfolders
         """
         ws_id = workspace_id or user_id
+
+        
+        # Use folder_id as root if provided, otherwise "root"
+        root_folder = folder_id or "root"
+        
+        # List files with new parameters
+        files = await self.list_files(
+            user_id, parent_id=root_folder, team_id=team_id,
+            workspace_id=workspace_id, recursive=recursive
+        )
+        parseable_exts = (".docx", ".xlsx", ".xls", ".csv", ".pdf", ".txt", ".md", ".pptx")
         files = await self.walk_files(user_id)
+
 
         ingested = 0
         skipped: list[str] = []
@@ -605,6 +952,9 @@ class ZohoWorkDriveService(IntegrationService):
         return {
             "success": True,
             "workspace_id": ws_id,
+            "team_id": team_id,
+            "folder_id": folder_id,
+            "recursive": recursive,
             "files_found": len(files),
             "files_ingested": ingested,
             "files_skipped": skipped,

--- a/backend/integrations/zoho_workdrive_service.py
+++ b/backend/integrations/zoho_workdrive_service.py
@@ -25,6 +25,10 @@ class ZohoWorkDriveService(IntegrationService):
     PAGE_SIZE = 50
     MAX_LIST_ITEMS = 10000
     MAX_WALK_DEPTH = 25
+    # Global caps for client-triggered recursive traversal — bound request
+    # latency and upstream API calls on large drives.
+    MAX_RECURSIVE_ITEMS = 2000
+    MAX_TREE_NODES = 1000
 
     def __init__(self, tenant_id: str = "default", config: Dict[str, Any] = None):
         if config is None:
@@ -489,10 +493,18 @@ class ZohoWorkDriveService(IntegrationService):
             # Recursive traversal if requested. Subfolders are always regular
             # folders (even inside team folders / workspaces), so recurse with
             # plain parent_id — dropping team_id/workspace_id prevents routing
-            # subfolders to the teamfolders/workspaces endpoints.
+            # subfolders to the teamfolders/workspaces endpoints. The budget
+            # caps TOTAL items across the whole recursion, not per folder, so
+            # a deep tree can't fan out into unbounded sequential API calls.
             if recursive:
                 all_files = list(files)
                 for f in files:
+                    if len(all_files) >= self.MAX_RECURSIVE_ITEMS:
+                        logger.warning(
+                            "Recursive listing hit cap of %s items; truncating",
+                            self.MAX_RECURSIVE_ITEMS,
+                        )
+                        break
                     if f.get("type") == "folder":
                         subfiles = await self.list_files(
                             user_id, parent_id=f["id"], recursive=True
@@ -553,9 +565,14 @@ class ZohoWorkDriveService(IntegrationService):
                 return {"id": "root", "name": "Root", "type": "folder", "children": [], "error": "Could not resolve workspace"}
 
             # Build tree recursively
+            nodes_built = 0
+
             async def build_tree(folder_id: str, depth: int) -> Dict[str, Any]:
+                nonlocal nodes_built
                 if depth > max_depth:
                     return {"id": folder_id, "name": "..." if depth > 0 else "Root", "type": "folder", "children": [], "truncated": True}
+                if nodes_built >= self.MAX_TREE_NODES:
+                    return {"id": folder_id, "name": "...", "type": "folder", "children": [], "truncated": True}
 
                 # Get folder contents
                 if folder_id == "root":
@@ -573,6 +590,7 @@ class ZohoWorkDriveService(IntegrationService):
                 if resp.status_code != 200:
                     return {"id": folder_id, "name": "Error", "type": "folder", "children": [], "error": f"HTTP {resp.status_code}"}
 
+                nodes_built += 1
                 data = resp.json()
                 node = {
                     "id": folder_id if folder_id != "root" else target_url.split("/")[-2],
@@ -582,13 +600,6 @@ class ZohoWorkDriveService(IntegrationService):
                     "file_count": 0
                 }
 
-                # Get name for non-root
-                if folder_id != "root":
-                    meta_resp = await self.client.get(f"{self.base_url}/files/{folder_id}", headers=headers)
-                    if meta_resp.status_code == 200:
-                        meta = meta_resp.json().get("data", {}).get("attributes", {})
-                        node["name"] = meta.get("name") or meta.get("display_name") or "Folder"
-
                 for item in data.get("data", []):
                     attrs = item.get("attributes", {})
                     item_type = attrs.get("type", "file")
@@ -596,6 +607,8 @@ class ZohoWorkDriveService(IntegrationService):
 
                     if item_type == "folder":
                         child = await build_tree(item.get("id"), depth + 1)
+                        # The parent listing already carries the child's name —
+                        # no per-folder metadata fetch needed (was N+1).
                         child["name"] = name
                         node["children"].append(child)
                     else:
@@ -603,7 +616,12 @@ class ZohoWorkDriveService(IntegrationService):
 
                 return node
 
-            return await build_tree("root", 0)
+            tree = await build_tree("root", 0)
+            if nodes_built >= self.MAX_TREE_NODES:
+                logger.warning(
+                    "Folder tree hit cap of %s nodes; truncated", self.MAX_TREE_NODES
+                )
+            return tree
 
         except Exception as e:
             logger.error(f"Failed to build folder tree: {e}")

--- a/backend/integrations/zoho_workdrive_service.py
+++ b/backend/integrations/zoho_workdrive_service.py
@@ -392,24 +392,27 @@ class ZohoWorkDriveService(IntegrationService):
 
             target_url = None
 
-            # Explicit workspace takes priority (covers both personal and team workspaces)
-            if workspace_id:
+            # A team folder (team_id + parent_id that is a team folder id) is
+            # the precise scope and wins over workspace_id — the UI sends both
+            # for a team folder, and /workspaces/{id}/files would otherwise
+            # replace the selected folder's file set with the workspace root.
+            if team_id and parent_id and parent_id != "root":
+                # parent_id is a team folder id — list its files directly.
+                target_url = f"{self.base_url}/teamfolders/{parent_id}/files"
+            # Explicit workspace (personal or team workspace root)
+            elif workspace_id:
                 target_url = f"{self.base_url}/workspaces/{workspace_id}/files"
             # Explicit team_id: fetch that team's root workspace
             elif team_id:
-                if parent_id and parent_id != "root":
-                    # parent_id is a team folder id — list its files directly.
-                    target_url = f"{self.base_url}/teamfolders/{parent_id}/files"
-                else:
-                    # GET /teams/{team_id} -> get workspace_id from team's root workspace
-                    team_res = await self.client.get(f"{self.base_url}/teams/{team_id}", headers=headers)
-                    if team_res.status_code == 200:
-                        team_data = team_res.json().get("data", {})
-                        attrs = team_data.get("attributes", {})
-                        root_ws = attrs.get("root_workspace", {})
-                        ws_id = root_ws.get("id") if isinstance(root_ws, dict) else None
-                        if ws_id:
-                            target_url = f"{self.base_url}/workspaces/{ws_id}/files"
+                # GET /teams/{team_id} -> get workspace_id from team's root workspace
+                team_res = await self.client.get(f"{self.base_url}/teams/{team_id}", headers=headers)
+                if team_res.status_code == 200:
+                    team_data = team_res.json().get("data", {})
+                    attrs = team_data.get("attributes", {})
+                    root_ws = attrs.get("root_workspace", {})
+                    ws_id = root_ws.get("id") if isinstance(root_ws, dict) else None
+                    if ws_id:
+                        target_url = f"{self.base_url}/workspaces/{ws_id}/files"
             # parent_id is "root" or folder ID
             elif not parent_id or parent_id == "root":
                 # Default to user's private workspace
@@ -604,7 +607,7 @@ class ZohoWorkDriveService(IntegrationService):
 
         except Exception as e:
             logger.error(f"Failed to build folder tree: {e}")
-            return {"id": "root", "name": "Root", "type": "folder", "children": [], "error": str(e)}
+            return {"id": "root", "name": "Root", "type": "folder", "children": [], "error": "Failed to build folder tree"}
     async def get_team_folder_ids(self, user_id: str) -> List[str]:
         """Return the IDs of all team folders (shared workspaces) across the
         user's teams. Team folders are the shared-drive counterpart to the
@@ -760,7 +763,7 @@ class ZohoWorkDriveService(IntegrationService):
             return {"success": True, "result": result}
         except Exception as e:
             logger.error(f"Failed to ingest Zoho WorkDrive file: {e}")
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": "Failed to ingest file"}
 
     async def ingest_folder_tree(self, user_id: str,
                                  folder_id: str,
@@ -820,7 +823,8 @@ class ZohoWorkDriveService(IntegrationService):
                     elif res.get("error"):
                         errors.append(f"{name}: {res['error']}")
                 except Exception as file_err:
-                    errors.append(f"{name}: {file_err}")
+                    logger.warning(f"Ingest failed for {name}: {file_err}")
+                    errors.append(f"{name}: ingest failed")
 
             return {
                 "success": True,
@@ -831,7 +835,7 @@ class ZohoWorkDriveService(IntegrationService):
             }
         except Exception as e:
             logger.error(f"Failed to ingest folder tree: {e}")
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": "Failed to ingest folder tree"}
 
     async def sync_to_postgres_cache(self, user_id: str) -> Dict[str, Any]:
         """Sync Zoho WorkDrive analytics to PostgreSQL IntegrationMetric table."""
@@ -876,14 +880,15 @@ class ZohoWorkDriveService(IntegrationService):
                 db.commit()
             except Exception as e:
                 db.rollback()
-                return {"success": False, "error": str(e)}
+                logger.error(f"Zoho WorkDrive metrics sync failed: {e}")
+                return {"success": False, "error": "Failed to sync metrics"}
             finally:
                 db.close()
                 
             return {"success": True, "metrics_synced": metrics_synced}
         except Exception as e:
             logger.error(f"Zoho WorkDrive PostgreSQL cache sync failed: {e}")
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": "Failed to sync Zoho WorkDrive cache"}
 
     async def full_sync(self, user_id: str,
                          workspace_id: Optional[str] = None,
@@ -914,12 +919,13 @@ class ZohoWorkDriveService(IntegrationService):
         root_folder = folder_id or "root"
         
         # List files with new parameters
+        # Scoped listing: /sync-team must honor the requested workspace/team/
+        # folder scope. walk_files() is unscoped and would silently ingest
+        # unrelated files — it must NOT replace this result.
         files = await self.list_files(
             user_id, parent_id=root_folder, team_id=team_id,
             workspace_id=workspace_id, recursive=recursive
         )
-        parseable_exts = (".docx", ".xlsx", ".xls", ".csv", ".pdf", ".txt", ".md", ".pptx")
-        files = await self.walk_files(user_id)
 
 
         ingested = 0
@@ -943,10 +949,11 @@ class ZohoWorkDriveService(IntegrationService):
                     else:
                         skipped.append(f"{name} ({inner.get('reason') or 'no_text'})")
                 except Exception as file_err:
-                    errors.append(f"{name}: {file_err}")
+                    logger.warning(f"Ingest failed for {name}: {file_err}")
+                    errors.append(f"{name}: ingest failed")
         except Exception as e:
             logger.error(f"Zoho WorkDrive memory ingestion failed: {e}")
-            errors.append(str(e))
+            errors.append("memory ingestion failed")
 
         cache_result = await self.sync_to_postgres_cache(user_id)
         return {
@@ -1016,7 +1023,7 @@ class ZohoWorkDriveService(IntegrationService):
             return {"success": True, "result": result}
         except Exception as e:
             logger.error(f"Zoho WorkDrive operation {operation} failed: {e}")
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": "Operation failed"}
 
 
 # Create a default instance for hub_sync_service compatibility

--- a/backend/integrations/zoho_workdrive_service.py
+++ b/backend/integrations/zoho_workdrive_service.py
@@ -919,13 +919,16 @@ class ZohoWorkDriveService(IntegrationService):
         root_folder = folder_id or "root"
         
         # List files with new parameters
-        # Scoped listing: /sync-team must honor the requested workspace/team/
-        # folder scope. walk_files() is unscoped and would silently ingest
-        # unrelated files — it must NOT replace this result.
-        files = await self.list_files(
-            user_id, parent_id=root_folder, team_id=team_id,
-            workspace_id=workspace_id, recursive=recursive
-        )
+        # Scoped sync honors the requested workspace/team/folder scope; an
+        # unscoped full sync walks the private workspace AND all team folders
+        # (walk_files with no root_ids starts at ["root"] + team folder ids).
+        if workspace_id or team_id or folder_id:
+            files = await self.list_files(
+                user_id, parent_id=root_folder, team_id=team_id,
+                workspace_id=workspace_id, recursive=recursive
+            )
+        else:
+            files = await self.walk_files(user_id)
 
 
         ingested = 0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -57,6 +57,7 @@ pandas>=1.5.0,<3.0.0
 numpy>=1.24.0,<2.0.0
 scikit-learn>=1.3.0,<2.0.0
 openpyxl>=3.1.0,<4.0.0
+xlrd>=2.0.1,<3.0.0
 formulas>=1.2.0
 python-dotenv>=1.0.0,<2.0.0
 click>=8.1.0,<9.0.0

--- a/backend/tests/test_covpush_w38_zoho_workdrive.py
+++ b/backend/tests/test_covpush_w38_zoho_workdrive.py
@@ -56,25 +56,45 @@ class TestListFiles:
         with patch("api.zoho_workdrive_routes.zoho_service.list_files",
                    new=AsyncMock(return_value=[{"id": "f1"}])):
             resp = client.post("/api/zoho-workdrive/files/list", json={
-                "user_id": "u1", "parent_id": "root"})
+                "parent_id": "root"})
         assert resp.status_code == 200
         assert resp.json()["data"] == [{"id": "f1"}]
 
     def test_list_files_default_parent(self, client):
         with patch("api.zoho_workdrive_routes.zoho_service.list_files",
                    new=AsyncMock(return_value=[])) as m:
-            resp = client.post("/api/zoho-workdrive/files/list", json={"user_id": "u1"})
+            resp = client.post("/api/zoho-workdrive/files/list", json={})
+        assert resp.status_code == 200
+        m.assert_awaited_once_with("u1", "root", None, None, False)
+
+    def test_list_files_forged_user_id_ignored(self, client):
+        # Identity comes from the token: a client-supplied user_id in the body
+        # must be ignored (extra fields) — the service still receives "u1".
+        with patch("api.zoho_workdrive_routes.zoho_service.list_files",
+                   new=AsyncMock(return_value=[])) as m:
+            resp = client.post("/api/zoho-workdrive/files/list",
+                               json={"user_id": "attacker", "parent_id": "root"})
         assert resp.status_code == 200
         m.assert_awaited_once_with("u1", "root", None, None, False)
 
     def test_list_files_error_500(self, client):
         with patch("api.zoho_workdrive_routes.zoho_service.list_files",
                    new=AsyncMock(side_effect=RuntimeError("boom"))):
-            resp = client.post("/api/zoho-workdrive/files/list", json={"user_id": "u1"})
+            resp = client.post("/api/zoho-workdrive/files/list", json={})
         assert resp.status_code == 500
 
-    def test_list_files_validation_422(self, client):
-        resp = client.post("/api/zoho-workdrive/files/list", json={})
+    def test_list_files_empty_body_is_valid(self, client):
+        # Every FileListRequest field is optional (user_id removed — identity
+        # is token-derived), so an empty body now defaults to the root folder.
+        with patch("api.zoho_workdrive_routes.zoho_service.list_files",
+                   new=AsyncMock(return_value=[])) as m:
+            resp = client.post("/api/zoho-workdrive/files/list", json={})
+        assert resp.status_code == 200
+        m.assert_awaited_once_with("u1", "root", None, None, False)
+
+    def test_ingest_folder_max_files_bounds_422(self, client):
+        resp = client.post("/api/zoho-workdrive/ingest-folder", json={
+            "folder_id": "root", "max_files": 10_000_000})
         assert resp.status_code == 422
 
 

--- a/backend/tests/test_covpush_w38_zoho_workdrive.py
+++ b/backend/tests/test_covpush_w38_zoho_workdrive.py
@@ -65,7 +65,7 @@ class TestListFiles:
                    new=AsyncMock(return_value=[])) as m:
             resp = client.post("/api/zoho-workdrive/files/list", json={"user_id": "u1"})
         assert resp.status_code == 200
-        m.assert_awaited_once_with("u1", "root")
+        m.assert_awaited_once_with("u1", "root", None, None, False)
 
     def test_list_files_error_500(self, client):
         with patch("api.zoho_workdrive_routes.zoho_service.list_files",

--- a/backend/tests/test_covpush_w79c_api_routes.py
+++ b/backend/tests/test_covpush_w79c_api_routes.py
@@ -528,9 +528,9 @@ class TestZohoListFiles:
     def test_list_files_default_parent(self, zoho_client):
         with patch("api.zoho_workdrive_routes.zoho_service.list_files",
                    new=AsyncMock(return_value=[])) as m:
-            resp = zoho_client.post("/api/zoho-workdrive/files/list", json={"user_id": "u1"})
+            resp = zoho_client.post("/api/zoho-workdrive/files/list", json={})
         assert resp.status_code == 200
-        m.assert_awaited_once_with("admin-w79c", "root")
+        m.assert_awaited_once_with("admin-w79c", "root", None, None, False)
 
     def test_list_files_error_500(self, zoho_client):
         with patch("api.zoho_workdrive_routes.zoho_service.list_files",
@@ -538,9 +538,14 @@ class TestZohoListFiles:
             resp = zoho_client.post("/api/zoho-workdrive/files/list", json={"user_id": "u1"})
         assert resp.status_code == 500
 
-    def test_list_files_validation_422(self, zoho_client):
-        resp = zoho_client.post("/api/zoho-workdrive/files/list", json={})
-        assert resp.status_code == 422
+    def test_list_files_empty_body_is_valid(self, zoho_client):
+        # user_id removed from the schema (token-derived identity): all fields
+        # are optional now, so an empty body defaults to the root folder.
+        with patch("api.zoho_workdrive_routes.zoho_service.list_files",
+                   new=AsyncMock(return_value=[])) as m:
+            resp = zoho_client.post("/api/zoho-workdrive/files/list", json={})
+        assert resp.status_code == 200
+        m.assert_awaited_once_with("admin-w79c", "root", None, None, False)
 
 
 class TestZohoIngest:

--- a/backend/tests/test_round38_api_auth_governance.py
+++ b/backend/tests/test_round38_api_auth_governance.py
@@ -366,7 +366,7 @@ class TestImpersonation:
         client = make_client(zoho_mod.router, current_user=authed_user)
 
         captured = {}
-        async def fake_list(user_id, parent_id):
+        async def fake_list(user_id, parent_id, team_id=None, workspace_id=None, recursive=False):
             captured["user_id"] = user_id
             return []
 

--- a/backend/tests/test_zoho_workdrive_ingest_xls.py
+++ b/backend/tests/test_zoho_workdrive_ingest_xls.py
@@ -1,0 +1,109 @@
+"""Tests for the Zoho WorkDrive ingest path: old-format .xls parsing and
+honest success reporting (skipped/errored files must not be reported as
+ingested)."""
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from core.auto_document_ingestion import DocumentParser
+from integrations.zoho_workdrive_service import ZohoWorkDriveService
+
+OLE2_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, data=None):
+        self.status_code = status_code
+        self._data = data if data is not None else {}
+        self.content = b""
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _FakeSheet:
+    name = "Sheet1"
+    nrows = 2
+    ncols = 2
+
+    def cell_value(self, r, c):
+        return [["Item", "Price"], ["Widget", "12.50"]][r][c]
+
+
+class _FakeWB:
+    def sheets(self):
+        return [_FakeSheet()]
+
+
+class _FakeXlrd:
+    def open_workbook(self, file_contents=None):
+        return _FakeWB()
+
+
+async def test_parse_excel_reads_old_xls_with_xlrd():
+    fake = _FakeXlrd()
+    mod = types.ModuleType("xlrd")
+    mod.open_workbook = fake.open_workbook
+    sys.modules["xlrd"] = mod
+    try:
+        text = await DocumentParser._parse_excel(OLE2_MAGIC + b"\x00" * 64)
+    finally:
+        sys.modules.pop("xlrd", None)
+    assert "Sheet1" in text
+    assert "Widget" in text
+    assert "12.50" in text
+
+
+async def test_ingest_reports_skipped_as_failure_not_success():
+    svc = ZohoWorkDriveService(
+        tenant_id="default",
+        config={"client_id": "cid", "client_secret": "cs", "redirect_uri": "uri"},
+    )
+    svc.get_access_token = AsyncMock(return_value="tok")
+    svc.download_file = AsyncMock(return_value=b"some bytes")
+    svc.client = MagicMock()
+    svc.client.get = AsyncMock(
+        return_value=_FakeResponse(200, {"data": {"attributes": {"name": "old.xls"}}})
+    )
+
+    with patch(
+        "core.auto_document_ingestion.AutoDocumentIngestionService"
+    ) as cls:
+        ingestor = cls.return_value
+        ingestor.process_file_bytes = AsyncMock(
+            return_value={"status": "skipped", "reason": "no_text", "file_name": "old.xls"}
+        )
+        result = await svc.ingest_file_to_memory("u1", "f1")
+
+    assert result["success"] is False
+    assert "no_text" in result["error"]
+    ingestor.process_file_bytes.assert_awaited_once()
+
+
+async def test_ingest_reports_success_only_when_actually_ingested():
+    svc = ZohoWorkDriveService(
+        tenant_id="default",
+        config={"client_id": "cid", "client_secret": "cs", "redirect_uri": "uri"},
+    )
+    svc.get_access_token = AsyncMock(return_value="tok")
+    svc.download_file = AsyncMock(return_value=b"# fly.toml\n")
+    svc.client = MagicMock()
+    svc.client.get = AsyncMock(
+        return_value=_FakeResponse(200, {"data": {"attributes": {"name": "fly.toml"}}})
+    )
+
+    with patch(
+        "core.auto_document_ingestion.AutoDocumentIngestionService"
+    ) as cls:
+        ingestor = cls.return_value
+        ingestor.process_file_bytes = AsyncMock(
+            return_value={"status": "ingested", "file_name": "fly.toml", "chars_ingested": 12}
+        )
+        result = await svc.ingest_file_to_memory("u1", "f1")
+
+    assert result["success"] is True
+    assert result["result"]["status"] == "ingested"

--- a/backend/tests/test_zoho_workdrive_service_team_folders.py
+++ b/backend/tests/test_zoho_workdrive_service_team_folders.py
@@ -1,0 +1,232 @@
+"""Service-level tests for Zoho WorkDrive team discovery fallback.
+
+RED case: `GET /api/v1/teams` returns `{"data":[]}` for users who are plain
+members of their org's team (no admin/owner role) — the previous code returned
+[] and the UI never saw the org's team folders. Fixed by falling back to
+`/users/me` -> `preferred_team_id`, then listing that team's folders, and by
+listing a team folder's files via `/teamfolders/{id}/files` (team folders have
+no `workspace_id`).
+"""
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from integrations.zoho_workdrive_service import ZohoWorkDriveService
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, data=None):
+        self.status_code = status_code
+        self._data = data if data is not None else {}
+        self.text = ""
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _service(responses):
+    svc = ZohoWorkDriveService(
+        tenant_id="default",
+        config={"client_id": "cid", "client_secret": "cs", "redirect_uri": "uri"},
+    )
+    svc.get_access_token = AsyncMock(return_value="tok")
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=responses)
+    svc.client = client
+    return svc, client
+
+
+TEAMS_EMPTY = {"data": []}
+ME_WITH_TEAM = {"data": {"attributes": {"preferred_team_id": "team-1"}}}
+TEAM_1 = {
+    "data": {
+        "id": "team-1",
+        "type": "teams",
+        "attributes": {"name": "Brennan Machinery Inc.", "status": "ACTIVE", "role_id": 30},
+    }
+}
+
+
+async def test_get_teams_falls_back_to_preferred_team_when_list_empty():
+    svc, client = _service(
+        [
+            _FakeResponse(200, TEAMS_EMPTY),
+            _FakeResponse(200, ME_WITH_TEAM),
+            _FakeResponse(200, TEAM_1),
+        ]
+    )
+    teams = await svc.get_teams("u1")
+    assert teams == [
+        {"id": "team-1", "name": "Brennan Machinery Inc.", "type": "teams", "status": "ACTIVE", "role": 30}
+    ]
+    urls = [c.args[0] for c in client.get.await_args_list]
+    assert urls == [
+        f"{svc.base_url}/teams",
+        f"{svc.base_url}/users/me",
+        f"{svc.base_url}/teams/team-1",
+    ]
+
+
+async def test_get_teams_returns_list_when_not_empty():
+    svc, client = _service(
+        [
+            _FakeResponse(200, {"data": [{"id": "t1", "attributes": {"name": "Team A"}}]}),
+        ]
+    )
+    teams = await svc.get_teams("u1")
+    assert teams == [{"id": "t1", "name": "Team A", "type": "teams", "status": None, "role": None}]
+    assert len(client.get.await_args_list) == 1  # no /users/me fallback call
+
+
+async def test_get_team_folders_falls_back_to_preferred_team():
+    tf_item = {
+        "id": "tf1",
+        "type": "teamfolders",
+        "attributes": {"name": "Accounting", "workspace": {"id": "ws1"}},
+    }
+    svc, client = _service(
+        [
+            _FakeResponse(200, TEAMS_EMPTY),
+            _FakeResponse(200, ME_WITH_TEAM),
+            _FakeResponse(200, {"data": [tf_item]}),
+        ]
+    )
+    folders = await svc.get_team_folders("u1")
+    assert folders and folders[0]["name"] == "Accounting"
+    assert folders[0]["workspace_id"] == "ws1"
+    urls = [c.args[0] for c in client.get.await_args_list]
+    assert urls[-1] == f"{svc.base_url}/teams/team-1/teamfolders"
+
+
+async def test_get_team_folders_explicit_team_id_skips_fallback():
+    tf_item = {
+        "id": "tf1",
+        "type": "teamfolders",
+        "attributes": {"name": "General", "workspace": None},
+    }
+    svc, client = _service(
+        [
+            _FakeResponse(200, {"data": [tf_item]}),
+        ]
+    )
+    folders = await svc.get_team_folders("u1", team_id="team-9")
+    assert folders and folders[0]["name"] == "General"
+    assert folders[0]["workspace_id"] is None
+    assert len(client.get.await_args_list) == 1
+    assert client.get.await_args_list[0].args[0] == f"{svc.base_url}/teams/team-9/teamfolders"
+
+
+async def test_list_files_team_folder_uses_teamfolders_endpoint():
+    svc, client = _service(
+        [
+            _FakeResponse(
+                200,
+                {"data": [{"id": "file1", "attributes": {"name": "a.pdf", "type": "file"}}]},
+            ),
+        ]
+    )
+    files = await svc.list_files("u1", parent_id="tf1", team_id="team-1")
+    assert files == [
+        {"id": "file1", "name": "a.pdf", "type": "file", "extension": None, "size": 0, "modified_at": None}
+    ]
+    assert client.get.await_args_list[0].args[0] == f"{svc.base_url}/teamfolders/tf1/files"
+
+
+async def test_list_files_team_root_without_teamfolder_id_still_tries_root_workspace():
+    svc, client = _service(
+        [
+            _FakeResponse(200, {"data": {"attributes": {"root_workspace": {"id": "wsX"}}}}),
+            _FakeResponse(200, {"data": [{"id": "f2", "attributes": {"name": "b.xlsx", "type": "file"}}]}),
+        ]
+    )
+    files = await svc.list_files("u1", parent_id="root", team_id="team-1")
+    assert files and files[0]["name"] == "b.xlsx"
+    urls = [c.args[0] for c in client.get.await_args_list]
+    assert urls[0] == f"{svc.base_url}/teams/team-1"
+    assert urls[1] == f"{svc.base_url}/workspaces/wsX/files"
+
+
+async def test_list_files_recursive_subfolders_use_files_endpoint():
+    svc, client = _service(
+        [
+            _FakeResponse(
+                200,
+                {
+                    "data": [
+                        {"id": "f1", "attributes": {"name": "a.pdf", "type": "file"}},
+                        {"id": "sub1", "attributes": {"name": "sub", "type": "folder"}},
+                    ]
+                },
+            ),
+            _FakeResponse(
+                200,
+                {"data": [{"id": "f2", "attributes": {"name": "b.pdf", "type": "file"}}]},
+            ),
+        ]
+    )
+    files = await svc.list_files("u1", parent_id="tf1", team_id="team-1", recursive=True)
+    assert {f["name"] for f in files} == {"a.pdf", "sub", "b.pdf"}
+    urls = [c.args[0] for c in client.get.await_args_list]
+    assert urls[0] == f"{svc.base_url}/teamfolders/tf1/files"
+    assert urls[1] == f"{svc.base_url}/files/sub1/files"
+
+
+async def test_download_file_uses_fresh_redirect_following_client():
+    """download_file must not reuse the shared pool (stale keep-alive hangs)
+    and must follow the signed-URL redirect."""
+    from unittest.mock import patch as _patch
+
+    svc = ZohoWorkDriveService(
+        tenant_id="default",
+        config={"client_id": "cid", "client_secret": "cs", "redirect_uri": "uri"},
+    )
+    svc.get_access_token = AsyncMock(return_value="tok")
+
+    fake_resp = _FakeResponse(200, {})
+    fake_resp.content = b"%PDF-1.6 fake-content"
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=fake_resp)
+
+    class _FakeAsyncClient:
+        last_kwargs = None
+
+        def __init__(self, **kwargs):
+            _FakeAsyncClient.last_kwargs = kwargs
+
+        async def __aenter__(self):
+            return fake_client
+
+        async def __aexit__(self, *args):
+            return False
+
+    with _patch("integrations.zoho_workdrive_service.httpx.AsyncClient", _FakeAsyncClient):
+        content = await svc.download_file("u1", "f1")
+
+    assert content == b"%PDF-1.6 fake-content"
+    assert fake_client.get.await_args_list[0].args[0] == f"{svc.base_url}/download/f1"
+    assert _FakeAsyncClient.last_kwargs.get("follow_redirects") is True
+
+
+async def test_download_file_returns_none_on_failure():
+    from unittest.mock import patch as _patch
+
+    svc = ZohoWorkDriveService(
+        tenant_id="default",
+        config={"client_id": "cid", "client_secret": "cs", "redirect_uri": "uri"},
+    )
+    svc.get_access_token = AsyncMock(return_value="tok")
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return MagicMock(get=AsyncMock(side_effect=RuntimeError("download failed")))
+
+        async def __aexit__(self, *args):
+            return False
+
+    with _patch("integrations.zoho_workdrive_service.httpx.AsyncClient", _FakeAsyncClient):
+        content = await svc.download_file("u1", "f1")
+
+    assert content is None

--- a/backend/tests/test_zoho_workdrive_service_team_folders.py
+++ b/backend/tests/test_zoho_workdrive_service_team_folders.py
@@ -230,3 +230,38 @@ async def test_download_file_returns_none_on_failure():
         content = await svc.download_file("u1", "f1")
 
     assert content is None
+
+
+async def test_full_sync_unscoped_walks_private_and_team_folders():
+    """Unscoped /full-sync must walk the private workspace AND all team
+    folders (walk_files with no root_ids) — not just the private root.
+    Greptile P1: removing the walker entirely left team-folder documents
+    unsynchronized."""
+    svc, _client = _service([])
+    svc.walk_files = AsyncMock(return_value=[{"id": "f1", "name": "a.pdf", "path": "/private", "type": "file"}])
+    svc.list_files = AsyncMock(return_value=[{"id": "wrong", "name": "x.pdf", "type": "file"}])
+    svc.ingest_file_to_memory = AsyncMock(return_value={"success": True, "result": {"status": "ingested"}})
+    svc.sync_to_postgres_cache = AsyncMock(return_value={"success": True, "metrics_synced": 0})
+
+    res = await svc.full_sync("u1")
+
+    svc.walk_files.assert_awaited_once()
+    svc.list_files.assert_not_awaited()
+    assert res["files_found"] == 1
+    assert res["files_ingested"] == 1
+
+
+async def test_full_sync_scoped_uses_list_files_not_walk_files():
+    """Scoped /sync-team must use the scoped listing — never the unscoped
+    whole-tree walk (which would ingest unrelated files)."""
+    svc, _client = _service([])
+    svc.walk_files = AsyncMock(return_value=[{"id": "wrong", "name": "x.pdf", "type": "file"}])
+    svc.list_files = AsyncMock(return_value=[])
+    svc.ingest_file_to_memory = AsyncMock(return_value={"success": True, "result": {"status": "ingested"}})
+    svc.sync_to_postgres_cache = AsyncMock(return_value={"success": True, "metrics_synced": 0})
+
+    res = await svc.full_sync("u1", workspace_id="ws1")
+
+    svc.walk_files.assert_not_awaited()
+    svc.list_files.assert_awaited_once()
+    assert res["files_found"] == 0

--- a/frontend-nextjs/components/Settings/ZohoWorkDriveIngestion.tsx
+++ b/frontend-nextjs/components/Settings/ZohoWorkDriveIngestion.tsx
@@ -242,8 +242,13 @@ export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
                     body: JSON.stringify({ user_id: userId, file_id: file.id })
                 });
                 if (response.ok) {
-                    setIngestedFileIds(prev => new Set(prev).add(file.id));
-                    successCount++;
+                    // HTTP 200 can still carry {success: false} (download or
+                    // parse failure) — only count real ingestions.
+                    const data = await response.json().catch(() => null);
+                    if (data?.success) {
+                        setIngestedFileIds(prev => new Set(prev).add(file.id));
+                        successCount++;
+                    }
                 }
             } catch (err) {
                 console.error(`Failed to ingest ${file.name}:`, err);

--- a/frontend-nextjs/components/Settings/ZohoWorkDriveIngestion.tsx
+++ b/frontend-nextjs/components/Settings/ZohoWorkDriveIngestion.tsx
@@ -64,7 +64,7 @@ function extractErrorMessage(text: string, status: number): string {
     return errMsg;
 }
 
-export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
+export default function ZohoWorkDriveIngestion() {
     const [teams, setTeams] = useState<ZohoTeam[]>([]);
     const [teamFolders, setTeamFolders] = useState<ZohoTeamFolder[]>([]);
     const [files, setFiles] = useState<ZohoFile[]>([]);
@@ -93,12 +93,14 @@ export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
     };
 
     const handleConnectZoho = () => {
-        window.location.href = `/api/v1/auth/oauth/zoho/authorize?user_id=${userId}`;
+        // R88: the authorize endpoint derives identity from the auth session
+        // (JWT/cookie) and fails closed — no user_id is passed or trusted.
+        window.location.href = '/api/v1/auth/oauth/zoho/authorize';
     };
 
     const fetchTeams = async () => {
         try {
-            const response = await fetch(`/api/zoho-workdrive/teams?user_id=${userId}`);
+            const response = await fetch('/api/zoho-workdrive/teams');
             if (response.ok) {
                 const data = await response.json();
                 if (data.success) {
@@ -113,7 +115,7 @@ export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
 
     const fetchTeamFolders = async () => {
         try {
-            const response = await fetch(`/api/zoho-workdrive/team-folders?user_id=${userId}`);
+            const response = await fetch('/api/zoho-workdrive/team-folders');
             if (response.ok) {
                 const data = await response.json();
                 if (data.success) {
@@ -134,7 +136,6 @@ export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    user_id: userId,
                     parent_id,
                     ...(workspace_id ? { workspace_id } : {}),
                     ...(team_id ? { team_id } : {}),
@@ -201,7 +202,7 @@ export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
             const response = await fetch('/api/zoho-workdrive/ingest', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ user_id: userId, file_id: file.id })
+                body: JSON.stringify({ file_id: file.id })
             });
             if (!response.ok) {
                 const text = await response.text();
@@ -231,34 +232,56 @@ export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
     const handleIngestAll = async () => {
         const ingestableFiles = files.filter(f => f.type !== 'folder');
         if (ingestableFiles.length === 0) return;
-        
+
         setIngestingAll(true);
-        let successCount = 0;
-        for (const file of ingestableFiles) {
-            try {
-                const response = await fetch('/api/zoho-workdrive/ingest', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ user_id: userId, file_id: file.id })
-                });
-                if (response.ok) {
-                    // HTTP 200 can still carry {success: false} (download or
-                    // parse failure) — only count real ingestions.
-                    const data = await response.json().catch(() => null);
-                    if (data?.success) {
-                        setIngestedFileIds(prev => new Set(prev).add(file.id));
-                        successCount++;
-                    }
-                }
-            } catch (err) {
-                console.error(`Failed to ingest ${file.name}:`, err);
+        try {
+            // Server-side batch: one /ingest-folder call with a max_files cap
+            // and aggregated error reporting, instead of N sequential /ingest
+            // requests from the client.
+            const response = await fetch('/api/zoho-workdrive/ingest-folder', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    folder_id: currentFolderId,
+                    ...(lastParams.workspace_id ? { workspace_id: lastParams.workspace_id } : {}),
+                    ...(lastParams.team_id ? { team_id: lastParams.team_id } : {}),
+                    recursive: false,
+                })
+            });
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(extractErrorMessage(text, response.status));
             }
+            const data = await response.json();
+            if (data.success) {
+                const ingested = data.files_ingested ?? 0;
+                // Only mark the visible files as ingested when every file in
+                // the folder actually landed — per-file errors are listed in
+                // data.errors and surfaced via the toast instead.
+                if (ingested === ingestableFiles.length && (!data.errors || data.errors.length === 0)) {
+                    setIngestedFileIds(prev => {
+                        const next = new Set(prev);
+                        ingestableFiles.forEach(f => next.add(f.id));
+                        return next;
+                    });
+                }
+                toast({
+                    title: "Batch Ingestion Complete",
+                    description: `Ingested ${ingested} of ${ingestableFiles.length} files into AI working memory.` +
+                        (data.errors?.length ? ` (${data.errors.length} failed)` : ''),
+                });
+            } else {
+                throw new Error(data.error || 'Batch ingestion failed');
+            }
+        } catch (error: any) {
+            toast({
+                title: "Batch Ingestion Failed",
+                description: error.message,
+                variant: "error"
+            });
+        } finally {
+            setIngestingAll(false);
         }
-        setIngestingAll(false);
-        toast({
-            title: "Batch Ingestion Complete",
-            description: `Ingested ${successCount} of ${ingestableFiles.length} files into AI working memory.`,
-        });
     };
 
     const formatSize = (bytes?: number) => {

--- a/frontend-nextjs/components/Settings/ZohoWorkDriveIngestion.tsx
+++ b/frontend-nextjs/components/Settings/ZohoWorkDriveIngestion.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../ui
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { useToast } from '../ui/use-toast';
-import { HardDrive, RefreshCw, Folder, File, Download, Search, CheckCircle, AlertTriangle } from 'lucide-react';
+import { HardDrive, RefreshCw, Folder, File, Download, Search, CheckCircle, AlertTriangle, ExternalLink } from 'lucide-react';
 
 interface ZohoFile {
     id: string;
@@ -23,59 +23,175 @@ interface ZohoTeam {
     };
 }
 
+interface ZohoTeamFolder {
+    id: string;
+    name: string;
+    team_id?: string;
+    team_name?: string;
+    workspace_id?: string;
+    type?: string;
+}
+
+interface ListParams {
+    parent_id: string;
+    workspace_id?: string;
+    team_id?: string;
+    folderName?: string;
+    recursive?: boolean;
+}
+
+interface Breadcrumb {
+    id: string;
+    name: string;
+    teamFolderId?: string;
+}
+
+function extractErrorMessage(text: string, status: number): string {
+    let errMsg = `Server returned ${status}`;
+    try {
+        const json = JSON.parse(text);
+        const err = json.error || json.detail || json.message;
+        if (typeof err === 'string') {
+            return err;
+        } else if (err && typeof err.message === 'string') {
+            return err.message;
+        } else if (Array.isArray(json.detail)) {
+            return json.detail.map((d: any) => d.msg || JSON.stringify(d)).join(', ');
+        } else if (err) {
+            return JSON.stringify(err);
+        }
+    } catch (_) {}
+    return errMsg;
+}
+
 export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
     const [teams, setTeams] = useState<ZohoTeam[]>([]);
+    const [teamFolders, setTeamFolders] = useState<ZohoTeamFolder[]>([]);
     const [files, setFiles] = useState<ZohoFile[]>([]);
     const [currentFolderId, setCurrentFolderId] = useState<string>('root');
+    const [lastParams, setLastParams] = useState<ListParams>({ parent_id: 'root' });
+    const [showAllFiles, setShowAllFiles] = useState(false);
+    const [breadcrumbs, setBreadcrumbs] = useState<Breadcrumb[]>([{ id: 'root', name: 'My WorkDrive' }]);
     const [loading, setLoading] = useState(false);
+    const [isConnected, setIsConnected] = useState(false);
     const [ingesting, setIngesting] = useState<string | null>(null);
+    const [ingestingAll, setIngestingAll] = useState(false);
+    const [ingestedFileIds, setIngestedFileIds] = useState<Set<string>>(new Set());
     const { toast } = useToast();
 
     useEffect(() => {
-        fetchTeams();
+        init();
     }, []);
 
-    const fetchTeams = async () => {
+    const init = async () => {
         setLoading(true);
         try {
-            const response = await fetch(`/api/zoho-workdrive/teams?user_id=${userId}`);
-            const data = await response.json();
-            if (data.success) {
-                setTeams(data.data);
-                // If teams exist, maybe load the first one's root
-                if (data.data.length > 0) {
-                    // In a real app, we might need to drill down into teams
-                }
-            }
-        } catch (error) {
-            console.error('Failed to fetch Zoho teams:', error);
+            await Promise.all([fetchTeams(), fetchTeamFolders(), fetchFiles({ parent_id: 'root' })]);
         } finally {
             setLoading(false);
         }
     };
 
-    const fetchFiles = async (parentId: string = 'root') => {
+    const handleConnectZoho = () => {
+        window.location.href = `/api/v1/auth/oauth/zoho/authorize?user_id=${userId}`;
+    };
+
+    const fetchTeams = async () => {
+        try {
+            const response = await fetch(`/api/zoho-workdrive/teams?user_id=${userId}`);
+            if (response.ok) {
+                const data = await response.json();
+                if (data.success) {
+                    setIsConnected(true);
+                    setTeams(data.data || []);
+                }
+            }
+        } catch (error) {
+            console.error('Failed to fetch Zoho teams:', error);
+        }
+    };
+
+    const fetchTeamFolders = async () => {
+        try {
+            const response = await fetch(`/api/zoho-workdrive/team-folders?user_id=${userId}`);
+            if (response.ok) {
+                const data = await response.json();
+                if (data.success) {
+                    setTeamFolders(data.data || []);
+                }
+            }
+        } catch (error) {
+            console.error('Failed to fetch Zoho team folders:', error);
+        }
+    };
+
+    const fetchFiles = async (params: ListParams) => {
         setLoading(true);
+        const { parent_id, workspace_id, team_id, folderName, recursive } = params;
+        const inTeamContext = Boolean(workspace_id || team_id);
         try {
             const response = await fetch('/api/zoho-workdrive/files/list', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ user_id: userId, parent_id: parentId })
+                body: JSON.stringify({
+                    user_id: userId,
+                    parent_id,
+                    ...(workspace_id ? { workspace_id } : {}),
+                    ...(team_id ? { team_id } : {}),
+                    ...(recursive ? { recursive: true } : {}),
+                })
             });
-            const data = await response.json();
-            if (data.success) {
-                setFiles(data.data);
-                setCurrentFolderId(parentId);
+            if (response.ok) {
+                const data = await response.json();
+                if (data.success) {
+                    setIsConnected(true);
+                    setFiles(data.data || []);
+                    setCurrentFolderId(parent_id);
+                    setLastParams({
+                        parent_id,
+                        workspace_id,
+                        team_id,
+                        folderName,
+                    });
+
+                    if (inTeamContext) {
+                        // Breadcrumbs for team folders are set by openTeamFolder.
+                    } else if (parent_id === 'root') {
+                        setBreadcrumbs([{ id: 'root', name: 'My WorkDrive' }]);
+                    } else if (folderName) {
+                        setBreadcrumbs(prev => [...prev.filter(b => b.id !== parent_id), { id: parent_id, name: folderName }]);
+                    }
+                }
             }
-        } catch (error) {
+        } catch (error: any) {
             console.error('Failed to fetch Zoho files:', error);
-            toast({
-                title: "Error",
-                description: "Failed to load files from Zoho WorkDrive",
-                variant: "error"
-            });
         } finally {
             setLoading(false);
+        }
+    };
+
+    const toggleAllFiles = () => {
+        const next = !showAllFiles;
+        setShowAllFiles(next);
+        fetchFiles({ ...lastParams, recursive: next });
+    };
+
+    const openTeamFolder = async (tf: ZohoTeamFolder) => {
+        setBreadcrumbs([
+            { id: 'root', name: 'My WorkDrive' },
+            { id: tf.id, name: tf.name, teamFolderId: tf.id },
+        ]);
+        await fetchFiles({ parent_id: tf.id, workspace_id: tf.workspace_id, team_id: tf.team_id });
+    };
+
+    const handleBreadcrumb = (b: Breadcrumb) => {
+        if (b.id === 'root') {
+            fetchFiles({ parent_id: 'root' });
+        } else if (b.teamFolderId) {
+            const tf = teamFolders.find(t => t.id === b.teamFolderId);
+            if (tf) openTeamFolder(tf);
+        } else {
+            fetchFiles({ parent_id: b.id, folderName: b.name });
         }
     };
 
@@ -87,11 +203,16 @@ export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ user_id: userId, file_id: file.id })
             });
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(extractErrorMessage(text, response.status));
+            }
             const data = await response.json();
             if (data.success) {
+                setIngestedFileIds(prev => new Set(prev).add(file.id));
                 toast({
-                    title: "Success",
-                    description: `Successfully ingested ${file.name} to ATOM memory`,
+                    title: "Ingestion Successful",
+                    description: `Loaded ${file.name} into AI Employee working memory.`,
                 });
             } else {
                 throw new Error(data.error || 'Ingestion failed');
@@ -107,6 +228,34 @@ export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
         }
     };
 
+    const handleIngestAll = async () => {
+        const ingestableFiles = files.filter(f => f.type !== 'folder');
+        if (ingestableFiles.length === 0) return;
+        
+        setIngestingAll(true);
+        let successCount = 0;
+        for (const file of ingestableFiles) {
+            try {
+                const response = await fetch('/api/zoho-workdrive/ingest', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ user_id: userId, file_id: file.id })
+                });
+                if (response.ok) {
+                    setIngestedFileIds(prev => new Set(prev).add(file.id));
+                    successCount++;
+                }
+            } catch (err) {
+                console.error(`Failed to ingest ${file.name}:`, err);
+            }
+        }
+        setIngestingAll(false);
+        toast({
+            title: "Batch Ingestion Complete",
+            description: `Ingested ${successCount} of ${ingestableFiles.length} files into AI working memory.`,
+        });
+    };
+
     const formatSize = (bytes?: number) => {
         if (!bytes) return '0 B';
         const k = 1024;
@@ -114,6 +263,10 @@ export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
         const i = Math.floor(Math.log(bytes) / Math.log(k));
         return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
     };
+
+    const nonFolderFiles = files.filter(f => f.type !== 'folder');
+    const showTeamFolders = currentFolderId === 'root' && !lastParams.workspace_id && !lastParams.team_id;
+    const displayFiles = showAllFiles ? files.filter(f => f.type !== 'folder') : files;
 
     return (
         <Card className="w-full">
@@ -125,71 +278,183 @@ export default function ZohoWorkDriveIngestion({ userId }: { userId: string }) {
                             Zoho WorkDrive Ingestion
                         </CardTitle>
                         <CardDescription>
-                            Sync and ingest documents directly from your Zoho WorkDrive teams.
+                            Sync and ingest documents directly into AI Employee working memory.
                         </CardDescription>
                     </div>
-                    <Button variant="outline" size="sm" onClick={() => fetchFiles(currentFolderId)} disabled={loading}>
-                        <RefreshCw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
-                        Refresh
-                    </Button>
+                    <div className="flex items-center gap-3">
+                        {isConnected ? (
+                            <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200 dark:bg-green-950 dark:text-green-300 dark:border-green-800 flex items-center gap-1.5 px-3 py-1 text-xs font-medium">
+                                <CheckCircle className="w-3.5 h-3.5 text-green-600 dark:text-green-400" />
+                                Connected
+                            </Badge>
+                        ) : null}
+                        {nonFolderFiles.length > 0 && isConnected && (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={handleIngestAll}
+                                disabled={ingestingAll || loading}
+                                className="border-blue-300 text-blue-700 hover:bg-blue-50 dark:border-blue-700 dark:text-blue-300"
+                            >
+                                <Download className={`w-4 h-4 mr-2 ${ingestingAll ? 'animate-bounce' : ''}`} />
+                                {ingestingAll ? "Ingesting..." : "Ingest All Files"}
+                            </Button>
+                        )}
+                        <Button
+                            variant={isConnected ? "outline" : "default"}
+                            size="sm"
+                            onClick={handleConnectZoho}
+                            className={isConnected ? "text-gray-600 dark:text-gray-300" : "bg-blue-600 hover:bg-blue-700 text-white"}
+                        >
+                            <ExternalLink className="w-4 h-4 mr-2" />
+                            {isConnected ? "Reconnect" : "Connect Zoho Account"}
+                        </Button>
+                        <Button variant="outline" size="sm" onClick={toggleAllFiles} disabled={loading} className={showAllFiles ? 'bg-blue-50 border-blue-300 text-blue-700 dark:bg-blue-950 dark:text-blue-300' : ''}>
+                            <Search className={`w-4 h-4 mr-2`} />
+                            {showAllFiles ? 'Current Folder' : 'All Files'}
+                        </Button>
+                        <Button variant="outline" size="sm" onClick={() => fetchFiles(lastParams)} disabled={loading}>
+                            <RefreshCw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+                            Refresh
+                        </Button>
+                    </div>
                 </div>
             </CardHeader>
             <CardContent>
                 <div className="space-y-4">
-                    {/* Navigation/Breadcrumbs could go here */}
+                    {/* Breadcrumbs */}
+                    {breadcrumbs.length > 1 && (
+                        <div className="flex items-center gap-1 text-xs text-gray-500 mb-2">
+                            {breadcrumbs.map((b, idx) => (
+                                <React.Fragment key={b.id}>
+                                    {idx > 0 && <span className="text-gray-400">/</span>}
+                                    <button
+                                        onClick={() => handleBreadcrumb(b)}
+                                        className={`hover:underline ${idx === breadcrumbs.length - 1 ? 'font-semibold text-gray-800 dark:text-gray-200' : ''}`}
+                                    >
+                                        {b.name}
+                                    </button>
+                                </React.Fragment>
+                            ))}
+                        </div>
+                    )}
+
+                    {showTeamFolders && teamFolders.length > 0 && (
+                        <div className="border rounded-md divide-y overflow-hidden">
+                            <div className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800">
+                                Team Folders
+                            </div>
+                            {teamFolders.map(tf => (
+                                <div
+                                    key={tf.id}
+                                    onDoubleClick={() => openTeamFolder(tf)}
+                                    className="flex items-center justify-between p-3 hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+                                >
+                                    <div className="flex items-center gap-3 min-w-0">
+                                        <Folder className="w-5 h-5 text-yellow-500 flex-shrink-0" />
+                                        <div className="min-w-0">
+                                            <p className="font-medium truncate">{tf.name}</p>
+                                            <p className="text-xs text-gray-500 dark:text-gray-400">
+                                                {tf.team_name ? `${tf.team_name} • ` : ''}Team Folder
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <Button variant="ghost" size="sm" onClick={() => openTeamFolder(tf)}>
+                                        Open
+                                    </Button>
+                                </div>
+                            ))}
+                        </div>
+                    )}
 
                     <div className="border rounded-md divide-y overflow-hidden">
                         {loading && files.length === 0 ? (
                             <div className="p-8 text-center text-gray-500 dark:text-gray-400">
-                                <RefreshCw className="w-8 h-8 mx-auto mb-2 animate-spin" />
-                                <p>Loading files...</p>
+                                <RefreshCw className="w-8 h-8 mx-auto mb-2 animate-spin text-blue-600" />
+                                <p className="font-medium">Loading files from Zoho WorkDrive...</p>
                             </div>
                         ) : files.length === 0 ? (
                             <div className="p-8 text-center text-gray-500 dark:text-gray-400">
-                                <Search className="w-8 h-8 mx-auto mb-2" />
-                                <p>No files found in this folder</p>
-                                <Button variant="link" onClick={() => fetchFiles('root')}>Go to Root</Button>
+                                <Search className="w-8 h-8 mx-auto mb-2 text-gray-400" />
+                                <p className="font-medium text-gray-700 dark:text-gray-300">
+                                    {isConnected ? "No files found in this folder" : "No files available"}
+                                </p>
+                                <p className="text-xs text-gray-500 mt-1 mb-4">
+                                    {isConnected
+                                        ? "Your Zoho WorkDrive is connected, but this folder contains no files yet. Upload files to Zoho WorkDrive and click Refresh."
+                                        : "Connect your Zoho WorkDrive account to sync team folders and documents."}
+                                </p>
+                                <div className="flex items-center justify-center gap-3">
+                                    {isConnected ? (
+                                        <Button variant="default" size="sm" onClick={() => fetchFiles(lastParams)} className="bg-blue-600 hover:bg-blue-700 text-white">
+                                            <RefreshCw className="w-4 h-4 mr-2" />
+                                            Refresh Files
+                                        </Button>
+                                    ) : (
+                                        <Button variant="default" size="sm" onClick={handleConnectZoho} className="bg-blue-600 hover:bg-blue-700 text-white">
+                                            <ExternalLink className="w-4 h-4 mr-2" />
+                                            Connect Zoho Account
+                                        </Button>
+                                    )}
+                                    {currentFolderId !== 'root' && (
+                                        <Button variant="outline" size="sm" onClick={() => fetchFiles({ parent_id: 'root' })}>Go to Root</Button>
+                                    )}
+                                </div>
                             </div>
                         ) : (
-                            files.map(file => (
-                                <div key={file.id} className="flex items-center justify-between p-3 hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-800 transition-colors">
-                                    <div className="flex items-center gap-3 min-w-0">
-                                        {file.type === 'folder' ? (
-                                            <Folder className="w-5 h-5 text-yellow-500 flex-shrink-0" />
-                                        ) : (
-                                            <File className="w-5 h-5 text-gray-400 flex-shrink-0" />
-                                        )}
-                                        <div className="min-w-0">
-                                            <p className="font-medium truncate">{file.name}</p>
-                                            <p className="text-xs text-gray-500 dark:text-gray-400">
-                                                {file.type === 'folder' ? 'Folder' : `${file.extension?.toUpperCase() || 'FILE'} • ${formatSize(file.size)}`}
-                                            </p>
+                            displayFiles.map(file => {
+                                const isIngested = ingestedFileIds.has(file.id);
+                                return (
+                                    <div
+                                        key={file.id}
+                                        onDoubleClick={file.type === 'folder' ? () => fetchFiles({ parent_id: file.id, folderName: file.name }) : undefined}
+                                        className={`flex items-center justify-between p-3 hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-800 transition-colors${file.type === 'folder' ? ' cursor-pointer' : ''}`}
+                                    >
+                                        <div className="flex items-center gap-3 min-w-0">
+                                            {file.type === 'folder' ? (
+                                                <Folder className="w-5 h-5 text-yellow-500 flex-shrink-0" />
+                                            ) : (
+                                                <File className="w-5 h-5 text-gray-400 flex-shrink-0" />
+                                            )}
+                                            <div className="min-w-0">
+                                                <div className="flex items-center gap-2">
+                                                    <p className="font-medium truncate">{file.name}</p>
+                                                    {isIngested && (
+                                                        <Badge variant="outline" className="text-[10px] px-1.5 py-0 bg-green-50 text-green-700 border-green-200">
+                                                            ✓ Ingested to Memory
+                                                        </Badge>
+                                                    )}
+                                                </div>
+                                                <p className="text-xs text-gray-500 dark:text-gray-400">
+                                                    {file.type === 'folder' ? 'Folder' : `${file.extension?.toUpperCase() || 'FILE'} • ${formatSize(file.size)}`}
+                                                </p>
+                                            </div>
+                                        </div>
+
+                                        <div className="flex items-center gap-2">
+                                            {file.type === 'folder' ? (
+                                                <Button variant="ghost" size="sm" onClick={() => fetchFiles({ parent_id: file.id, folderName: file.name })}>
+                                                    Open
+                                                </Button>
+                                            ) : (
+                                                <Button
+                                                    variant={isIngested ? "secondary" : "outline"}
+                                                    size="sm"
+                                                    onClick={() => handleIngest(file)}
+                                                    disabled={ingesting === file.id || ingestingAll}
+                                                >
+                                                    {ingesting === file.id ? (
+                                                        <RefreshCw className="w-3 h-3 animate-spin mr-1" />
+                                                    ) : (
+                                                        <Download className="w-3 h-3 mr-1" />
+                                                    )}
+                                                    {isIngested ? "Re-Ingest" : "Ingest"}
+                                                </Button>
+                                            )}
                                         </div>
                                     </div>
-
-                                    <div className="flex items-center gap-2">
-                                        {file.type === 'folder' ? (
-                                            <Button variant="ghost" size="sm" onClick={() => fetchFiles(file.id)}>
-                                                Open
-                                            </Button>
-                                        ) : (
-                                            <Button
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() => handleIngest(file)}
-                                                disabled={ingesting === file.id}
-                                            >
-                                                {ingesting === file.id ? (
-                                                    <RefreshCw className="w-3 h-3 animate-spin mr-1" />
-                                                ) : (
-                                                    <Download className="w-3 h-3 mr-1" />
-                                                )}
-                                                Ingest
-                                            </Button>
-                                        )}
-                                    </div>
-                                </div>
-                            ))
+                                );
+                            })
                         )}
                     </div>
                 </div>

--- a/frontend-nextjs/components/Settings/__tests__/ZohoWorkDriveIngestion.test.tsx
+++ b/frontend-nextjs/components/Settings/__tests__/ZohoWorkDriveIngestion.test.tsx
@@ -1,12 +1,9 @@
 /**
  * ZohoWorkDriveIngestion component tests.
  *
- * Note: the component only fetches files on user action (Refresh / Open
- * folder / Go to Root) — there is no auto-load on mount (teams fetch only).
- *
- * Covers: card render, empty-folder state with Go to Root, file/folder
- * listing (size formatting, extensions), opening a folder, ingest success and
- * failure toasts, and the Refresh action.
+ * The component auto-loads on mount: teams, team folders, and the private
+ * workspace ("root") listing. It also browses Team Folders via the
+ * /team-folders endpoint, passing workspace_id/team_id to /files/list.
  */
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -19,23 +16,42 @@ jest.mock('@/components/ui/use-toast', () => ({
   ToastProvider: ({ children }: { children: any }) => children,
 }));
 
-const files = [
+const privateFiles = [
   { id: 'f1', name: 'quarterly-report.pdf', type: 'file', extension: 'pdf', size: 2621440 },
   { id: 'f2', name: 'Budget.xlsx', type: 'file', extension: 'xlsx', size: 512 },
-  { id: 'd1', name: 'Team Drive', type: 'folder' },
+  { id: 'd1', name: 'My Folder', type: 'folder' },
 ];
 
-function mockApi({ fileList = files, ingestSuccess = true } = {}) {
+const teamFolderFiles = [
+  { id: 'tff1', name: 'team-notes.docx', type: 'file', extension: 'docx', size: 1024 },
+];
+
+const teamFolders = [
+  { id: 'tf1', name: 'Marketing Assets', team_id: 't1', team_name: 'Marketing', workspace_id: 'ws1', type: 'teamfolder' },
+  { id: 'tf2', name: 'Finance Docs', team_id: 't2', team_name: 'Finance', workspace_id: 'ws2', type: 'teamfolder' },
+];
+
+function mockApi({
+  fileList = privateFiles,
+  teamFiles = teamFolderFiles,
+  teamFolderList = teamFolders,
+  ingestSuccess = true,
+} = {}) {
   global.fetch = jest.fn().mockImplementation((url: string, init?: RequestInit) => {
     const u = String(url);
     if (u.includes('/api/zoho-workdrive/files/list')) {
-      return Promise.resolve({ ok: true, json: async () => ({ success: true, data: fileList }) });
+      const body = JSON.parse(String(init?.body || '{}'));
+      const data = body.workspace_id ? teamFiles : fileList;
+      return Promise.resolve({ ok: true, json: async () => ({ success: true, data }) });
     }
     if (u.includes('/api/zoho-workdrive/ingest')) {
       return Promise.resolve({
         ok: true,
         json: async () => (ingestSuccess ? { success: true } : { success: false, error: 'permission denied' }),
       });
+    }
+    if (u.includes('/api/zoho-workdrive/team-folders')) {
+      return Promise.resolve({ ok: true, json: async () => ({ success: true, data: teamFolderList }) });
     }
     if (u.includes('/api/zoho-workdrive/teams')) {
       return Promise.resolve({ ok: true, json: async () => ({ success: true, data: [] }) });
@@ -44,11 +60,13 @@ function mockApi({ fileList = files, ingestSuccess = true } = {}) {
   });
 }
 
+
 async function loadFiles() {
   // The component auto-loads the root folder on mount (files are fetched
   // during init, not only on user action), so wait for the listing itself.
   await screen.findByText('quarterly-report.pdf');
 }
+
 
 describe('ZohoWorkDriveIngestion', () => {
   beforeEach(() => {
@@ -62,6 +80,12 @@ describe('ZohoWorkDriveIngestion', () => {
     expect(screen.getByText(/Sync and ingest documents/)).toBeInTheDocument();
   });
 
+
+  it('auto-lists the private workspace on mount, with sizes and folder Open buttons', async () => {
+    render(<ZohoWorkDriveIngestion userId="u1" />);
+    expect(await screen.findByText('quarterly-report.pdf')).toBeInTheDocument();
+  });
+
   it('shows the empty state and Go to Root fetches the root folder', async () => {
     // Stateful mock: the root folder holds files; opening Team Drive (d1)
     // returns an empty listing so the empty state admits the Go to Root CTA
@@ -73,7 +97,7 @@ describe('ZohoWorkDriveIngestion', () => {
         const empty = body.parent_id === 'd1';
         return Promise.resolve({
           ok: true,
-          json: async () => ({ success: true, data: empty ? [] : files }),
+          json: async () => ({ success: true, data: empty ? [] : privateFiles }),
         });
       }
       if (u.includes('/api/zoho-workdrive/teams')) {
@@ -102,17 +126,47 @@ describe('ZohoWorkDriveIngestion', () => {
     await loadFiles();
     expect(screen.getByText('quarterly-report.pdf')).toBeInTheDocument();
     expect(screen.getByText('Budget.xlsx')).toBeInTheDocument();
-    expect(screen.getByText('Team Drive')).toBeInTheDocument();
+    expect(screen.getByText('My Folder')).toBeInTheDocument();
     expect(screen.getByText(/PDF • 2\.5 MB/)).toBeInTheDocument();
     expect(screen.getByText(/XLSX • 512 B/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Open/ })).toBeInTheDocument();
     expect(screen.getByText('Folder')).toBeInTheDocument();
   });
 
-  it('opens a folder by fetching its children', async () => {
+  it('lists Team Folders at the private root', async () => {
     render(<ZohoWorkDriveIngestion userId="u1" />);
-    await loadFiles();
-    fireEvent.click(await screen.findByRole('button', { name: /Open/ }));
+    expect(await screen.findByText('Marketing Assets')).toBeInTheDocument();
+    expect(screen.getByText('Finance Docs')).toBeInTheDocument();
+    expect(screen.getByText(/Marketing • Team Folder/)).toBeInTheDocument();
+  });
+
+  it('opens a team folder by fetching its workspace files with workspace_id', async () => {
+    render(<ZohoWorkDriveIngestion userId="u1" />);
+    await screen.findByText('Marketing Assets');
+    fireEvent.click(screen.getAllByRole('button', { name: /Open/ })[0]);
+    expect(await screen.findByText('team-notes.docx')).toBeInTheDocument();
+    const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
+    const teamCall = listCalls[listCalls.length - 1];
+    expect(JSON.parse(teamCall[1].body)).toEqual({ user_id: 'u1', parent_id: 'tf1', workspace_id: 'ws1', team_id: 't1' });
+  });
+
+  it('hides team folders inside a team folder and returns to the private root via the breadcrumb', async () => {
+    render(<ZohoWorkDriveIngestion userId="u1" />);
+    await screen.findByText('Marketing Assets');
+    fireEvent.click(screen.getAllByRole('button', { name: /Open/ })[0]);
+    await screen.findByText('team-notes.docx');
+    expect(screen.queryByText('Finance Docs')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('My WorkDrive'));
+    expect(await screen.findByText('quarterly-report.pdf')).toBeInTheDocument();
+    const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
+    const rootCall = listCalls[listCalls.length - 1];
+    expect(JSON.parse(rootCall[1].body)).toEqual({ user_id: 'u1', parent_id: 'root' });
+  });
+
+  it('opens a regular folder by fetching its children', async () => {
+    mockApi({ teamFolderList: [] });
+    render(<ZohoWorkDriveIngestion userId="u1" />);
+    await screen.findByText('My Folder');
+    fireEvent.click(screen.getByRole('button', { name: /Open/ }));
     await waitFor(() => {
       const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
       const openCall = listCalls[listCalls.length - 1];
@@ -120,8 +174,50 @@ describe('ZohoWorkDriveIngestion', () => {
     });
   });
 
+  it('opens a folder row on double-click', async () => {
+    mockApi({ teamFolderList: [] });
+    render(<ZohoWorkDriveIngestion userId="u1" />);
+    await screen.findByText('My Folder');
+    fireEvent.dblClick(screen.getByText('My Folder'));
+    await waitFor(() => {
+      const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
+      const openCall = listCalls[listCalls.length - 1];
+      expect(JSON.parse(openCall[1].body)).toEqual({ user_id: 'u1', parent_id: 'd1' });
+    });
+  });
+
+  it('opens a team folder row on double-click', async () => {
+    render(<ZohoWorkDriveIngestion userId="u1" />);
+    await screen.findByText('Marketing Assets');
+    fireEvent.dblClick(screen.getByText('Marketing Assets'));
+    await waitFor(() => {
+      const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
+      const openCall = listCalls[listCalls.length - 1];
+      expect(JSON.parse(openCall[1].body)).toEqual({ user_id: 'u1', parent_id: 'tf1', workspace_id: 'ws1', team_id: 't1' });
+    });
+  });
+
+  it('does not open anything when double-clicking a file row', async () => {
+    render(<ZohoWorkDriveIngestion userId="u1" />);
+    await screen.findByText('quarterly-report.pdf');
+    fireEvent.dblClick(screen.getByText('quarterly-report.pdf'));
+    // No extra /files/list call beyond the mount-time fetch.
+    const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
+    expect(listCalls.length).toBe(1);
+  });
+
+  it('shows the empty state with Refresh Files while still listing team folders', async () => {
+    mockApi({ fileList: [] });
+    render(<ZohoWorkDriveIngestion userId="u1" />);
+    expect(await screen.findByText('No files found in this folder')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Refresh Files/ })).toBeInTheDocument();
+    // Team folders are still listed so the user can navigate to them
+    expect(screen.getByText('Marketing Assets')).toBeInTheDocument();
+  });
+
   it('ingests a file and toasts success', async () => {
     render(<ZohoWorkDriveIngestion userId="u1" />);
+
     await loadFiles();
     // Match the per-file Ingest button exactly (the header also renders an
     // "Ingest All Files" button that matches a loose /Ingest/ regex); the
@@ -143,9 +239,13 @@ describe('ZohoWorkDriveIngestion', () => {
   it('toasts an error when ingestion fails', async () => {
     mockApi({ ingestSuccess: false });
     render(<ZohoWorkDriveIngestion userId="u1" />);
+    await screen.findByText('quarterly-report.pdf');
+    fireEvent.click(screen.getAllByRole('button', { name: /^Ingest$/ })[0]);
+
     await loadFiles();
     const ingestBtn = (await screen.findAllByRole('button', { name: /^Ingest$/ }))[0];
     fireEvent.click(ingestBtn);
+
     await waitFor(() => {
       expect(mockToast.toast).toHaveBeenCalledWith(
         expect.objectContaining({ title: 'Ingestion Failed', description: 'permission denied' })
@@ -153,15 +253,45 @@ describe('ZohoWorkDriveIngestion', () => {
     });
   });
 
-  it('refreshes the current folder via the Refresh button', async () => {
+  it('refreshes the current folder via the Refresh button using the last params', async () => {
     render(<ZohoWorkDriveIngestion userId="u1" />);
+
+
     await screen.findByText('quarterly-report.pdf');
     fireEvent.click(screen.getByRole('button', { name: /Refresh/ }));
     await screen.findByText('quarterly-report.pdf');
-    fireEvent.click(screen.getByRole('button', { name: /Refresh/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Refresh$/ }));
     await waitFor(() => {
       const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
       expect(listCalls.length).toBeGreaterThanOrEqual(2);
+      expect(JSON.parse(listCalls[listCalls.length - 1][1].body)).toEqual({ user_id: 'u1', parent_id: 'root' });
     });
+  });
+
+  it('shows only files in recursive All Files mode and toggles back', async () => {
+    render(<ZohoWorkDriveIngestion userId="u1" />);
+    await screen.findByText('quarterly-report.pdf');
+    expect(screen.getByText('My Folder')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^All Files$/ }));
+    await waitFor(() => {
+      const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
+      expect(JSON.parse(listCalls[listCalls.length - 1][1].body)).toEqual({ user_id: 'u1', parent_id: 'root', recursive: true });
+    });
+    // folders are filtered out in all-files mode
+    expect(screen.queryByText('My Folder')).not.toBeInTheDocument();
+    expect(screen.getByText('quarterly-report.pdf')).toBeInTheDocument();
+
+    // The button stays disabled until the recursive fetch settles — wait for
+    // it to re-enable so the toggle-back click isn't suppressed.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Current Folder$/ })).not.toBeDisabled();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Current Folder$/ }));
+    await waitFor(() => {
+      const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
+      expect(JSON.parse(listCalls[listCalls.length - 1][1].body)).toEqual({ user_id: 'u1', parent_id: 'root' });
+    });
+    expect(await screen.findByText('My Folder')).toBeInTheDocument();
   });
 });

--- a/frontend-nextjs/components/Settings/__tests__/ZohoWorkDriveIngestion.test.tsx
+++ b/frontend-nextjs/components/Settings/__tests__/ZohoWorkDriveIngestion.test.tsx
@@ -44,6 +44,13 @@ function mockApi({
       const data = body.workspace_id ? teamFiles : fileList;
       return Promise.resolve({ ok: true, json: async () => ({ success: true, data }) });
     }
+    if (u.includes('/api/zoho-workdrive/ingest-folder')) {
+      const ingested = fileList.filter((f: any) => f.type !== 'folder').length;
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ success: true, files_ingested: ingested, files_processed: ingested, errors: [] }),
+      });
+    }
     if (u.includes('/api/zoho-workdrive/ingest')) {
       return Promise.resolve({
         ok: true,
@@ -75,14 +82,14 @@ describe('ZohoWorkDriveIngestion', () => {
   });
 
   it('renders the card title and description', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     expect(await screen.findByText('Zoho WorkDrive Ingestion')).toBeInTheDocument();
     expect(screen.getByText(/Sync and ingest documents/)).toBeInTheDocument();
   });
 
 
   it('auto-lists the private workspace on mount, with sizes and folder Open buttons', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     expect(await screen.findByText('quarterly-report.pdf')).toBeInTheDocument();
   });
 
@@ -106,7 +113,7 @@ describe('ZohoWorkDriveIngestion', () => {
       return Promise.resolve({ ok: true, json: async () => ({}) });
     });
 
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     await screen.findByText('quarterly-report.pdf');
     fireEvent.click(await screen.findByRole('button', { name: /Open/ }));
     await screen.findByText('No files found in this folder');
@@ -122,7 +129,7 @@ describe('ZohoWorkDriveIngestion', () => {
   });
 
   it('lists files after Refresh, with formatted sizes and folder Open buttons', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     await loadFiles();
     expect(screen.getByText('quarterly-report.pdf')).toBeInTheDocument();
     expect(screen.getByText('Budget.xlsx')).toBeInTheDocument();
@@ -133,24 +140,24 @@ describe('ZohoWorkDriveIngestion', () => {
   });
 
   it('lists Team Folders at the private root', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     expect(await screen.findByText('Marketing Assets')).toBeInTheDocument();
     expect(screen.getByText('Finance Docs')).toBeInTheDocument();
     expect(screen.getByText(/Marketing • Team Folder/)).toBeInTheDocument();
   });
 
   it('opens a team folder by fetching its workspace files with workspace_id', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     await screen.findByText('Marketing Assets');
     fireEvent.click(screen.getAllByRole('button', { name: /Open/ })[0]);
     expect(await screen.findByText('team-notes.docx')).toBeInTheDocument();
     const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
     const teamCall = listCalls[listCalls.length - 1];
-    expect(JSON.parse(teamCall[1].body)).toEqual({ user_id: 'u1', parent_id: 'tf1', workspace_id: 'ws1', team_id: 't1' });
+    expect(JSON.parse(teamCall[1].body)).toEqual({ parent_id: 'tf1', workspace_id: 'ws1', team_id: 't1' });
   });
 
   it('hides team folders inside a team folder and returns to the private root via the breadcrumb', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     await screen.findByText('Marketing Assets');
     fireEvent.click(screen.getAllByRole('button', { name: /Open/ })[0]);
     await screen.findByText('team-notes.docx');
@@ -159,46 +166,46 @@ describe('ZohoWorkDriveIngestion', () => {
     expect(await screen.findByText('quarterly-report.pdf')).toBeInTheDocument();
     const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
     const rootCall = listCalls[listCalls.length - 1];
-    expect(JSON.parse(rootCall[1].body)).toEqual({ user_id: 'u1', parent_id: 'root' });
+    expect(JSON.parse(rootCall[1].body)).toEqual({ parent_id: 'root' });
   });
 
   it('opens a regular folder by fetching its children', async () => {
     mockApi({ teamFolderList: [] });
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     await screen.findByText('My Folder');
     fireEvent.click(screen.getByRole('button', { name: /Open/ }));
     await waitFor(() => {
       const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
       const openCall = listCalls[listCalls.length - 1];
-      expect(JSON.parse(openCall[1].body)).toEqual({ user_id: 'u1', parent_id: 'd1' });
+      expect(JSON.parse(openCall[1].body)).toEqual({ parent_id: 'd1' });
     });
   });
 
   it('opens a folder row on double-click', async () => {
     mockApi({ teamFolderList: [] });
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     await screen.findByText('My Folder');
     fireEvent.dblClick(screen.getByText('My Folder'));
     await waitFor(() => {
       const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
       const openCall = listCalls[listCalls.length - 1];
-      expect(JSON.parse(openCall[1].body)).toEqual({ user_id: 'u1', parent_id: 'd1' });
+      expect(JSON.parse(openCall[1].body)).toEqual({ parent_id: 'd1' });
     });
   });
 
   it('opens a team folder row on double-click', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     await screen.findByText('Marketing Assets');
     fireEvent.dblClick(screen.getByText('Marketing Assets'));
     await waitFor(() => {
       const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
       const openCall = listCalls[listCalls.length - 1];
-      expect(JSON.parse(openCall[1].body)).toEqual({ user_id: 'u1', parent_id: 'tf1', workspace_id: 'ws1', team_id: 't1' });
+      expect(JSON.parse(openCall[1].body)).toEqual({ parent_id: 'tf1', workspace_id: 'ws1', team_id: 't1' });
     });
   });
 
   it('does not open anything when double-clicking a file row', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     await screen.findByText('quarterly-report.pdf');
     fireEvent.dblClick(screen.getByText('quarterly-report.pdf'));
     // No extra /files/list call beyond the mount-time fetch.
@@ -208,7 +215,7 @@ describe('ZohoWorkDriveIngestion', () => {
 
   it('shows the empty state with Refresh Files while still listing team folders', async () => {
     mockApi({ fileList: [] });
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     expect(await screen.findByText('No files found in this folder')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Refresh Files/ })).toBeInTheDocument();
     // Team folders are still listed so the user can navigate to them
@@ -216,7 +223,7 @@ describe('ZohoWorkDriveIngestion', () => {
   });
 
   it('ingests a file and toasts success', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
 
     await loadFiles();
     // Match the per-file Ingest button exactly (the header also renders an
@@ -233,12 +240,29 @@ describe('ZohoWorkDriveIngestion', () => {
       );
     });
     const ingestCall = (global.fetch as jest.Mock).mock.calls.find(([u]) => String(u).includes('/ingest'));
-    expect(JSON.parse(ingestCall[1].body)).toEqual({ user_id: 'u1', file_id: 'f1' });
+    expect(JSON.parse(ingestCall[1].body)).toEqual({ file_id: 'f1' });
+  });
+
+  it('ingests all files via the server-side batch endpoint', async () => {
+    render(<ZohoWorkDriveIngestion />);
+    await loadFiles();
+    fireEvent.click(screen.getByRole('button', { name: /Ingest All Files/ }));
+    await waitFor(() => {
+      expect(mockToast.toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Batch Ingestion Complete' })
+      );
+    });
+    const batchCall = (global.fetch as jest.Mock).mock.calls
+      .filter(([u]) => String(u).includes('/api/zoho-workdrive/ingest-folder'))
+      .slice(-1)[0];
+    expect(JSON.parse(batchCall[1].body)).toEqual({ folder_id: 'root', recursive: false });
+    // Every visible file is marked ingested on a clean batch
+    expect(await screen.findAllByText('✓ Ingested to Memory')).toHaveLength(2);
   });
 
   it('toasts an error when ingestion fails', async () => {
     mockApi({ ingestSuccess: false });
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     await screen.findByText('quarterly-report.pdf');
     fireEvent.click(screen.getAllByRole('button', { name: /^Ingest$/ })[0]);
 
@@ -254,7 +278,7 @@ describe('ZohoWorkDriveIngestion', () => {
   });
 
   it('refreshes the current folder via the Refresh button using the last params', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
 
 
     await screen.findByText('quarterly-report.pdf');
@@ -264,19 +288,19 @@ describe('ZohoWorkDriveIngestion', () => {
     await waitFor(() => {
       const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
       expect(listCalls.length).toBeGreaterThanOrEqual(2);
-      expect(JSON.parse(listCalls[listCalls.length - 1][1].body)).toEqual({ user_id: 'u1', parent_id: 'root' });
+      expect(JSON.parse(listCalls[listCalls.length - 1][1].body)).toEqual({ parent_id: 'root' });
     });
   });
 
   it('shows only files in recursive All Files mode and toggles back', async () => {
-    render(<ZohoWorkDriveIngestion userId="u1" />);
+    render(<ZohoWorkDriveIngestion />);
     await screen.findByText('quarterly-report.pdf');
     expect(screen.getByText('My Folder')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /^All Files$/ }));
     await waitFor(() => {
       const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
-      expect(JSON.parse(listCalls[listCalls.length - 1][1].body)).toEqual({ user_id: 'u1', parent_id: 'root', recursive: true });
+      expect(JSON.parse(listCalls[listCalls.length - 1][1].body)).toEqual({ parent_id: 'root', recursive: true });
     });
     // folders are filtered out in all-files mode
     expect(screen.queryByText('My Folder')).not.toBeInTheDocument();
@@ -290,7 +314,7 @@ describe('ZohoWorkDriveIngestion', () => {
     fireEvent.click(screen.getByRole('button', { name: /^Current Folder$/ }));
     await waitFor(() => {
       const listCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) => String(u).includes('/files/list'));
-      expect(JSON.parse(listCalls[listCalls.length - 1][1].body)).toEqual({ user_id: 'u1', parent_id: 'root' });
+      expect(JSON.parse(listCalls[listCalls.length - 1][1].body)).toEqual({ parent_id: 'root' });
     });
     expect(await screen.findByText('My Folder')).toBeInTheDocument();
   });

--- a/frontend-nextjs/pages/integrations/zoho-workdrive.tsx
+++ b/frontend-nextjs/pages/integrations/zoho-workdrive.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Layout } from '../../components/layout';
 import ZohoWorkDriveIngestion from '../../components/Settings/ZohoWorkDriveIngestion';
 import { useSession } from 'next-auth/react';
 
@@ -8,10 +7,8 @@ export default function ZohoWorkDrivePage() {
     const userId = (session?.user as any)?.id || 'demo-user';
 
     return (
-        <Layout>
-            <div className="container mx-auto py-8">
-                <ZohoWorkDriveIngestion userId={userId} />
-            </div>
-        </Layout>
+        <div className="container mx-auto py-8">
+            <ZohoWorkDriveIngestion userId={userId} />
+        </div>
     );
 }

--- a/frontend-nextjs/pages/integrations/zoho-workdrive.tsx
+++ b/frontend-nextjs/pages/integrations/zoho-workdrive.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
+import { Layout } from '../../components/layout';
 import ZohoWorkDriveIngestion from '../../components/Settings/ZohoWorkDriveIngestion';
-import { useSession } from 'next-auth/react';
 
 export default function ZohoWorkDrivePage() {
-    const { data: session } = useSession();
-    const userId = (session?.user as any)?.id || 'demo-user';
-
+    // Identity comes from the authenticated session server-side (JWT/cookie);
+    // there is deliberately no demo-user fallback here.
     return (
-        <div className="container mx-auto py-8">
-            <ZohoWorkDriveIngestion userId={userId} />
-        </div>
+        <Layout>
+            <div className="container mx-auto py-8">
+                <ZohoWorkDriveIngestion />
+            </div>
+        </Layout>
     );
 }

--- a/frontend-nextjs/tests/pages/integrations-zoho-workdrive.test.tsx
+++ b/frontend-nextjs/tests/pages/integrations-zoho-workdrive.test.tsx
@@ -1,20 +1,17 @@
 /**
- * Zoho WorkDrive page tests (pages/integrations/zoho-workdrive.tsx, was 0% coverage)
+ * Zoho WorkDrive page tests (pages/integrations/zoho-workdrive.tsx)
  *
- * Covers: session-derived userId propagation to ZohoWorkDriveIngestion and
- * the 'demo-user' fallback when there is no session.
+ * Covers: the page renders inside the shared Layout and mounts the ingestion
+ * component. The page no longer derives or forwards a userId — identity is
+ * resolved server-side from the authenticated session (JWT/cookie), and the
+ * demo-user fallback has been removed.
  */
 
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import ZohoWorkDrivePage from "@/pages/integrations/zoho-workdrive";
 
-const mockUseSession = jest.fn();
 const mockIngestion = jest.fn();
-
-jest.mock("next-auth/react", () => ({
-  useSession: (...args: any[]) => mockUseSession(...args),
-}));
 
 jest.mock("@/components/layout", () => ({
   Layout: ({ children }: { children: React.ReactNode }) => (
@@ -31,28 +28,23 @@ describe("ZohoWorkDrivePage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, "error").mockImplementation(() => {});
-    mockIngestion.mockImplementation((props: any) => (
-      <div data-testid="zoho-ingestion">Ingestion for {props.userId}</div>
+    mockIngestion.mockImplementation(() => (
+      <div data-testid="zoho-ingestion">Ingestion</div>
     ));
   });
 
-  test("renders Layout and passes the session user id to the ingestion component", () => {
-    mockUseSession.mockReturnValue({ data: { user: { id: "user-42" } } });
-
+  test("renders the ingestion component inside the shared Layout", () => {
     render(<ZohoWorkDrivePage />);
 
-    expect(mockUseSession).toHaveBeenCalled();
     expect(screen.getByTestId("layout")).toBeInTheDocument();
-    expect(screen.getByTestId("zoho-ingestion")).toHaveTextContent("Ingestion for user-42");
-    expect(mockIngestion).toHaveBeenCalledWith(expect.objectContaining({ userId: "user-42" }));
+    expect(screen.getByTestId("zoho-ingestion")).toBeInTheDocument();
   });
 
-  test("falls back to 'demo-user' when there is no session", () => {
-    mockUseSession.mockReturnValue({ data: null });
-
+  test("does not pass a client-derived userId to the ingestion component", () => {
     render(<ZohoWorkDrivePage />);
 
-    expect(screen.getByTestId("zoho-ingestion")).toHaveTextContent("Ingestion for demo-user");
-    expect(mockIngestion).toHaveBeenCalledWith(expect.objectContaining({ userId: "demo-user" }));
+    expect(mockIngestion).toHaveBeenCalledWith(
+      expect.not.objectContaining({ userId: expect.anything() })
+    );
   });
 });


### PR DESCRIPTION
- routes: restore router-level auth (identity from token, never client-supplied user_id or demo-user fallback); errors raise 500 per main's contract; drop duplicate /ingest
- service: fix list_files double-fetch (dead first parse wiped the result; pagination + recursion now single-pass)
- auto_document_ingestion: add OLE2/xlrd branch for old .xls files (zip-based parsers raise BadZipFile on OLE2 content); xlrd added to requirements
- tests: team-folders fallback suite + xls ingest suite + w38 route contract updated for the 5-arg list_files signature; frontend test syntax repair (unclosed blocks, undefined fixture var)

## Review follow-ups (final commit)
- Removed dead `user_id` from every request model and all frontend payloads — identity is token-only end to end (R88 fail-closed model); authorize link no longer passes `?user_id=`
- Added `xlrd>=2.0.1` to backend requirements (the OLE2 branch was silently inert without it)
- Bounded client-triggered traversal: `MAX_RECURSIVE_ITEMS` (2000) global cap on recursive listing, `MAX_TREE_NODES` (1000) cap on folder-tree, removed the N+1 per-folder metadata fetch, and `max_files` (1..2000) / `max_depth` (1..25) validation
- Batch ingest now uses the server-side `/ingest-folder` endpoint (one call, cap, aggregated errors) instead of N sequential `/ingest` requests
- Restored shared `Layout` on the page and removed the `demo-user` fallback
- Tests updated for the new signatures, plus new coverage: forged `user_id` ignored, empty-body defaults, batch endpoint UI, page-level no-userId propagation

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Backend tests pass (`pytest` — WorkDrive suites: 35 passed; unrelated pre-existing failures verified present on branch before these changes)
- [x] Frontend tests pass (`jest` — 19/19 across component + page suites)
- [x] `tsc --noEmit` — no new errors introduced (4 pre-existing Zoho test-file errors unchanged; repo baseline already red)

## Checklist
- [x] Code follows the project style (match surrounding patterns)
- [x] Self-reviewed the diff
- [x] Comments added for complex logic
- [x] No new warnings introduced