### PR TITLE
fix(zoho): gate batch-ingest badges on parseable extensions

### DIFF
--- a/frontend-nextjs/components/Settings/ZohoWorkDriveIngestion.tsx
+++ b/frontend-nextjs/components/Settings/ZohoWorkDriveIngestion.tsx
@@ -46,6 +46,9 @@ interface Breadcrumb {
     teamFolderId?: string;
 }
 
+// Keep in sync with PARSEABLE_EXTS in backend/integrations/zoho_workdrive_service.py
+const INGESTABLE_EXTS = ['.docx', '.xlsx', '.xls', '.csv', '.pdf', '.txt', '.md', '.pptx'];
+
 function extractErrorMessage(text: string, status: number): string {
     let errMsg = `Server returned ${status}`;
     try {
@@ -230,7 +233,13 @@ export default function ZohoWorkDriveIngestion() {
     };
 
     const handleIngestAll = async () => {
-        const ingestableFiles = files.filter(f => f.type !== 'folder');
+        // Mirror of backend PARSEABLE_EXTS (integrations/zoho_workdrive_service.py):
+        // /ingest-folder skips other extensions, so they shouldn't count as
+        // failures or block the ingested badges.
+        const ingestableFiles = files.filter(f =>
+            f.type !== 'folder' &&
+            INGESTABLE_EXTS.some(ext => (f.name || '').toLowerCase().endsWith(ext))
+        );
         if (ingestableFiles.length === 0) return;
 
         setIngestingAll(true);

--- a/frontend-nextjs/components/Settings/__tests__/ZohoWorkDriveIngestion.test.tsx
+++ b/frontend-nextjs/components/Settings/__tests__/ZohoWorkDriveIngestion.test.tsx
@@ -45,7 +45,11 @@ function mockApi({
       return Promise.resolve({ ok: true, json: async () => ({ success: true, data }) });
     }
     if (u.includes('/api/zoho-workdrive/ingest-folder')) {
-      const ingested = fileList.filter((f: any) => f.type !== 'folder').length;
+      // Mirror the backend: /ingest-folder only counts parseable extensions.
+      const supported = ['.docx', '.xlsx', '.xls', '.csv', '.pdf', '.txt', '.md', '.pptx'];
+      const ingested = fileList.filter(
+        (f: any) => f.type !== 'folder' && supported.some(ext => (f.name || '').toLowerCase().endsWith(ext))
+      ).length;
       return Promise.resolve({
         ok: true,
         json: async () => ({ success: true, files_ingested: ingested, files_processed: ingested, errors: [] }),
@@ -256,7 +260,35 @@ describe('ZohoWorkDriveIngestion', () => {
       .filter(([u]) => String(u).includes('/api/zoho-workdrive/ingest-folder'))
       .slice(-1)[0];
     expect(JSON.parse(batchCall[1].body)).toEqual({ folder_id: 'root', recursive: false });
-    // Every visible file is marked ingested on a clean batch
+    // Every ingestable visible file is marked ingested on a clean batch
+    expect(await screen.findAllByText('✓ Ingested to Memory')).toHaveLength(2);
+  });
+
+  it('batch ingests only parseable extensions and still marks them when unsupported files are present', async () => {
+    // A .xyz file sits alongside supported ones; the backend /ingest-folder
+    // skips it, so it must not count as a failure or block the badges.
+    const mixedFiles = [
+      ...privateFiles,
+      { id: 'fx', name: 'notes.xyz', type: 'file', extension: 'xyz', size: 10 },
+    ];
+    mockApi({ fileList: mixedFiles });
+    render(<ZohoWorkDriveIngestion />);
+    await screen.findByText('notes.xyz');
+    fireEvent.click(screen.getByRole('button', { name: /Ingest All Files/ }));
+    await waitFor(() => {
+      const batchCall = (global.fetch as jest.Mock).mock.calls
+        .filter(([u]) => String(u).includes('/api/zoho-workdrive/ingest-folder'))
+        .slice(-1)[0];
+      // Badge gating succeeded — the toast reports the supported count only
+      expect(mockToast.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Batch Ingestion Complete',
+          description: expect.stringContaining('2 of 2 files'),
+        })
+      );
+      expect(JSON.parse(batchCall[1].body)).toEqual({ folder_id: 'root', recursive: false });
+    });
+    // Only the two supported files get the badge
     expect(await screen.findAllByText('✓ Ingested to Memory')).toHaveLength(2);
   });
 


### PR DESCRIPTION
Follow-up to #595 (Greptile P1 'Stored files remain unmarked'):

`/ingest-folder` skips unsupported extensions server-side, so the UI's all-or-nothing badge marking never fired in folders mixing supported and unsupported files. The component now filters the visible files by a mirrored `PARSEABLE_EXTS` list before counting, and a test covers the mixed-extension case.

- [x] jest: 20/20 across ZohoWorkDriveIngestion + page suites