### PR TITLE
fix(routing): static BPC fallback honors rate/monthly/context hard gates

### DIFF
--- a/backend/core/llm/byok_handler.py
+++ b/backend/core/llm/byok_handler.py
@@ -1972,10 +1972,43 @@ class BYOKHandler:
         
         capability_blocked_options: List[tuple] = []
 
+        # Hard-gate parity with the dynamic ranker above. The static fallback
+        # exists to recover from pricing-cache misses/exceptions — NOT to
+        # override the rate/monthly/context hard-skips: whenever those gates
+        # empty the dynamic pool (e.g. the SIMPLE quality floor leaves only
+        # one candidate), falling through here re-added the exact exhausted
+        # provider the gates had just excluded, routing into guaranteed 429s.
+        FALLBACK_MIN_CONTEXT = {
+            QueryComplexity.SIMPLE: 4000,
+            QueryComplexity.MODERATE: 8000,
+            QueryComplexity.COMPLEX: 16000,
+            QueryComplexity.ADVANCED: 32000,
+        }
+        fallback_min_context = FALLBACK_MIN_CONTEXT.get(complexity, 8000)
+        fallback_monthly_tpm_limit = self._monthly_tpm_limit()
+
         for provider_id in provider_priority:
             if provider_id in self.clients:
                 models = COST_EFFICIENT_MODELS.get(provider_id, {})
                 model = models.get(complexity, "gpt-4o-mini")
+
+                # Same hard gates as the dynamic ranker's rate-aware pass:
+                # provider/per-model headroom, monthly subscription quota,
+                # and the provider-level context clamp.
+                if self.rate_tracker.get_headroom(provider_id) <= 0.0:
+                    continue
+                if self.rate_tracker.get_model_headroom(provider_id, model) <= 0.0:
+                    continue
+                if fallback_monthly_tpm_limit and self._monthly_budget_exhausted(
+                    provider_id, fallback_monthly_tpm_limit
+                ):
+                    continue
+                provider_max_context = self.rate_tracker.get_max_context(provider_id)
+                if (
+                    provider_max_context is not None
+                    and provider_max_context < fallback_min_context
+                ):
+                    continue
 
                 # Check Tool/Structured Support (Phase 6.6 / BUG-113): the
                 # dynamic pricing cache is authoritative for capabilities.


### PR DESCRIPTION
## Description

Fixes the 3 red tests in `tests/test_opencode_go_provider.py` that have been failing `backend-tests` CI on main (same failures disclosed in PR #599 as pre-existing).

**Root cause** (introduced when `8bd9920de` raised the SIMPLE quality floor to 85): when the rate-aware pass hard-skips a provider, the dynamic candidate pool can empty entirely — e.g. `deepseek-chat` scores 80 < 85 (quality-dropped), `deepseek-v4-flash` sits at headroom 0.00 (rate-skipped). `get_ranked_providers` then falls through to the static `COST_EFFICIENT_MODELS` fallback, which knew nothing about the hard gates and **re-added the exact exhausted provider**, routing traffic into guaranteed 429s. The hard-skip was effectively advisory whenever the dynamic pool happened to empty.

## Fix

The static fallback loop now applies the same hard gates as the dynamic ranker's rate-aware pass:
- provider headroom (`get_headroom`)
- per-model headroom (`get_model_headroom` for the static model choice)
- `OPENCODE_MONTHLY_TPM` monthly subscription quota (`_monthly_budget_exhausted`)
- provider-level `max_context` clamp vs the complexity's minimum context window

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `tests/test_opencode_go_provider.py`: **50/50 passed** (was 47/50 — the 3 CI-red tests now green)
- Regression: `test_byok_handler.py`, `test_byok_handler_extended_coverage.py`, `test_covpush_w107_byok_handler.py`, `test_cache_aware_routing.py`, `test_capability_routing.py`, `test_bughunt_byok.py`, `test_covpush_byok.py` → **285 passed / 1 failed**; the 1 failure (`test_analyze_query_complexity_code` — complexity classifier contract, unrelated to routing gates) fails identically on pristine main.

Closes the pre-existing CI failure disclosed in #599.