### PR TITLE
fix(email): curated merge from #606/#607 — Outlook cursor UTC + search_emails all providers

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -434,3 +434,46 @@ copy the markup as the canvas body and edit the wording; canvas + send preserve 
 (funnel `normalize_email_content` passes HTML through; composer sanitizer allows style).
 Block cap 6000 chars. Tests: tests/test_tool_planner_styled_base.py (5) + the 3 existing
 planner suites 28 green. Backend restarted.
+
+## 2026-09-08 — ZCode (Rish): PRs #606/#607/#608 review outcome — curated merge
+
+Reviewed the three stacked email PRs by visak14 against AGENTS.md/CLAUDE.md.
+**Merged (curated branch, cherry-picked with authorship kept):**
+
+- `294851b2` **Outlook poller cursor UTC fix** (+10 regression tests). Root cause:
+  naive local `datetime.now()` cursors formatted with a blind `Z` shifted the
+  watermark ~5.5h into the future — incremental polls returned empty windows
+  while cursors advanced; new mail never reached the comms store. Now aware
+  UTC end-to-end; naive legacy values assumed UTC.
+  **OPERATIONAL (carried from the original entry, still outstanding):** the live
+  server runs the old code and its legacy cursor is ambiguous — after deploying,
+  restart via `scripts/restart_backend.sh` and clear the poller cursors once so
+  the 90-day window initial-syncs (125 msgs).
+- `1ce0431` **search_emails defaults to every connected mail provider** (+2
+  tests, 1 updated). With no `platform` arg it queried ONLY gmail — Outlook mail
+  was silently invisible to agents (live 2026-09-08: Forrester thread found
+  nothing, no reply draft). Per-provider failures surfaced, not swallowed.
+
+**Discarded, with reasons (do NOT reintroduce as-is):**
+
+- `bad832fb` X-Session-Id + browser Origin/Referer/UA headers on the Zen gateway
+  clients: this masquerades as the OpenCode web client specifically to defeat the
+  gateway's free-tier client gate ("OpenCode's free tier can only be used in
+  OpenCode") — ToS circumvention + account-ban risk for the subscription key.
+  `-free` models are therefore effectively unusable via the API from Atom; the
+  paid-fallback machinery (CreditsError retry) already covers that path.
+- `65bd1b8`/`7f7c874`/`9420785` email send-policy gate (`core/email_policy_gate.py`
+  + hook + tool params + seed script): the deterministic Level B idea is
+  vision-aligned, but as written it (a) duplicates the existing general mechanism
+  `core/email_policy.py` (ALLOW/APPROVE/BLOCK, wired at mcp/canvas/chat) with a
+  second module, different vocabulary, different layer, no documented precedence;
+  (b) ships default-on blocking with NO kill switch / shadow mode / audit, against
+  the repo convention every other policy layer follows (ATOM_* flag +
+  settings-catalog + shadow-first); (c) hardcodes one business's machinery-sales
+  rules in core for all workspaces; (d) `price_verified` is agent self-attestation,
+  not verification. If Level B is wanted, rebuild ON `core/email_policy.py` with a
+  flag + per-workspace rule config. Seed script also wrote demo rows (real
+  counterparties' names/emails) into the live dev DB.
+
+Verified: 56/56 new tests green; covpush suites show the same 15 pre-existing
+main failures before/after (InterventionService signature drift — separate issue).

--- a/backend/integrations/atom_communication_ingestion_pipeline.py
+++ b/backend/integrations/atom_communication_ingestion_pipeline.py
@@ -116,10 +116,40 @@ def _format_graph_timestamp(dt: datetime) -> str:
     unconsumed message at 12:00:00.5 fell outside an inclusive
     ``le 12:00:00`` filter and was skipped. The compact form is kept for
     zero-microsecond values so ordinary cursors stay readable in filters.
+
+    Naive datetimes are assumed to be UTC (legacy persisted cursors were
+    written tz-less): treating a naive LOCAL wall-clock value as UTC here
+    would shift the watermark by the host offset and make incremental polls
+    silently skip mail (Sep 2026 — cursors advanced every cycle while the
+    store stayed empty).
     """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
     if dt.microsecond:
         return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _coerce_utc_ts(value: Any) -> Optional[datetime]:
+    """Coerce a persisted cursor / Graph timestamp to an AWARE UTC datetime.
+
+    Naive values are assumed to be UTC (see :func:`_format_graph_timestamp`).
+    Returns None for values that cannot be parsed — callers treat that as
+    "no cursor" (an initial-sync re-walk) rather than guessing.
+    """
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except Exception:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    return None
 
 
 def _extract_tables_from_html(html_body: str):
@@ -1412,10 +1442,9 @@ class CommunicationIngestionPipeline:
             if self._fetch_state_path.exists():
                 data = json.loads(self._fetch_state_path.read_text() or "{}")
                 for key, ts in (data.get("fetch_timestamps") or {}).items():
-                    try:
-                        self.fetch_timestamps[key] = datetime.fromisoformat(ts)
-                    except Exception:
-                        continue
+                    parsed = _coerce_utc_ts(ts)
+                    if parsed is not None:
+                        self.fetch_timestamps[key] = parsed
                 by_owner = data.get("seen_message_ids_by_owner") or {}
                 self._seen_message_ids = {
                     str(app): {
@@ -2368,7 +2397,7 @@ class CommunicationIngestionPipeline:
                 ts = message.get("timestamp")
                 if isinstance(ts, datetime) and (newest is None or ts > newest):
                     newest = ts
-            self.fetch_timestamps[last_fetch_key] = newest or datetime.now()
+            self.fetch_timestamps[last_fetch_key] = newest or datetime.now(timezone.utc)
             self._save_fetch_state()
 
             return fresh
@@ -3587,7 +3616,7 @@ class CommunicationIngestionPipeline:
                         history_days = get_automation_settings().get_initial_sync_days("outlook")
                     except Exception:
                         history_days = 90
-                    since = (datetime.now() - timedelta(days=history_days))
+                    since = (datetime.now(timezone.utc) - timedelta(days=history_days))
                     ts = _format_graph_timestamp(since)
                     params["$filter"] = f"receivedDateTime ge {ts}"
                     # Enough pages to walk the window in one pass; if it
@@ -3670,9 +3699,11 @@ class CommunicationIngestionPipeline:
                                 # Parse timestamp
                                 received_datetime = msg.get("receivedDateTime")
                                 if received_datetime:
-                                    timestamp = datetime.fromisoformat(received_datetime)
+                                    timestamp = _coerce_utc_ts(received_datetime)
+                                    if timestamp is None:
+                                        timestamp = datetime.now(timezone.utc)
                                 else:
-                                    timestamp = datetime.now()
+                                    timestamp = datetime.now(timezone.utc)
 
                                 # Extract sender
                                 from_data = msg.get("from", {})
@@ -3763,7 +3794,7 @@ class CommunicationIngestionPipeline:
                             # bound when draining one, else the newest message
                             # seen (or now() on an empty window, so polls
                             # don't re-walk an empty window forever).
-                            new_cursor = resume_max or newest or datetime.now()
+                            new_cursor = resume_max or newest or datetime.now(timezone.utc)
                             new_resume = None
                             break
 

--- a/backend/integrations/mcp_service.py
+++ b/backend/integrations/mcp_service.py
@@ -2310,9 +2310,25 @@ class MCPService(IntegrationService):
                 service = UniversalIntegrationService()
                 platform = arguments.get("platform")
                 query = arguments.get("query")
-                if platform: return await service.execute(platform, "list_messages", {"query": query}, context=context)
-                else:
-                    return {"gmail": await service.execute("gmail", "list_messages", {"query": query}, context=context)}
+                if platform:
+                    return await service.execute(platform, "list_messages", {"query": query}, context=context)
+                # No platform => search EVERY connected mail provider, matching
+                # the tool description ("across Gmail, Outlook, and Zoho Mail").
+                # The gmail-only default silently missed mail that lived in
+                # Outlook (live 2026-09-08: agent searched gmail, the Forrester
+                # email sat in Outlook, and the reply draft never happened).
+                # Per-provider failures are SURFACED, not swallowed, so the
+                # agent can tell "no results" apart from "not connected".
+                results = {}
+                for _p in ("gmail", "outlook", "zoho_mail"):
+                    try:
+                        results[_p] = await service.execute(
+                            _p, "list_messages", {"query": query}, context=context
+                        )
+                    except Exception as _se:
+                        logger.debug("search_emails %s failed: %s", _p, _se, exc_info=True)
+                        results[_p] = {"status": "error", "error": str(_se)[:300]}
+                return results
 
             elif tool_name == "unified_communication_search":
                 from integrations.universal_integration_service import UniversalIntegrationService

--- a/backend/tests/test_comm_poll_cursor_tz.py
+++ b/backend/tests/test_comm_poll_cursor_tz.py
@@ -1,0 +1,92 @@
+"""Cursor timezone regression tests (Sep 2026).
+
+The Outlook poller persisted NAIVE local ``datetime.now()`` cursors and
+formatted them with a blind ``Z`` suffix — the watermark instant shifted by
+the host offset (+05:30 here), so ``receivedDateTime gt <local-as-UTC>`` was
+~5.5h in the FUTURE and every incremental poll returned an empty window
+while the cursor happily advanced. The comms store stayed empty even though
+new mail existed. These tests pin the fix: cursors are AWARE UTC end-to-end
+(persist -> restore -> filter), and naive legacy values are assumed UTC.
+"""
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from integrations.atom_communication_ingestion_pipeline import (
+    CommunicationIngestionPipeline,
+    _coerce_utc_ts,
+    _format_graph_timestamp,
+)
+
+
+class TestFormatGraphTimestamp:
+    def test_naive_is_assumed_utc(self):
+        dt = datetime(2026, 9, 7, 23, 34, 56, 852060)  # legacy naive cursor
+        assert _format_graph_timestamp(dt) == "2026-09-07T23:34:56.852060Z"
+
+    def test_aware_utc_matches_naive_assumption(self):
+        dt = datetime(2026, 9, 7, 23, 34, 56, 852060, tzinfo=timezone.utc)
+        assert _format_graph_timestamp(dt) == "2026-09-07T23:34:56.852060Z"
+
+    def test_whole_seconds_compact_form(self):
+        assert _format_graph_timestamp(datetime(2026, 9, 1, 14, 42, 9)) == "2026-09-01T14:42:09Z"
+
+    def test_offset_datetime_is_normalized(self):
+        dt = datetime(2026, 9, 7, 14, 42, 9, tzinfo=timezone.utc)
+        assert _format_graph_timestamp(dt) == "2026-09-07T14:42:09Z"
+
+
+class TestCoerceUtcTs:
+    def test_naive_string_to_aware_utc(self):
+        out = _coerce_utc_ts("2026-09-07T23:34:56.852060")
+        assert out is not None
+        assert out.tzinfo is not None and out.utcoffset() == timezone.utc.utcoffset(None)
+        assert out.hour == 23
+
+    def test_z_string_to_aware_utc(self):
+        out = _coerce_utc_ts("2026-09-07T14:42:09Z")
+        assert out is not None and out.hour == 14
+
+    def test_offset_string_to_aware_utc(self):
+        out = _coerce_utc_ts("2026-09-07T14:42:09+00:00")
+        assert out is not None and out.utcoffset() == timezone.utc.utcoffset(None)
+
+    def test_naive_datetime_assumed_utc(self):
+        out = _coerce_utc_ts(datetime(2026, 9, 7, 10, 0, 0))
+        assert out is not None and out.tzinfo == timezone.utc and out.hour == 10
+
+    def test_garbage_returns_none(self):
+        assert _coerce_utc_ts("not-a-date") is None
+        assert _coerce_utc_ts(None) is None
+
+
+class TestLoadFetchState:
+    def test_restores_cursors_as_aware_utc(self, tmp_path):
+        state = {
+            "fetch_timestamps": {
+                # Legacy naive (local) value — must be assumed UTC, not crash.
+                "last_fetch_outlook": "2026-09-07T23:34:56.858121",
+                # Already-aware value round-tripped through isoformat().
+                "last_fetch_outlook_owner1": "2026-09-07T14:42:09+00:00",
+                "last_fetch_outlook_resume_owner1": "2026-09-01T09:00:00+00:00",
+            },
+            "seen_message_ids_by_owner": {},
+        }
+        path = Path(tmp_path) / "poll_fetch_state.json"
+        path.write_text(json.dumps(state))
+
+        obj = CommunicationIngestionPipeline.__new__(CommunicationIngestionPipeline)
+        obj._fetch_state_path = path
+        obj.fetch_timestamps = {}
+        obj._seen_message_ids = {}
+        obj._load_fetch_state()
+
+        assert set(obj.fetch_timestamps) == set(state["fetch_timestamps"])
+        for key, value in obj.fetch_timestamps.items():
+            assert value.tzinfo is not None, f"{key} restored naive"
+            assert value.utcoffset() == timezone.utc.utcoffset(None), key
+        # The legacy naive 23:34 value must be treated as 23:34 UTC, which is
+        # exactly what _format_graph_timestamp will send to Graph.
+        assert _format_graph_timestamp(obj.fetch_timestamps["last_fetch_outlook"]) == (
+            "2026-09-07T23:34:56.858121Z"
+        )

--- a/backend/tests/test_covpush_integrations_core.py
+++ b/backend/tests/test_covpush_integrations_core.py
@@ -836,7 +836,7 @@ class TestExecuteToolLocalTools:
             r = await _run_local(svc, "search_emails", {"query": "q", "platform": "gmail"}, {"user_id": "u"})
             assert r == {"ok": 1}
             r = await _run_local(svc, "search_emails", {"query": "q"})
-            assert "gmail" in r
+            assert set(r) == {"gmail", "outlook", "zoho_mail"}
             r = await _run_local(svc, "unified_communication_search", {"query": "q"}, {"user_id": "u"})
             assert "slack" in r
             r = await _run_local(svc, "list_calendar_events", {"calendar_id": "c"}, {"user_id": "u"})

--- a/backend/tests/test_covpush_mcp_svc.py
+++ b/backend/tests/test_covpush_mcp_svc.py
@@ -1611,13 +1611,32 @@ class TestExecuteToolUniversal:
         assert result == {"status": "success"}
 
     @pytest.mark.asyncio
-    async def test_search_emails_default_gmail(self, svc, monkeypatch):
+    async def test_search_emails_default_all_mail_providers(self, svc, monkeypatch):
+        """No platform => every mail provider is searched (description says
+        'across Gmail, Outlook, and Zoho Mail'); gmail-only silently missed
+        mail that lived in Outlook."""
         cls, inst = _fake_universal_cls(execute_result={"status": "success"})
         monkeypatch.setattr("integrations.universal_integration_service.UniversalIntegrationService", cls)
         result = await svc.execute_tool(
             "local-tools", "search_emails", {"query": "q"}, {}
         )
-        assert result == {"gmail": {"status": "success"}}
+        assert result == {
+            "gmail": {"status": "success"},
+            "outlook": {"status": "success"},
+            "zoho_mail": {"status": "success"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_search_emails_surfaces_provider_failures(self, svc, monkeypatch):
+        """Per-provider failures are surfaced (not swallowed) so the agent can
+        tell 'no results' apart from 'not connected'."""
+        cls, inst = _fake_universal_cls(execute_raises=Exception("boom"))
+        monkeypatch.setattr("integrations.universal_integration_service.UniversalIntegrationService", cls)
+        result = await svc.execute_tool(
+            "local-tools", "search_emails", {"query": "q"}, {}
+        )
+        assert set(result) == {"gmail", "outlook", "zoho_mail"}
+        assert all(v["status"] == "error" and v["error"] == "boom" for v in result.values())
 
     @pytest.mark.asyncio
     async def test_unified_communication_search_all_fail(self, svc, monkeypatch):


### PR DESCRIPTION
## Description

Curated merge from the stacked PRs #606/#607/#608 (reviewed against AGENTS.md/CLAUDE.md). Keeps the two changes that are legally safe and meet repo standards; the rest was discarded with reasons logged in `AGENT_COORDINATION.md`.

**Kept (cherry-picked, original authorship preserved):**
- `294851b2` — Outlook poller cursors are now aware UTC end-to-end (persist/restore/parse). Naive local `now()` cursors + a blind `Z` suffix shifted the watermark ~5.5h into the future, so incremental polls returned empty windows while cursors advanced — new mail never reached the comms store. 10 regression tests.
- `1ce0431` — `search_emails` with no `platform` now queries every connected mail provider (gmail/outlook/zoho_mail) with per-provider failures surfaced. The gmail-only default silently hid Outlook mail from agents (live 2026-09-08: the Forrester thread was invisible, so no reply draft was ever made).

**Discarded:**
- Zen gateway `X-Session-Id` + browser-header masquerade — circumvents OpenCode's free-tier client gate (ToS/ban risk).
- Email send-policy gate stack (`email_policy_gate.py`/`email_policy_data.py`/seed script) — duplicates the existing `core/email_policy.py` mechanism, ships default-on blocking with no kill switch/shadow/audit, hardcodes one business's rules in core. Should be rebuilt on `email_policy.py` with a flag if Level B enforcement is wanted.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Backend tests pass (`pytest` — 384 passed; the 15 covpush failures are pre-existing on main, identical set before/after)
- [ ] Frontend type-checks (`tsc --noEmit`) — no frontend changes
- [x] Cursor fix verified end-to-end in the original PR (legacy naive cursor restored as UTC, incremental fetch returned the real 14:42:09Z message)

## Checklist

- [x] Code follows the project style (match surrounding patterns)
- [x] Self-reviewed the diff
- [x] Comments added for complex logic
- [x] No new warnings introduced

**Post-merge operational note:** restart the backend (`scripts/restart_backend.sh`) and clear the Outlook poller cursors once so the 90-day window initial-syncs.